### PR TITLE
Support optional (Maybe<T>) members in outbox event payloads

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ Start with `docs/docfx_project/api_reference/trellis-api-cookbook.md`. Use its t
 
 ### Recommended context size
 
-The full set of API references is ~1,040 KB across 22 reference files (~266K tokens); the cookbook alone is ~228 KB (~58K tokens). These figures grow as the docs do — treat them as approximate and check `docs/docfx_project/api_reference/completeness-report.md` for the current package list. Together with framework source needed for cross-checking, project source under edit, and accumulated tool output across a typical 30–50 turn session, the working set is **1.5–2.5 MB**.
+The full set of API references is ~1,040 KB across 22 reference files (~266K tokens); the cookbook alone is ~228 KB (~58K tokens). These figures grow as the docs do — treat them as approximate; the current reference set is the `trellis-api-*.md` files under `docs/docfx_project/api_reference/`. Together with framework source needed for cross-checking, project source under edit, and accumulated tool output across a typical 30–50 turn session, the working set is **1.5–2.5 MB**.
 
 | Tier | Context | When this is enough |
 |---|---|---|

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,20 +14,20 @@ Start with `docs/docfx_project/api_reference/trellis-api-cookbook.md`. Use its t
 
 ### Recommended context size
 
-The full set of API references is ~548 KB (~137K tokens). The cookbook alone is ~92 KB (~23K tokens). Together with framework source needed for cross-checking, project source under edit, and accumulated tool output across a typical 30–50 turn session, the working set is **0.9–1.3 MB**.
+The full set of API references is ~1,040 KB across 22 reference files (~266K tokens); the cookbook alone is ~228 KB (~58K tokens). These figures grow as the docs do — treat them as approximate and check `docs/docfx_project/api_reference/completeness-report.md` for the current package list. Together with framework source needed for cross-checking, project source under edit, and accumulated tool output across a typical 30–50 turn session, the working set is **1.5–2.5 MB**.
 
 | Tier | Context | When this is enough |
 |---|---|---|
 | **Minimum** | 200K | Narrow, single-file tasks. Forces a strict "load only the area-specific reference per task" discipline; cross-cutting work is error-prone at this tier. |
 | **Recommended** | 400–500K | Most consumer projects. Lets the cookbook + 5–6 area-specific references stay resident through a PR-sized session. |
-| **Comfortable** | 1M | Framework-internal work and greenfield projects with multiple integration points. Lets all 16 references stay resident from turn 1 without eviction. |
+| **Comfortable** | 1M | Framework-internal work and greenfield projects with multiple integration points. Lets all 22 references stay resident from turn 1 without eviction. |
 
 ### Mandatory loads at session start
 
 For any non-trivial Trellis work, load these **before** writing the first line of code or running the first sub-agent:
 
 1. `trellis-api-cookbook.md` — always. Its task lookup table is the entry point.
-2. `trellis-api-servicedefaults.md` — always. **Every** `services.AddXxx()` extension method in Trellis has a matching `TrellisServiceBuilder.UseXxx()` slot. Designing or modifying a registration helper without reading this file silently misses the builder slot.
+2. `trellis-api-servicedefaults.md` — always. **Most** pipeline-module `services.AddXxx()` extensions have a matching `TrellisServiceBuilder.UseXxx()` slot — but leaf/store registrations are deliberate exceptions with **no** slot (e.g. `AddInMemoryIdempotencyStore`, `AddTrellisRouteConstraint`/`AddTrellisRouteConstraints`). Designing or modifying a registration helper without reading this file either silently misses a builder slot that should exist, or wrongly adds one where none belongs.
 3. The area-specific reference for the package being modified (from the table below).
 4. The reference for **every package whose pipeline this work composes with**. Specifically: anything touching the Mediator pipeline must also load `trellis-api-efcore.md` (transactional behavior) and `trellis-api-authorization.md` (resource-authorization behavior); anything touching ASP must also load `trellis-api-mediator.md`.
 
@@ -35,17 +35,22 @@ For any non-trivial Trellis work, load these **before** writing the first line o
 |---|---|
 | Result, Maybe, Error, ROP operations, aggregates, entities, specifications | `docs/docfx_project/api_reference/trellis-api-core.md` |
 | Ready-to-use value objects and primitive attributes | `docs/docfx_project/api_reference/trellis-api-primitives.md` |
+| Choosing a value-object category (scalar / symbolic / structured / optional) | `docs/docfx_project/api_reference/trellis-value-object-taxonomy.md` |
 | ASP.NET Core response mapping, validation, ETags, Prefer handling | `docs/docfx_project/api_reference/trellis-api-asp.md` |
+| ASP.NET Core API versioning (versioned `Location`/route + pagination URLs) | `docs/docfx_project/api_reference/trellis-api-asp-apiversioning.md` |
 | EF Core integration | `docs/docfx_project/api_reference/trellis-api-efcore.md` |
 | Transactional outbox and domain/integration event publishing | `docs/docfx_project/api_reference/trellis-api-efcore-outbox.md` |
 | Authorization | `docs/docfx_project/api_reference/trellis-api-authorization.md` |
 | FluentValidation integration | `docs/docfx_project/api_reference/trellis-api-fluentvalidation.md` |
 | HttpClient extensions | `docs/docfx_project/api_reference/trellis-api-http.md` |
+| HTTP transport abstractions (`WriteOutcome`, `HttpError`, ETag/precondition value types) | `docs/docfx_project/api_reference/trellis-api-http-abstractions.md` |
 | Mediator pipeline behaviors | `docs/docfx_project/api_reference/trellis-api-mediator.md` |
+| FluentValidation in the Mediator pipeline | `docs/docfx_project/api_reference/trellis-api-mediator-fluentvalidation.md` |
 | State machine integration | `docs/docfx_project/api_reference/trellis-api-statemachine.md` |
 | Service defaults and composition root setup | `docs/docfx_project/api_reference/trellis-api-servicedefaults.md` |
 | Testing helpers | `docs/docfx_project/api_reference/trellis-api-testing-reference.md` |
 | ASP.NET Core integration-test helpers | `docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md` |
+| Worker / `BackgroundService` test harness | `docs/docfx_project/api_reference/trellis-api-testing-worker.md` |
 | Analyzer rules and diagnostic IDs | `docs/docfx_project/api_reference/trellis-api-anti-patterns.md` for ready-to-apply WRONG/FIX shapes, then `docs/docfx_project/api_reference/trellis-api-analyzers.md` for the formal spec |
 
 ### Preflight verification — required before generating non-trivial code
@@ -54,7 +59,7 @@ Reading the references is necessary but not sufficient. Before producing any non
 
 1. **Which task am I doing?** Name the task in the cookbook's task-lookup table — verbatim if possible.
 2. **Which recipe applies?** Cite the recipe number (e.g. *"Recipe 1 — CRUD aggregate"* or *"Recipe 21 — Parallel independent loads"*). If no recipe applies, name the cookbook section or package reference that does.
-3. **Which inherited surface does my type already get?** For any type derived from `Aggregate<TId>`, `Entity<TId>`, `RequiredGuid<T>`, `RequiredString<T>`, `RequiredEnum<T>`, the scalar `Required*<T>` primitives (`RequiredInt<T>`, `RequiredLong<T>`, `RequiredDecimal<T>`, `RequiredBool<T>`, `RequiredDateTime<T>`), `ValueObject`, or `ScalarValueObject<TSelf, T>`, list the inherited members you will *not* redeclare. Recipe 1 in the cookbook enumerates the standard set for `RequiredGuid<T>`, `RequiredString<T>`, `ValueObject`, and `Aggregate<TId>`; for `Entity<TId>`, `RequiredEnum<T>`, and the other scalar primitives, consult `trellis-api-primitives.md` and `trellis-api-core.md`. The most common Recipe 1 mistake is redeclaring `Id`, equality methods, or `TryCreate` that the base class already provides.
+3. **Which inherited surface does my type already get?** For any type derived from `Aggregate<TId>`, `Entity<TId>`, `RequiredGuid<T>`, `RequiredString<T>`, `RequiredEnum<T>`, the scalar `Required*<T>` primitives (`RequiredInt<T>`, `RequiredLong<T>`, `RequiredDecimal<T>`, `RequiredBool<T>`, `RequiredDateTime<T>`, `RequiredDateTimeOffset<T>`), `ValueObject`, or `ScalarValueObject<TSelf, T>`, list the inherited members you will *not* redeclare. Recipe 1 in the cookbook enumerates the standard set for `RequiredGuid<T>`, `RequiredString<T>`, `ValueObject`, and `Aggregate<TId>`; for `Entity<TId>`, `RequiredEnum<T>`, and the other scalar primitives, consult `trellis-api-primitives.md` and `trellis-api-core.md`. The most common Recipe 1 mistake is redeclaring `Id`, equality methods, or `TryCreate` that the base class already provides.
 4. **Am I about to invent an API?** If you cannot point at a specific reference file + line range for the method/extension/attribute you are about to use, stop and load that reference. Do not synthesize the signature from prior knowledge.
 5. **What does the analyzer say?** If the change is in a `Result`/`Maybe`/EF-Core/value-object pipeline, list which `TRLSxxx` IDs are relevant. Cite the matching section in `trellis-api-anti-patterns.md` if one exists; otherwise cite `trellis-api-analyzers.md` and the relevant package reference. Preserve the WRONG/FIX control-flow shape from the anti-pattern file, adapting identifiers, types, and error values to the caller — the snippets are pattern examples, not self-contained replacements.
 
@@ -113,8 +118,15 @@ Tests are organized by source area:
 | ASP.NET Core | `Trellis.Asp/src/` | `Trellis.Asp/tests/` |
 | HTTP | `Trellis.Http/src/` | `Trellis.Http/tests/` |
 | EF Core | `Trellis.EntityFrameworkCore/src/` | `Trellis.EntityFrameworkCore/tests/` |
+| EF Core outbox | `Trellis.EntityFrameworkCore.Outbox/src/` | `Trellis.EntityFrameworkCore.Outbox/tests/` |
 | State machine | `Trellis.StateMachine/src/` | `Trellis.StateMachine/tests/` |
 | Testing helpers | `Trellis.Testing*/src/` | `Trellis.Testing*/tests/` |
+| FluentValidation (standalone) | `Trellis.FluentValidation/src/` | `Trellis.FluentValidation/tests/` |
+| FluentValidation (Mediator) | `Trellis.Mediator.FluentValidation/src/` | `Trellis.Mediator.FluentValidation/tests/` |
+| HTTP abstractions | `Trellis.Http.Abstractions/src/` | `Trellis.Http.Abstractions/tests/` |
+| API versioning | `Trellis.Asp.ApiVersioning/src/` | `Trellis.Asp.ApiVersioning/tests/` |
+| Service defaults / composition root | `Trellis.ServiceDefaults/src/` | `Trellis.ServiceDefaults/tests/` |
+| Analyzers | `Trellis.Analyzers/src/` | `Trellis.Analyzers/tests/` |
 
 Async extension tests use this file naming convention:
 
@@ -162,10 +174,11 @@ Avoid `Set-Content` for repository files because it can change encoding.
 
 Before considering code work complete:
 
-1. Run `dotnet build` from the repository root.
+1. Run `dotnet build` from the repository root (single solution: `Trellis.slnx`).
 2. Run `dotnet test` from the repository root.
 3. Confirm public API changes are reflected in the API references and related package docs.
-4. For changed code, use a code-review agent with `model: gpt-5.5` before committing.
+
+Before committing, also complete the **Pre-commit checklist** below — it adds the `gpt-5.5` code review and the diff check.
 
 Documentation-only changes do not require a build or test run unless they affect generated docs, examples that are compiled, or documented public API behavior.
 
@@ -189,7 +202,7 @@ Documentation-only changes do not require a build or test run unless they affect
 
 Before committing any changes after explicit approval:
 
-1. Confirm required validation has passed.
+1. Confirm the **Validation before handoff** steps passed (build, test, docs in sync).
 2. Confirm the diff contains only intended changes.
 3. Run a code-review agent with `model: gpt-5.5` for changed code and address substantive findings.
 4. Present the final summary to the user.

--- a/Trellis.EntityFrameworkCore.Outbox/NUGET_README.md
+++ b/Trellis.EntityFrameworkCore.Outbox/NUGET_README.md
@@ -78,7 +78,7 @@ The relay drains `IIntegrationEventCollector` after dispatching each domain even
 
 ## Delivery & Serialization Notes
 - The guarantee is at-least-once **delivery**, not handler success: per the `IDomainEventHandler<TEvent>` contract the publisher logs and swallows handler exceptions, so a failing handler does **not** retry — only infrastructure failures do.
-- Events are serialized with the default `System.Text.Json` options. Trellis value objects that carry a `[JsonConverter]` attribute round-trip; use a **nullable transport** (not `Maybe<T>`) for optional event payload members.
+- Events are serialized with a Trellis-owned `System.Text.Json` options instance. Value objects that carry a `[JsonConverter]` attribute round-trip, and `Maybe<T>` members are supported (present → value, absent → `null`); use a nullable transport for members that rely on a caller-registered converter.
 
 ## Documentation
 - [Full documentation](https://xavierjohn.github.io/Trellis/articles/integration-outbox.html)

--- a/Trellis.EntityFrameworkCore.Outbox/README.md
+++ b/Trellis.EntityFrameworkCore.Outbox/README.md
@@ -85,7 +85,7 @@ After each outboxed domain event is dispatched, the relay drains the collector a
 
 ## Delivery & Serialization Notes
 - The guarantee is at-least-once **delivery**, not handler success: per the `IDomainEventHandler<TEvent>` contract the publisher logs and swallows handler exceptions, so a failing handler does **not** retry — only infrastructure failures do. Retry-until-handlers-succeed needs a non-swallowing publish path (a planned follow-up).
-- Events are serialized with the default `System.Text.Json` options. Trellis value objects that carry a `[JsonConverter]` attribute round-trip; use a **nullable transport** (not `Maybe<T>`) for optional event payload members.
+- Events are serialized with a Trellis-owned `System.Text.Json` options instance. Value objects that carry a `[JsonConverter]` attribute round-trip, and `Maybe<T>` members are supported (present → value, absent → `null`); use a nullable transport for members that rely on a caller-registered converter.
 
 ## Documentation
 - [Full documentation](https://xavierjohn.github.io/Trellis/articles/integration-outbox.html)

--- a/Trellis.EntityFrameworkCore.Outbox/src/OutboxCaptureInterceptor.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/src/OutboxCaptureInterceptor.cs
@@ -23,11 +23,12 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 /// relay becomes the single durable dispatch path.
 /// </para>
 /// <para>
-/// <b>Serialization.</b> Events are serialized with the default <see cref="JsonSerializerOptions"/>.
+/// <b>Serialization.</b> Events are serialized with <see cref="OutboxEventSerialization.Options"/>.
 /// Value objects that carry a <c>[JsonConverter]</c> attribute (the scalar and composite Trellis
-/// primitives) round-trip correctly; events whose properties rely on factory-registered converters
-/// or use <c>Maybe&lt;T&gt;</c> are not supported by this MVP — use a nullable transport in the event
-/// (consistent with TRLS020). A configurable serializer is a planned follow-up.
+/// primitives) round-trip correctly, and <c>Maybe&lt;T&gt;</c> members are supported — a present value
+/// serializes as the underlying value and an absent one as JSON <c>null</c>. Events whose properties rely
+/// on other (non-attribute, caller-registered) converters are not supported by this MVP — use a nullable
+/// transport in the event. A configurable serializer is a planned follow-up.
 /// </para>
 /// </remarks>
 internal sealed class OutboxCaptureInterceptor : SaveChangesInterceptor
@@ -134,7 +135,7 @@ internal sealed class OutboxCaptureInterceptor : SaveChangesInterceptor
                     Guid.CreateVersion7(),
                     domainEvent.OccurredAt,
                     eventType,
-                    JsonSerializer.Serialize(domainEvent, type),
+                    JsonSerializer.Serialize(domainEvent, type, OutboxEventSerialization.Options),
                     OutboxMessageKind.Domain));
             }
         }

--- a/Trellis.EntityFrameworkCore.Outbox/src/OutboxEventSerialization.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/src/OutboxEventSerialization.cs
@@ -1,0 +1,73 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Shared <see cref="JsonSerializerOptions"/> for outbox event payloads.
+/// </summary>
+/// <remarks>
+/// Registers <see cref="MaybeJsonConverterFactory"/> so domain and integration events may carry
+/// <see cref="Maybe{T}"/> members: a present value serializes as the underlying value, an absent value as
+/// JSON <c>null</c>, and both read back symmetrically. Without it the default serializer walks a
+/// <see cref="Maybe{T}"/>'s value accessor on an absent member and throws while capturing the event. The
+/// same options instance is used for capture, integration-row creation, and relay deserialization so a
+/// payload written by one side reads back on the other.
+/// </remarks>
+internal static class OutboxEventSerialization
+{
+    /// <summary>The serializer options used for every outbox event payload.</summary>
+    public static JsonSerializerOptions Options { get; } = Create();
+
+    private static JsonSerializerOptions Create()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new MaybeJsonConverterFactory());
+        return options;
+    }
+}
+
+/// <summary>
+/// Creates a <see cref="MaybeJsonConverter{T}"/> for each <see cref="Maybe{T}"/> event member.
+/// </summary>
+internal sealed class MaybeJsonConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert) =>
+        typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Maybe<>);
+
+    /// <inheritdoc />
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var valueType = typeToConvert.GetGenericArguments()[0];
+        return (JsonConverter)Activator.CreateInstance(typeof(MaybeJsonConverter<>).MakeGenericType(valueType))!;
+    }
+}
+
+/// <summary>
+/// Serializes a present <see cref="Maybe{T}"/> as its underlying value and an absent one as JSON
+/// <c>null</c>, reading both back symmetrically.
+/// </summary>
+/// <typeparam name="T">The wrapped value type.</typeparam>
+internal sealed class MaybeJsonConverter<T> : JsonConverter<Maybe<T>>
+    where T : notnull
+{
+    /// <inheritdoc />
+    public override Maybe<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return Maybe<T>.None;
+
+        var value = JsonSerializer.Deserialize<T>(ref reader, options);
+        return value is null ? Maybe<T>.None : Maybe<T>.From(value);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, Maybe<T> value, JsonSerializerOptions options)
+    {
+        if (value.TryGetValue(out var inner))
+            JsonSerializer.Serialize(writer, inner, options);
+        else
+            writer.WriteNullValue();
+    }
+}

--- a/Trellis.EntityFrameworkCore.Outbox/src/OutboxRelay.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/src/OutboxRelay.cs
@@ -211,7 +211,7 @@ internal sealed class OutboxRelay<TContext> : BackgroundService
             Guid.CreateVersion7(),
             integrationEvent.OccurredAt,
             eventType,
-            JsonSerializer.Serialize(integrationEvent, type),
+            JsonSerializer.Serialize(integrationEvent, type, OutboxEventSerialization.Options),
             OutboxMessageKind.Integration);
     }
 
@@ -222,7 +222,7 @@ internal sealed class OutboxRelay<TContext> : BackgroundService
             ?? throw new InvalidOperationException(
                 $"Cannot resolve outbox event type '{message.EventType}'. The producing assembly must be loaded by the relay.");
 
-        return JsonSerializer.Deserialize(message.Payload, type) as T
+        return JsonSerializer.Deserialize(message.Payload, type, OutboxEventSerialization.Options) as T
             ?? throw new InvalidOperationException(
                 $"Outbox payload for '{message.EventType}' did not deserialize to an {typeof(T).Name}.");
     }

--- a/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
@@ -507,13 +507,107 @@ public sealed class OutboxTests
             domain.Attempts.Should().Be(1);
         }
     }
+
+    [Fact]
+    public async Task Relay_roundtrips_a_domain_event_with_a_None_optional_member()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        var captured = new List<ThingTagged>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(captured);
+        services.AddDbContext<OutboxTestDbContext>(o => o
+            .UseSqlite(connection)
+            .AddTrellisInterceptors()
+            .AddTrellisOutboxInterceptor());
+        services.AddDomainEventDispatch();
+        services.AddDomainEventHandler<ThingTagged, TaggedCapturingHandler>();
+        services.AddTrellisOutbox<OutboxTestDbContext>();
+
+        await using var provider = services.BuildServiceProvider();
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            await context.Database.EnsureCreatedAsync(ct);
+            var thing = Thing.Create(ThingId.NewUniqueV7(), "untagged", DateTimeOffset.UnixEpoch);
+            context.Things.Add(thing);
+            await context.SaveChangesAsync(ct);
+
+            // Capturing an event whose Maybe<T> member is None must not throw: the default serializer
+            // walked Maybe<T>.Value and threw on the absent value.
+            thing.Tag(Maybe<TeamId>.None, DateTimeOffset.UnixEpoch);
+            await context.SaveChangesAsync(ct);
+        }
+
+        var relay = provider.GetServices<IHostedService>()
+            .OfType<OutboxRelay<OutboxTestDbContext>>()
+            .Single();
+
+        await relay.DrainAsync(ct);
+
+        var tagged = captured.Should().ContainSingle().Subject;
+        tagged.OwningTeam.HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Relay_roundtrips_a_domain_event_with_a_Some_optional_member()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        var captured = new List<ThingTagged>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(captured);
+        services.AddDbContext<OutboxTestDbContext>(o => o
+            .UseSqlite(connection)
+            .AddTrellisInterceptors()
+            .AddTrellisOutboxInterceptor());
+        services.AddDomainEventDispatch();
+        services.AddDomainEventHandler<ThingTagged, TaggedCapturingHandler>();
+        services.AddTrellisOutbox<OutboxTestDbContext>();
+
+        await using var provider = services.BuildServiceProvider();
+
+        var teamId = TeamId.NewUniqueV7();
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            await context.Database.EnsureCreatedAsync(ct);
+            var thing = Thing.Create(ThingId.NewUniqueV7(), "tagged", DateTimeOffset.UnixEpoch);
+            context.Things.Add(thing);
+            await context.SaveChangesAsync(ct);
+
+            thing.Tag(Maybe<TeamId>.From(teamId), DateTimeOffset.UnixEpoch);
+            await context.SaveChangesAsync(ct);
+        }
+
+        var relay = provider.GetServices<IHostedService>()
+            .OfType<OutboxRelay<OutboxTestDbContext>>()
+            .Single();
+
+        await relay.DrainAsync(ct);
+
+        var tagged = captured.Should().ContainSingle().Subject;
+        tagged.OwningTeam.HasValue.Should().BeTrue();
+        tagged.OwningTeam.Value.Should().Be(teamId);
+    }
 }
 
 // ── Test domain model ──────────────────────────────────────────────────────────
 
 internal sealed partial class ThingId : RequiredGuid<ThingId>;
 
+internal sealed partial class TeamId : RequiredGuid<TeamId>;
+
 internal sealed record ThingCreated(ThingId Id, string Name, DateTimeOffset OccurredAt) : IDomainEvent;
+
+internal sealed record ThingTagged(ThingId Id, Maybe<TeamId> OwningTeam, DateTimeOffset OccurredAt) : IDomainEvent;
 
 internal sealed record ThingCreatedIntegrationEvent(Guid Id, string Name, DateTimeOffset OccurredAt) : IIntegrationEvent;
 
@@ -565,11 +659,23 @@ internal sealed class Thing : Aggregate<ThingId>
         thing.DomainEvents.Add(new ThingCreated(id, name, occurredAt));
         return thing;
     }
+
+    public void Tag(Maybe<TeamId> owningTeam, DateTimeOffset occurredAt) =>
+        DomainEvents.Add(new ThingTagged(Id, owningTeam, occurredAt));
 }
 
 internal sealed class CapturingHandler(List<ThingCreated> captured) : IDomainEventHandler<ThingCreated>
 {
     public ValueTask HandleAsync(ThingCreated domainEvent, CancellationToken cancellationToken)
+    {
+        captured.Add(domainEvent);
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed class TaggedCapturingHandler(List<ThingTagged> captured) : IDomainEventHandler<ThingTagged>
+{
+    public ValueTask HandleAsync(ThingTagged domainEvent, CancellationToken cancellationToken)
     {
         captured.Add(domainEvent);
         return ValueTask.CompletedTask;

--- a/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
@@ -597,6 +597,65 @@ public sealed class OutboxTests
         tagged.OwningTeam.HasValue.Should().BeTrue();
         tagged.OwningTeam.Value.Should().Be(teamId);
     }
+
+    [Fact]
+    public async Task Relay_roundtrips_an_integration_event_with_optional_members()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        var captured = new List<ThingTaggedIntegrationEvent>();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(captured);
+        services.AddDbContext<OutboxTestDbContext>(o => o
+            .UseSqlite(connection)
+            .AddTrellisInterceptors()
+            .AddTrellisOutboxInterceptor());
+        services.AddDomainEventDispatch();
+        // The translator emits an integration event carrying the domain event's Maybe<TeamId> member,
+        // so the relay's CreateIntegrationRow (serialize) and Deserialize must round-trip it too.
+        services.AddDomainEventHandler<ThingTagged, ThingTaggedTranslator>();
+        services.AddIntegrationEventHandler<ThingTaggedIntegrationEvent, IntegrationTaggedCapturingHandler>();
+        services.AddTrellisOutbox<OutboxTestDbContext>();
+
+        await using var provider = services.BuildServiceProvider();
+
+        var teamId = TeamId.NewUniqueV7();
+        var noneId = ThingId.NewUniqueV7();
+        var someId = ThingId.NewUniqueV7();
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            await context.Database.EnsureCreatedAsync(ct);
+
+            var none = Thing.Create(noneId, "none", DateTimeOffset.UnixEpoch);
+            context.Things.Add(none);
+            await context.SaveChangesAsync(ct);
+            none.Tag(Maybe<TeamId>.None, DateTimeOffset.UnixEpoch);
+            await context.SaveChangesAsync(ct);
+
+            var some = Thing.Create(someId, "some", DateTimeOffset.UnixEpoch);
+            context.Things.Add(some);
+            await context.SaveChangesAsync(ct);
+            some.Tag(Maybe<TeamId>.From(teamId), DateTimeOffset.UnixEpoch);
+            await context.SaveChangesAsync(ct);
+        }
+
+        var relay = provider.GetServices<IHostedService>()
+            .OfType<OutboxRelay<OutboxTestDbContext>>()
+            .Single();
+
+        // Drain 1: domain rows dispatch and the translator stages an Integration row per ThingTagged.
+        // Drain 2: the staged Integration rows are deserialized and published to the integration handler.
+        await relay.DrainAsync(ct);
+        await relay.DrainAsync(ct);
+
+        captured.Should().HaveCount(2);
+        captured.Single(e => e.Id == noneId.Value).OwningTeam.HasValue.Should().BeFalse();
+        captured.Single(e => e.Id == someId.Value).OwningTeam.Value.Should().Be(teamId);
+    }
 }
 
 // ── Test domain model ──────────────────────────────────────────────────────────
@@ -624,6 +683,27 @@ internal sealed class IntegrationCapturingHandler(List<ThingCreatedIntegrationEv
     : IIntegrationEventHandler<ThingCreatedIntegrationEvent>
 {
     public ValueTask HandleAsync(ThingCreatedIntegrationEvent integrationEvent, CancellationToken cancellationToken)
+    {
+        captured.Add(integrationEvent);
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed record ThingTaggedIntegrationEvent(Guid Id, Maybe<TeamId> OwningTeam, DateTimeOffset OccurredAt) : IIntegrationEvent;
+
+internal sealed class ThingTaggedTranslator(IIntegrationEventCollector collector) : IDomainEventHandler<ThingTagged>
+{
+    public ValueTask HandleAsync(ThingTagged domainEvent, CancellationToken cancellationToken)
+    {
+        collector.Add(new ThingTaggedIntegrationEvent(domainEvent.Id.Value, domainEvent.OwningTeam, domainEvent.OccurredAt));
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal sealed class IntegrationTaggedCapturingHandler(List<ThingTaggedIntegrationEvent> captured)
+    : IIntegrationEventHandler<ThingTaggedIntegrationEvent>
+{
+    public ValueTask HandleAsync(ThingTaggedIntegrationEvent integrationEvent, CancellationToken cancellationToken)
     {
         captured.Add(integrationEvent);
         return ValueTask.CompletedTask;

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -3001,7 +3001,7 @@ Raise events exactly as before — `DomainEvents.Add(new OrderPlaced(Id, clock.G
 **Semantics to remember.**
 
 - The guarantee is at-least-once **delivery**, not handler success: the publisher swallows handler exceptions (the `IDomainEventHandler<TEvent>` contract), so a failing handler does **not** retry — only infrastructure failures retry, up to `OutboxOptions.MaxAttempts`, after which the message is parked. Make handlers idempotent.
-- Use a nullable transport (not `Maybe<T>`) in event payloads — the default serializer cannot round-trip `Maybe<T>` (consistent with [Recipe 17](#recipe-17--defining-custom-domain-events-occurredat-is-the-only-timestamp) and TRLS020).
+- `Maybe<T>` event members are supported — a present value serializes as the underlying value, an absent one as JSON `null`. Members that depend on a caller-registered (non-attribute) `JsonSerializerOptions` converter still need a nullable transport, since the outbox serializer only honors `[JsonConverter]`-attributed types.
 - This is an outbox, not an event store: rows are a transient delivery buffer and may be pruned once `ProcessedAt` is set.
 
 See [trellis-api-efcore-outbox.md](trellis-api-efcore-outbox.md#how-the-outbox-works) for the full contract, options, and operational guidance.

--- a/docs/docfx_project/api_reference/trellis-api-efcore-outbox.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore-outbox.md
@@ -31,7 +31,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#trellis-cross-packag
 | Tune poll interval, batch size, or max attempts | `OutboxOptions` (via the `configure` delegate) | [`OutboxOptions`](#outboxoptions) |
 | Inspect a captured-but-not-yet-relayed message | Query `TContext.Set<OutboxMessage>()` (read-only; rows are produced by the interceptor) | [`OutboxMessage`](#outboxmessage) |
 | Understand why a failing handler does not re-deliver | At-least-once **delivery** semantics; handler exceptions are swallowed by the publisher | [Delivery semantics](#delivery-semantics) |
-| Decide how to shape an event so it round-trips | Use attribute-driven value objects / nullable transports; avoid `Maybe<T>` in payloads | [Serialization](#serialization) |
+| Decide how to shape an event so it round-trips | Use attribute-driven value objects; `Maybe<T>` members are supported (present → value, absent → `null`) | [Serialization](#serialization) |
 | Publish a stable external contract instead of raw domain events | Translate a domain event into an `IIntegrationEvent` via `IIntegrationEventCollector`; the relay routes it to `IIntegrationEventPublisher` | [Integration events](#integration-events) |
 
 ## Common traps
@@ -39,7 +39,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#trellis-cross-packag
 - **The interceptor and the model mapping are *not* optional extras.** `AddTrellisOutbox<TContext>()` only registers the relay. Without `optionsBuilder.AddTrellisOutboxInterceptor()` nothing is captured, and without `modelBuilder.AddTrellisOutbox()` the `TrellisOutboxMessages` table is unmapped. All three calls are required — see [Wiring: three required calls](#wiring-three-required-calls).
 - **The relay host must have the producing assemblies loaded.** The relay rehydrates each event from its assembly-qualified `EventType` via `Type.GetType`. If the worker process does not reference the assembly that declares the event, the message fails deserialization and parks after `MaxAttempts`.
 - **Handlers must be idempotent.** Delivery is at-least-once; a crash between dispatch and the relay's bookkeeping `SaveChanges` re-delivers the message on the next drain.
-- **Do not put `Maybe<T>` in an event payload.** The default serializer cannot round-trip it; use a nullable transport (consistent with TRLS020). See [Serialization](#serialization).
+- **Caller-registered `JsonSerializerOptions` converters do not travel with the payload.** The outbox serializer round-trips `[JsonConverter]`-attributed value objects and `Maybe<T>` members; converters registered only on a caller's own options are not consulted — shape those members with attribute-driven types or nullable transports. See [Serialization](#serialization).
 - **`OutboxMessage` is read-only to application code.** Its constructor is private and its mutators are internal; rows are produced exclusively by the capture interceptor and advanced by the relay.
 - **Post-commit cancellation can defer the event-clear.** The capture interceptor clears aggregate events in `SavedChanges`, which runs *after* the commit. `AggregateETagInterceptor` (registered first by `AddTrellisInterceptors`) throws by design if the save's `CancellationToken` is cancelled in that post-commit window, and EF invokes `SavedChanges` interceptors in registration order, so the outbox clear can be skipped — leaving the aggregate's events in memory while the outbox row is already durable. Reusing the *same* context for another save then re-captures them into a duplicate row. This is bounded and absorbed by the at-least-once + idempotent-handler contract; disposing the context after a cancelled save (the normal per-request lifetime) avoids it entirely.
 - **Persist-on-failure (`FailAfterCommit`) events are dispatched by the outbox.** The capture interceptor cannot see the command `Result`, so it captures events from *every* commit — including the persist-on-failure commits that `TransactionalCommandBehavior` performs. Without the outbox, `DomainEventDispatchBehavior` deliberately does **not** dispatch events for a failed result: the `FailAfterCommit` contract (documented under persist-on-failure in `trellis-api-core.md`) treats those events as discarded, *not* a durable retry buffer. With the outbox enabled, those events are captured and the relay delivers them — so the suppression no longer holds. If you depend on it, do not raise domain events on persist-on-failure paths under the outbox: return a success result for events you want delivered, and model post-failure side effects explicitly (a follow-up command, or a dedicated outbox row).
@@ -177,9 +177,9 @@ Retry-until-handlers-succeed would require a non-swallowing publish path and is 
 
 ## Serialization
 
-Events are serialized and rehydrated with the default `System.Text.Json` options.
+Events are serialized and rehydrated with a Trellis-owned `System.Text.Json` options instance that adds a `Maybe<T>` converter.
 
-- **Supported:** value objects that carry a `[JsonConverter]` attribute (the Trellis scalar and composite primitives) round-trip, because the converter travels with the type.
-- **Not supported:** `Maybe<T>` (internal constructor, throwing `Value` getter) and converters registered only through `JsonSerializerOptions` factories. Use a **nullable transport** in the event (e.g. `string?` rather than `Maybe<string>`), consistent with TRLS020 for event/DTO contracts.
+- **Supported:** value objects that carry a `[JsonConverter]` attribute (the Trellis scalar and composite primitives) round-trip, because the converter travels with the type. `Maybe<T>` members also round-trip — a present value serializes as the underlying value and an absent one as JSON `null`.
+- **Not supported:** converters registered only through a caller-supplied `JsonSerializerOptions` factory (they are not consulted by the outbox serializer). Shape those members with attribute-driven value objects or a **nullable transport** (e.g. `string?`).
 
-A configurable serializer is a planned follow-up; until then, keep event payloads to attribute-driven and primitive-or-nullable members.
+A fully configurable serializer is a planned follow-up; until then, keep event payloads to attribute-driven, `Maybe<T>`, and primitive-or-nullable members.


### PR DESCRIPTION
## Issue
The transactional outbox serialized captured domain and integration events with the default `System.Text.Json` options. An event carrying a `Maybe<T>` member whose value was absent threw `InvalidOperationException` during capture (the serializer walked the value accessor of an absent `Maybe<T>`), which failed the persist that raised the event. Optional members were effectively unusable in event payloads; only a nullable transport worked.

## Fix
Add an internal `Maybe<T>` JSON converter (`MaybeJsonConverterFactory` / `MaybeJsonConverter<T>`) and route the capture interceptor and the relay (serialize and deserialize) through a shared `OutboxEventSerialization.Options` instance that registers it. A present value serializes as the underlying value and an absent one as JSON `null`, reading back symmetrically. `[JsonConverter]`-attributed value objects continue to round-trip; members relying on a caller-registered (non-attribute) converter still need a nullable transport.

Documentation (outbox API reference, cookbook, package READMEs, interceptor XML) is updated to the new contract.

This PR also tidies `.github/copilot-instructions.md`: corrected stale context-size figures, qualified the "every AddXxx has a UseXxx slot" claim (leaf/store registrations are exceptions), added missing reference-routing and test-organization rows, added `RequiredDateTimeOffset<T>`, and de-duplicated the validation/pre-commit sections.

## Upgrade note
The on-the-wire JSON shape for a `Maybe<T>` event member changes (now value-or-`null`). The previous behavior crashed on an absent value and was documented as unsupported, so conforming payloads could not exist; if any non-conforming outbox rows with a `Maybe<T>` member are pending, drain them before upgrading.