### PR TITLE
Add IETagStampable seam for stamping aggregate ETags outside EF Core

### DIFF
--- a/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
@@ -135,7 +135,7 @@ using System.Text.Json.Serialization;
 /// ServiceDefaults <c>UseEntityFrameworkUnitOfWork&lt;TContext&gt;()</c> and
 /// <c>UseTrackedAggregateDomainEvents()</c> slots).
 /// </example>
-public abstract class Aggregate<TId> : Entity<TId>, IAggregate
+public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable
     where TId : notnull
 {
     /// <summary>
@@ -181,10 +181,31 @@ public abstract class Aggregate<TId> : Entity<TId>, IAggregate
     /// <para>
     /// The ETag is managed by <c>AggregateETagConvention</c> (marks it as a concurrency token)
     /// and <c>AggregateETagInterceptor</c> (generates a new value on save). Domain code should
-    /// not modify this property directly.
+    /// not modify this property directly; non-EF persistence adapters stamp it through
+    /// <see cref="IETagStampable.StampETag(string)"/>.
     /// </para>
     /// </remarks>
     public string ETag { get; private set; } = string.Empty;
+
+    /// <inheritdoc />
+    void IETagStampable.StampETag(string etag) => ETag = ValidateETag(etag);
+
+    private static string ValidateETag(string etag)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(etag);
+        foreach (var c in etag)
+        {
+            // RFC 9110 §8.8.1: an unquoted opaque tag may contain only etagc = %x21 / %x23-7E / obs-text
+            // (0x80-FF). Mirrors EntityTagValue's validation so a stamped token is always HTTP ETag-safe.
+            if (c is < '\x21' or '"' or '\x7F' or > '\xFF')
+                throw new ArgumentException(
+                    $"Invalid character in ETag: U+{(int)c:X4}. Must be an unquoted RFC 9110 opaque tag " +
+                    "(e.g. Guid.NewGuid().ToString(\"N\")); normalize quoted store-native tokens before stamping.",
+                    nameof(etag));
+        }
+
+        return etag;
+    }
 
     /// <summary>
     /// Gets a value indicating whether the aggregate has uncommitted changes.

--- a/Trellis.Core/src/DomainDrivenDesign/IAggregate.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IAggregate.cs
@@ -90,9 +90,10 @@ public interface IAggregate : IChangeTracking
     /// The ETag is managed automatically by the persistence infrastructure:
     /// <list type="bullet">
     /// <item>For SQL databases, the EF Core interceptor generates a new GUID on each save</item>
-    /// <item>For CosmosDB, the native <c>_etag</c> is used directly</item>
+    /// <item>For Cosmos DB, the native <c>_etag</c> is stamped after normalizing it to its unquoted opaque form</item>
     /// </list>
-    /// Domain code should not modify this property directly.
+    /// Domain code should not modify this property directly. Non-EF persistence adapters stamp it
+    /// through <see cref="IETagStampable.StampETag(string)"/>.
     /// </para>
     /// </remarks>
     string ETag { get; }

--- a/Trellis.Core/src/DomainDrivenDesign/IAggregate.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IAggregate.cs
@@ -87,13 +87,13 @@ public interface IAggregate : IChangeTracking
     /// </value>
     /// <remarks>
     /// <para>
-    /// The ETag is managed automatically by the persistence infrastructure:
+    /// The ETag is managed by the persistence layer, never by domain code:
     /// <list type="bullet">
-    /// <item>For SQL databases, the EF Core interceptor generates a new GUID on each save</item>
-    /// <item>For Cosmos DB, the native <c>_etag</c> is stamped after normalizing it to its unquoted opaque form</item>
+    /// <item>The shipped EF Core integration generates a new value on each save via its change-tracker interceptor</item>
+    /// <item>A custom non-EF adapter (Dapper, raw ADO, a Cosmos SDK repository, ...) stamps it through
+    /// <see cref="IETagStampable.StampETag(string)"/> — for a store-native token such as a Cosmos
+    /// <c>_etag</c>, normalize it to its unquoted opaque form first</item>
     /// </list>
-    /// Domain code should not modify this property directly. Non-EF persistence adapters stamp it
-    /// through <see cref="IETagStampable.StampETag(string)"/>.
     /// </para>
     /// </remarks>
     string ETag { get; }

--- a/Trellis.Core/src/DomainDrivenDesign/IETagStampable.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IETagStampable.cs
@@ -38,9 +38,10 @@ public interface IETagStampable
     /// This is the value the HTTP layer emits as a strong <c>ETag</c>, so a store-native quoted token
     /// (such as a Cosmos <c>_etag</c>) must be normalized to its unquoted form first.
     /// </param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="etag"/> is <see langword="null"/>.</exception>
     /// <exception cref="System.ArgumentException">
-    /// <paramref name="etag"/> is <see langword="null"/>, empty, whitespace, or contains characters that are
-    /// not valid in an RFC 9110 opaque tag.
+    /// <paramref name="etag"/> is empty, whitespace, or contains characters that are not valid in an
+    /// RFC 9110 opaque tag.
     /// </exception>
     void StampETag(string etag);
 }

--- a/Trellis.Core/src/DomainDrivenDesign/IETagStampable.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IETagStampable.cs
@@ -1,0 +1,46 @@
+﻿namespace Trellis;
+
+/// <summary>
+/// Infrastructure seam that lets a persistence adapter stamp an aggregate's optimistic-concurrency
+/// token (<see cref="IAggregate.ETag"/>) without reflection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IAggregate.ETag"/> is read-only on the domain surface — domain code must never assign it.
+/// The Trellis EF Core integration stamps it through the change tracker (<c>AggregateETagInterceptor</c>),
+/// which writes the value via EF metadata and never needs the CLR setter. A non-EF persistence adapter
+/// (Dapper, raw ADO, a Cosmos SDK repository, ...) has no such mechanism, so <see cref="Aggregate{TId}"/>
+/// implements this interface <b>explicitly</b>: the stamp method stays off the aggregate's public/domain
+/// surface and is reachable only by code that deliberately casts to <see cref="IETagStampable"/>.
+/// </para>
+/// <para>
+/// Typical adapter usage:
+/// <code>
+/// // On load: restore the stored concurrency token.
+/// ((IETagStampable)aggregate).StampETag(row.ETag);
+///
+/// // On save: stamp a fresh, unquoted opaque token — e.g. Guid.NewGuid().ToString("N") to match the EF
+/// // default — and use the previous value in the optimistic WHERE clause. A store-native token that comes
+/// // quoted (such as a Cosmos _etag) must be normalized to its unquoted opaque form before stamping.
+/// ((IETagStampable)aggregate).StampETag(newETag);
+/// </code>
+/// </para>
+/// </remarks>
+public interface IETagStampable
+{
+    /// <summary>
+    /// Sets the aggregate's optimistic-concurrency token (<see cref="IAggregate.ETag"/>) to
+    /// <paramref name="etag"/>. For persistence infrastructure only — not domain code.
+    /// </summary>
+    /// <param name="etag">
+    /// The concurrency token to stamp. Must be a valid unquoted RFC 9110 §8.8.1 opaque tag — non-null,
+    /// non-whitespace, and free of double-quotes and control characters (e.g. <c>Guid.NewGuid().ToString("N")</c>).
+    /// This is the value the HTTP layer emits as a strong <c>ETag</c>, so a store-native quoted token
+    /// (such as a Cosmos <c>_etag</c>) must be normalized to its unquoted form first.
+    /// </param>
+    /// <exception cref="System.ArgumentException">
+    /// <paramref name="etag"/> is <see langword="null"/>, empty, whitespace, or contains characters that are
+    /// not valid in an RFC 9110 opaque tag.
+    /// </exception>
+    void StampETag(string etag);
+}

--- a/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
@@ -64,11 +64,23 @@ public class AggregateTests
     }
 
     [Fact]
-    public void StampETag_with_null_or_whitespace_throws()
+    public void StampETag_with_null_throws_ArgumentNullException()
     {
         var aggregate = (IETagStampable)TestAggregate.Create("agg-1");
 
-        var act = () => aggregate.StampETag("  ");
+        var act = () => aggregate.StampETag(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void StampETag_with_empty_or_whitespace_throws_ArgumentException(string etag)
+    {
+        var aggregate = (IETagStampable)TestAggregate.Create("agg-1");
+
+        var act = () => aggregate.StampETag(etag);
 
         act.Should().Throw<ArgumentException>();
     }

--- a/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
@@ -42,6 +42,56 @@ public class AggregateTests
 
     #endregion
 
+    #region Concurrency Stamp (ETag) Tests
+
+    [Fact]
+    public void Aggregate_implements_IETagStampable() =>
+        typeof(IETagStampable).IsAssignableFrom(typeof(Aggregate<string>)).Should().BeTrue();
+
+    [Fact]
+    public void StampETag_sets_the_ETag_for_persistence_infrastructure()
+    {
+        // Arrange
+        var aggregate = TestAggregate.Create("agg-1");
+        aggregate.ETag.Should().BeEmpty();
+
+        // Act — a non-EF persistence adapter stamps the concurrency token via the seam.
+        ((IETagStampable)aggregate).StampETag("etag-123");
+
+        // Assert
+        aggregate.ETag.Should().Be("etag-123");
+        aggregate.IsChanged.Should().BeFalse("stamping the concurrency token is not a domain change");
+    }
+
+    [Fact]
+    public void StampETag_with_null_or_whitespace_throws()
+    {
+        var aggregate = (IETagStampable)TestAggregate.Create("agg-1");
+
+        var act = () => aggregate.StampETag("  ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void StampETag_with_a_quoted_or_non_opaque_tag_character_throws()
+    {
+        // A store-native token such as a Cosmos _etag arrives quoted; stamping it verbatim would later
+        // break HTTP ETag generation (EntityTagValue rejects quotes per RFC 9110 §8.8.1), so reject it here.
+        var aggregate = (IETagStampable)TestAggregate.Create("agg-1");
+
+        var act = () => aggregate.StampETag("\"quoted-etag\"");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void StampETag_is_explicit_and_not_on_the_public_aggregate_surface() =>
+        typeof(Aggregate<string>).GetMethod("StampETag").Should().BeNull(
+            "StampETag is an infrastructure-only seam implemented explicitly");
+
+    #endregion
+
     #region Domain Events Tests
 
     [Fact]

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IEntity, "Entity<TId>", IDomainEvent, IIntegrationEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredDateTimeOffset<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, PositiveAttribute, NonNegativeAttribute, NegativeAttribute, NonPositiveAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResourceCollectionNameAttribute, ResultDebugSettings]
+types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IETagStampable, IEntity, "Entity<TId>", IDomainEvent, IIntegrationEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredDateTimeOffset<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, PositiveAttribute, NonNegativeAttribute, NegativeAttribute, NonPositiveAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResourceCollectionNameAttribute, ResultDebugSettings]
 version: v3
 last_verified: 2026-06-03
 audience: [llm]
@@ -1623,7 +1623,7 @@ public interface IAggregate : IChangeTracking
 ### `Aggregate<TId>`
 
 ```csharp
-public abstract class Aggregate<TId> : Entity<TId>, IAggregate where TId : notnull
+public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable where TId : notnull
 ```
 
 | Name | Type | Description |
@@ -1637,6 +1637,18 @@ public abstract class Aggregate<TId> : Entity<TId>, IAggregate where TId : notnu
 | `protected Aggregate(TId id)` | — | Initializes the aggregate identity. |
 | `public IReadOnlyList<IDomainEvent> UncommittedEvents()` | `IReadOnlyList<IDomainEvent>` | Returns a read-only snapshot of current domain events. |
 | `public void AcceptChanges()` | `void` | Clears `DomainEvents`. |
+
+### `IETagStampable`
+
+```csharp
+public interface IETagStampable
+```
+
+Persistence-infrastructure seam for stamping an aggregate's optimistic-concurrency token (`IAggregate.ETag`) without reflection. `Aggregate<TId>` implements it **explicitly**, so the method stays off the domain surface and is reachable only by casting to `IETagStampable`. The EF Core integration stamps the ETag through its change-tracker interceptor; non-EF persistence adapters (Dapper, raw ADO, Cosmos SDK) use this seam instead — on load to restore the stored token, on save to apply a fresh one.
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `void StampETag(string etag)` | `void` | Sets `IAggregate.ETag` to `etag`, which must be a valid unquoted RFC 9110 opaque tag (e.g. `Guid.NewGuid().ToString("N")`). Throws `ArgumentException` for null/empty/whitespace or non-opaque-tag characters. |
 
 ### `IDomainEvent`
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1648,7 +1648,7 @@ Persistence-infrastructure seam for stamping an aggregate's optimistic-concurren
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `void StampETag(string etag)` | `void` | Sets `IAggregate.ETag` to `etag`, which must be a valid unquoted RFC 9110 opaque tag (e.g. `Guid.NewGuid().ToString("N")`). Throws `ArgumentException` for null/empty/whitespace or non-opaque-tag characters. |
+| `void StampETag(string etag)` | `void` | Sets `IAggregate.ETag` to `etag`, which must be a valid unquoted RFC 9110 opaque tag (e.g. `Guid.NewGuid().ToString("N")`). Throws `ArgumentNullException` for null and `ArgumentException` for empty/whitespace or non-opaque-tag characters. |
 
 ### `IDomainEvent`
 


### PR DESCRIPTION
## Issue
`Aggregate<TId>.ETag` (the optimistic-concurrency token) has a `private set`. The EF Core integration stamps it through the change-tracker interceptor, which writes the value via EF metadata and never needs the CLR setter. Any other persistence stack — Dapper, raw ADO, a Cosmos SDK repository — has no way to set the ETag without reflection, so it cannot restore the stored token on load or apply a fresh one on save, and therefore cannot drive the framework's `ETag`/`If-Match` → 412 optimistic-concurrency flow.

## Fix
Add a public `IETagStampable` interface with `void StampETag(string etag)`, implemented **explicitly** by `Aggregate<TId>`. Explicit implementation keeps the method off the aggregate's public/domain surface (callers must cast to `IETagStampable`), preserving the "domain code must not modify ETag" intent while giving persistence infrastructure a sanctioned, reflection-free way to stamp the token.

`StampETag` validates that the value is a valid unquoted RFC 9110 §8.8.1 opaque tag (the same character rule `EntityTagValue` enforces), so a stamped token is always safe for the HTTP layer to emit as a strong `ETag`. Store-native quoted tokens (e.g. a Cosmos `_etag`) must be normalized to their unquoted form before stamping.

The EF Core ETag interceptor and concurrency-token mapping are unchanged; this is purely additive for non-EF persistence.