### PR TITLE
Add IReconstitutionStampable seam for rebuilding aggregates outside EF Core

### DIFF
--- a/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/Aggregate.cs
@@ -135,7 +135,7 @@ using System.Text.Json.Serialization;
 /// ServiceDefaults <c>UseEntityFrameworkUnitOfWork&lt;TContext&gt;()</c> and
 /// <c>UseTrackedAggregateDomainEvents()</c> slots).
 /// </example>
-public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable
+public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable, IReconstitutionStampable
     where TId : notnull
 {
     /// <summary>
@@ -205,6 +205,15 @@ public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable
         }
 
         return etag;
+    }
+
+    /// <inheritdoc />
+    void IReconstitutionStampable.StampReconstitutedState(DateTimeOffset createdAt, DateTimeOffset lastModified, string etag)
+    {
+        ETag = ValidateETag(etag);
+        CreatedAt = createdAt;
+        LastModified = lastModified;
+        AcceptChanges();
     }
 
     /// <summary>

--- a/Trellis.Core/src/DomainDrivenDesign/IReconstitutionStampable.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IReconstitutionStampable.cs
@@ -11,8 +11,8 @@
 /// its <c>Create</c>/<c>TryCreate</c> factory — no invariant re-validation, no new identity, and no
 /// creation events. The aggregate author owns rebuilding the <em>domain</em> state: expose a
 /// <c>Reconstitute(...)</c> factory that calls the (private) constructor and assigns get-only properties
-/// and private child collections directly. This seam owns only the <em>infrastructure</em> metadata that
-/// domain code must not touch.
+/// and private child collections directly. This seam restores only the <em>infrastructure</em> metadata —
+/// the audit timestamps and the concurrency token — and clears any uncommitted domain events.
 /// </para>
 /// <para>
 /// <see cref="Aggregate{TId}"/> implements this interface <b>explicitly</b>, so the method stays off the

--- a/Trellis.Core/src/DomainDrivenDesign/IReconstitutionStampable.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IReconstitutionStampable.cs
@@ -1,0 +1,55 @@
+﻿namespace Trellis;
+
+/// <summary>
+/// Infrastructure seam that lets a non-EF persistence adapter restore a reconstituted aggregate's
+/// persistence-managed metadata — audit timestamps and the optimistic-concurrency token — and clear its
+/// uncommitted domain events in one infra-only call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reconstitution rebuilds an aggregate from already-persisted, known-good state <em>without</em> running
+/// its <c>Create</c>/<c>TryCreate</c> factory — no invariant re-validation, no new identity, and no
+/// creation events. The aggregate author owns rebuilding the <em>domain</em> state: expose a
+/// <c>Reconstitute(...)</c> factory that calls the (private) constructor and assigns get-only properties
+/// and private child collections directly. This seam owns only the <em>infrastructure</em> metadata that
+/// domain code must not touch.
+/// </para>
+/// <para>
+/// <see cref="Aggregate{TId}"/> implements this interface <b>explicitly</b>, so the method stays off the
+/// aggregate's domain surface and is reachable only by a persistence adapter that casts to
+/// <see cref="IReconstitutionStampable"/>. The Trellis EF Core integration performs the equivalent through
+/// its materializer and interceptors.
+/// </para>
+/// <para>
+/// Typical adapter usage:
+/// <code>
+/// // The author's factory rebuilds domain state (private ctor + child collections); the adapter then
+/// // restores the infrastructure metadata it loaded from storage.
+/// var order = Order.Reconstitute(row.Id, row.CustomerId, row.Status, lineRows);
+/// ((IReconstitutionStampable)order).StampReconstitutedState(row.CreatedAt, row.LastModified, row.ETag);
+/// return order;
+/// </code>
+/// </para>
+/// </remarks>
+public interface IReconstitutionStampable
+{
+    /// <summary>
+    /// Restores the persistence-managed metadata of a reconstituted aggregate — the audit timestamps and
+    /// the optimistic-concurrency token — and clears any uncommitted domain events so the aggregate
+    /// represents already-persisted state. With the default event-based change tracking the aggregate then
+    /// reports <see cref="System.ComponentModel.IChangeTracking.IsChanged"/> as <see langword="false"/>.
+    /// For persistence infrastructure only — not domain code.
+    /// </summary>
+    /// <param name="createdAt">The stored creation timestamp.</param>
+    /// <param name="lastModified">The stored last-modified timestamp.</param>
+    /// <param name="etag">
+    /// The stored optimistic-concurrency token. Must be a valid unquoted RFC 9110 §8.8.1 opaque tag
+    /// (see <see cref="IETagStampable.StampETag(string)"/>).
+    /// </param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="etag"/> is <see langword="null"/>.</exception>
+    /// <exception cref="System.ArgumentException">
+    /// <paramref name="etag"/> is empty, whitespace, or contains characters that are not valid in an
+    /// RFC 9110 opaque tag.
+    /// </exception>
+    void StampReconstitutedState(DateTimeOffset createdAt, DateTimeOffset lastModified, string etag);
+}

--- a/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
@@ -144,7 +144,10 @@ public class AggregateTests
 
         // Act — an invalid (quoted) token must be rejected before any state is mutated.
         var act = () => ((IReconstitutionStampable)aggregate)
-            .StampReconstitutedState(default, default, "\"quoted\"");
+            .StampReconstitutedState(
+                new DateTimeOffset(2025, 5, 5, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2025, 6, 6, 0, 0, 0, TimeSpan.Zero),
+                "\"quoted\"");
 
         // Assert — throws, and the ETag, timestamps, and uncommitted event are all left untouched.
         act.Should().Throw<ArgumentException>();

--- a/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
+++ b/Trellis.Core/tests/DomainDrivenDesign/Aggregates/AggregateTests.cs
@@ -104,6 +104,63 @@ public class AggregateTests
 
     #endregion
 
+    #region Reconstitution Tests
+
+    [Fact]
+    public void Aggregate_implements_IReconstitutionStampable() =>
+        typeof(IReconstitutionStampable).IsAssignableFrom(typeof(Aggregate<string>)).Should().BeTrue();
+
+    [Fact]
+    public void StampReconstitutedState_restores_metadata_and_clears_events()
+    {
+        // Arrange — an aggregate carrying an uncommitted event, as if it had been mutated.
+        var aggregate = TestAggregate.Create("agg-1");
+        aggregate.DoSomething();
+        aggregate.IsChanged.Should().BeTrue();
+        var created = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var modified = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+        // Act — a non-EF adapter restores persistence metadata after rebuilding the aggregate.
+        ((IReconstitutionStampable)aggregate).StampReconstitutedState(created, modified, "etag-abc");
+
+        // Assert — persisted metadata restored; a reconstituted aggregate carries no uncommitted events.
+        aggregate.ETag.Should().Be("etag-abc");
+        aggregate.CreatedAt.Should().Be(created);
+        aggregate.LastModified.Should().Be(modified);
+        aggregate.UncommittedEvents().Should().BeEmpty();
+        aggregate.IsChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public void StampReconstitutedState_with_invalid_etag_throws_without_mutating_state()
+    {
+        // Arrange — seed metadata and an uncommitted event, so we can prove nothing is mutated on failure.
+        var aggregate = TestAggregate.Create("agg-1");
+        aggregate.DoSomething();
+        var created = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var modified = new DateTimeOffset(2024, 2, 1, 0, 0, 0, TimeSpan.Zero);
+        aggregate.CreatedAt = created;
+        aggregate.LastModified = modified;
+
+        // Act — an invalid (quoted) token must be rejected before any state is mutated.
+        var act = () => ((IReconstitutionStampable)aggregate)
+            .StampReconstitutedState(default, default, "\"quoted\"");
+
+        // Assert — throws, and the ETag, timestamps, and uncommitted event are all left untouched.
+        act.Should().Throw<ArgumentException>();
+        aggregate.ETag.Should().BeEmpty();
+        aggregate.CreatedAt.Should().Be(created);
+        aggregate.LastModified.Should().Be(modified);
+        aggregate.IsChanged.Should().BeTrue();
+    }
+
+    [Fact]
+    public void StampReconstitutedState_is_explicit_and_not_on_the_public_aggregate_surface() =>
+        typeof(Aggregate<string>).GetMethod("StampReconstitutedState").Should().BeNull(
+            "StampReconstitutedState is an infrastructure-only seam implemented explicitly");
+
+    #endregion
+
     #region Domain Events Tests
 
     [Fact]

--- a/Trellis.EntityFrameworkCore/tests/AggregateReconstitutionParityTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/AggregateReconstitutionParityTests.cs
@@ -1,0 +1,153 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Conformance test pinning EF Core materialization and the non-EF reconstitution contract
+/// (<see cref="IReconstitutionStampable"/> + an author-written <c>Reconstitute</c> factory) to identical
+/// results for the same stored state. EF and non-EF persistence are two implementations of the same
+/// reconstitution semantics; this proves they agree, so a divergence is caught immediately.
+/// </summary>
+public sealed class AggregateReconstitutionParityTests
+{
+    [Fact]
+    public async Task EfLoad_and_Reconstitute_produce_equivalent_aggregates()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+        await using var context = new GadgetContext(connection);
+        await context.Database.EnsureCreatedAsync(ct);
+
+        // Arrange — create and save through EF so its interceptors stamp the ETag and timestamps.
+        var saved = Gadget.New("g-1", "widget", "alpha", "beta");
+        // Preset CreatedAt: the interceptor preserves a non-default CreatedAt and stamps LastModified = now,
+        // so the parent's two timestamps differ and a swapped timestamp path would be caught.
+        saved.CreatedAt = new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        context.Add(saved);
+        await context.SaveChangesAsync(ct);
+        saved.CreatedAt.Should().NotBe(saved.LastModified, "the timestamp parity assertions are only meaningful if the two differ");
+
+        // Capture the persisted state from the saved instance.
+        var id = saved.Id;
+        var name = saved.Name;
+        var etag = saved.ETag;
+        var createdAt = saved.CreatedAt;
+        var lastModified = saved.LastModified;
+        var storedParts = saved.Parts
+            .Select(p => GadgetPart.Reconstitute(p.Id, p.OwnerId, p.Label, p.CreatedAt, p.LastModified))
+            .ToList();
+
+        context.ChangeTracker.Clear();
+
+        // Act — load the same row through EF, and rebuild it through the reconstitution contract.
+        var efLoaded = await context.Set<Gadget>()
+            .Include(g => g.Parts)
+            .SingleAsync(g => g.Id == id, ct);
+
+        var reconstituted = Gadget.Reconstitute(id, name, storedParts);
+        ((IReconstitutionStampable)reconstituted).StampReconstitutedState(createdAt, lastModified, etag);
+
+        // Assert — EF materialization and the reconstitution contract agree on every observable dimension.
+        efLoaded.IsChanged.Should().BeFalse("EF materialization must not raise creation events");
+        efLoaded.UncommittedEvents().Should().BeEmpty();
+
+        reconstituted.Id.Should().Be(efLoaded.Id);
+        reconstituted.Name.Should().Be(efLoaded.Name);
+        reconstituted.ETag.Should().Be(efLoaded.ETag);
+        reconstituted.CreatedAt.Should().Be(efLoaded.CreatedAt);
+        reconstituted.LastModified.Should().Be(efLoaded.LastModified);
+        reconstituted.IsChanged.Should().Be(efLoaded.IsChanged);
+        reconstituted.UncommittedEvents().Should().BeEquivalentTo(efLoaded.UncommittedEvents());
+        reconstituted.Parts.Select(p => new { p.Id, p.OwnerId, p.Label, p.CreatedAt, p.LastModified })
+            .Should().BeEquivalentTo(efLoaded.Parts.Select(p => new { p.Id, p.OwnerId, p.Label, p.CreatedAt, p.LastModified }));
+    }
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+// Child entity with encapsulated (private-set) state and a reconstitution factory.
+internal sealed class GadgetPart : Entity<string>
+{
+    private GadgetPart() : base(default!) { }
+
+    private GadgetPart(string id, string ownerId, string label) : base(id)
+    {
+        OwnerId = ownerId;
+        Label = label;
+    }
+
+    public string OwnerId { get; private set; } = null!;
+
+    public string Label { get; private set; } = null!;
+
+    internal static GadgetPart New(string ownerId, string label) =>
+        // Preset CreatedAt to a fixed past value: the timestamp interceptor preserves a non-default
+        // CreatedAt and stamps LastModified = now, so the two child timestamps stay distinct.
+        new(Guid.NewGuid().ToString("N"), ownerId, label)
+        {
+            CreatedAt = new DateTimeOffset(2021, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        };
+
+    internal static GadgetPart Reconstitute(
+        string id, string ownerId, string label, DateTimeOffset createdAt, DateTimeOffset lastModified) =>
+        new(id, ownerId, label)
+        {
+            CreatedAt = createdAt,
+            LastModified = lastModified,
+        };
+}
+
+// Aggregate with an encapsulated child collection; create-time and reconstitution factories.
+internal sealed class Gadget : Aggregate<string>
+{
+    private readonly List<GadgetPart> _parts = [];
+
+    private Gadget() : base(default!) { }
+
+    private Gadget(string id, string name, IEnumerable<GadgetPart> parts) : base(id)
+    {
+        Name = name;
+        _parts.AddRange(parts);
+    }
+
+    public string Name { get; private set; } = null!;
+
+    public IReadOnlyList<GadgetPart> Parts => _parts.AsReadOnly();
+
+    internal static Gadget New(string id, string name, params string[] labels) =>
+        new(id, name, labels.Select(label => GadgetPart.New(id, label)));
+
+    internal static Gadget Reconstitute(string id, string name, IEnumerable<GadgetPart> parts) =>
+        new(id, name, parts);
+}
+
+internal sealed class GadgetContext(SqliteConnection connection) : DbContext
+{
+    public DbSet<Gadget> Gadgets => Set<Gadget>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options) =>
+        options.UseSqlite(connection).AddTrellisInterceptors();
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder builder) =>
+        builder.ApplyTrellisConventions(typeof(GadgetContext).Assembly);
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        builder.Entity<Gadget>(e =>
+        {
+            e.ToTable("gadgets");
+            e.HasKey(g => g.Id);
+            e.Property(g => g.Name).IsRequired();
+            e.HasMany(g => g.Parts).WithOne().HasForeignKey(p => p.OwnerId);
+        });
+
+        builder.Entity<GadgetPart>(e =>
+        {
+            e.ToTable("gadget_parts");
+            e.HasKey(p => p.Id);
+            e.Property(p => p.Label).IsRequired();
+        });
+    }
+}

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -108,6 +108,7 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Fix analyzer warnings | [Recipe 11](#recipe-11--anti-pattern--fix-gallery-the-analyzers-in-action) |
 | Wire the composition root | [Recipe 12](#recipe-12--di-wiring-playbook-addtrellis-composition-builder) |
 | Rehydrate an entity from a database row (fail-loud vs Result-track) | [Recipe 30](#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track) |
+| Reconstitute an aggregate in a non-EF repository without re-running its factory (no re-validation, no events) | [Recipe 37](#recipe-37--reconstituting-an-aggregate-without-its-factory-non-ef-repositories) |
 | Avoid the pipeline-then-handler duplicate load when a command both authorizes and mutates the same resource | [Recipe 31](#recipe-31--avoid-duplicate-load-with-iauthorizedresourcetcommand-tresource) |
 | Hide existence of sensitive resources from unauthorized callers — translate `Forbidden`/`AuthenticationRequired` to `NotFound` | [Recipe 32](#recipe-32--hide-existence-with-authfailureexposurepolicyhideasnotfound) |
 | Configure the strict `AddJwtBearer` validation profile + key-rotation runbook for a gateway-minted internal JWT | [Moved: xavierjohn/Trellis.Microservices](#recipes-33-34--moved-to-xavierjohntrellismicroservices) (Recipe 1 in the microservices cookbook) |
@@ -3050,6 +3051,88 @@ services.AddTrellis(trellis => trellis
 - Integration events require the outbox: the collector is only a hand-off buffer, so events added without `UseOutbox<TContext>()` are never delivered.
 
 See [trellis-api-efcore-outbox.md](trellis-api-efcore-outbox.md#integration-events) for the routing contract.
+
+## Recipe 37 — Reconstituting an aggregate without its factory (non-EF repositories)
+
+**Problem.** A non-EF repository (Dapper, raw ADO, a Cosmos SDK) must rebuild an aggregate from a stored row **without** re-running its `Create`/`TryCreate` factory: reconstitution must not re-validate invariants, mint a new identity, or raise creation events. EF Core does this in its materializer; outside EF you assemble the aggregate yourself. [Recipe 30](#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track) covers turning stored primitives back into value objects; this recipe covers assembling the aggregate from them and restoring its persistence metadata via the `IReconstitutionStampable` seam.
+
+### 1. The aggregate exposes a reconstitution factory (author-owned)
+
+Add a private constructor that takes the **full** persisted domain state (including child collections) and a `Reconstitute(...)` factory that calls it — pure assignment, no `Create`, no behavior methods, no events. Make the factory `internal` (+ `[InternalsVisibleTo]` to the persistence assembly) to keep it off the public domain surface, or `public` when the adapter lives in another package.
+
+```csharp
+using Trellis;
+
+public sealed class Order : Aggregate<OrderId>
+{
+    private readonly List<OrderLine> _lines = [];
+
+    public CustomerId CustomerId { get; }
+    public OrderStatus Status { get; }
+    public IReadOnlyList<OrderLine> Lines => _lines.AsReadOnly();
+
+    private Order(OrderId id, CustomerId customerId) : base(id)   // create-time ctor
+    {
+        CustomerId = customerId;
+        Status = OrderStatus.Draft;
+    }
+
+    public static Result<Order> Create(CustomerId customerId) => /* invariant checks */ ;
+
+    private Order(OrderId id, CustomerId customerId, OrderStatus status, IEnumerable<OrderLine> lines)
+        : base(id)                                                // reconstitution ctor — pure assignment
+    {
+        CustomerId = customerId;
+        Status = status;
+        _lines.AddRange(lines);
+    }
+
+    // Rebuilds an Order from stored domain state. Does NOT run Create or raise events.
+    internal static Order Reconstitute(
+        OrderId id, CustomerId customerId, OrderStatus status, IEnumerable<OrderLine> lines) =>
+        new(id, customerId, status, lines);
+}
+```
+
+### 2. The repository assembles domain state, then stamps infrastructure metadata
+
+Rehydrate the value objects (fail-loud per [Recipe 30](#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track)), call `Reconstitute`, then cast to `IReconstitutionStampable` to restore the audit timestamps and the concurrency token in one call. `StampReconstitutedState` validates the ETag and clears any uncommitted events, so the loaded aggregate has no uncommitted events (`IsChanged == false` under the default event-based change tracking).
+
+```csharp
+public sealed class DapperOrderRepository(IDbConnection db) : IOrderRepository
+{
+    public async Task<Result<Order>> FindByIdAsync(OrderId id, CancellationToken ct)
+    {
+        var row = await db.QuerySingleOrDefaultAsync<OrderRow>(/* ... */);
+        if (row is null)
+            return Result.Fail<Order>(new Error.NotFound(ResourceRef.For<Order>(id)));
+
+        var lines = lineRows.Select(r => OrderLine.Reconstitute(
+            ProductId.TryCreate(r.ProductId).GetValueOrThrow($"Corrupt OrderLine.ProductId in row {r.Id}"),
+            r.Quantity));
+
+        var order = Order.Reconstitute(
+            OrderId.TryCreate(row.Id).GetValueOrThrow($"Corrupt Order.Id in row {row.Id}"),
+            CustomerId.TryCreate(row.CustomerId).GetValueOrThrow($"Corrupt Order.CustomerId in row {row.Id}"),
+            OrderStatus.TryFromName(row.Status).GetValueOrThrow($"Corrupt Order.Status in row {row.Id}"),
+            lines);
+
+        // Restore the infrastructure metadata loaded from the row. A store-native quoted token (e.g. a
+        // Cosmos _etag) must be normalized to its unquoted opaque form before stamping.
+        ((IReconstitutionStampable)order)
+            .StampReconstitutedState(row.CreatedAt, row.LastModified, row.ETag);
+
+        return Result.Ok(order);
+    }
+}
+```
+
+On **save**, generate a fresh token and stamp it the same way (or via `IETagStampable.StampETag`), using the previous value in the optimistic `WHERE ETag = @original` clause — the non-EF equivalent of the EF concurrency-token interceptor.
+
+**Semantics to remember.**
+- The reconstitution constructor must be pure assignment: no `Create`, no behavior methods, no events. `StampReconstitutedState` clears any uncommitted events defensively, but relying on that hides a modeling bug.
+- Reconstitution does **not** re-validate domain invariants — correct for trusted outbound reads (see [Recipe 30](#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track)). Value-object-level checks still run through each `TryCreate`.
+- Child entities follow the same pattern: a private reconstitution constructor + `Reconstitute` factory; the parent copies them into its backing collection.
 
 ## Cross-references
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IETagStampable, IEntity, "Entity<TId>", IDomainEvent, IIntegrationEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredDateTimeOffset<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, PositiveAttribute, NonNegativeAttribute, NegativeAttribute, NonPositiveAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResourceCollectionNameAttribute, ResultDebugSettings]
+types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IETagStampable, IReconstitutionStampable, IEntity, "Entity<TId>", IDomainEvent, IIntegrationEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredDateTimeOffset<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, PositiveAttribute, NonNegativeAttribute, NegativeAttribute, NonPositiveAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResourceCollectionNameAttribute, ResultDebugSettings]
 version: v3
 last_verified: 2026-06-03
 audience: [llm]
@@ -1623,7 +1623,7 @@ public interface IAggregate : IChangeTracking
 ### `Aggregate<TId>`
 
 ```csharp
-public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable where TId : notnull
+public abstract class Aggregate<TId> : Entity<TId>, IAggregate, IETagStampable, IReconstitutionStampable where TId : notnull
 ```
 
 | Name | Type | Description |
@@ -1649,6 +1649,18 @@ Persistence-infrastructure seam for stamping an aggregate's optimistic-concurren
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `void StampETag(string etag)` | `void` | Sets `IAggregate.ETag` to `etag`, which must be a valid unquoted RFC 9110 opaque tag (e.g. `Guid.NewGuid().ToString("N")`). Throws `ArgumentNullException` for null and `ArgumentException` for empty/whitespace or non-opaque-tag characters. |
+
+### `IReconstitutionStampable`
+
+```csharp
+public interface IReconstitutionStampable
+```
+
+Persistence-infrastructure seam for restoring a reconstituted aggregate's persistence-managed metadata without exposing setters to domain code. `Aggregate<TId>` implements it **explicitly**. The aggregate author rebuilds *domain* state via its own `Reconstitute(...)` factory (private constructor + assigning get-only properties and private child collections); a non-EF adapter then casts to `IReconstitutionStampable` to restore the *infrastructure* metadata it loaded from storage. Post-conditions: timestamps and ETag restored, no uncommitted domain events (so `IsChanged == false` under the default event-based change tracking). The EF Core integration does the equivalent via its materializer and interceptors.
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `void StampReconstitutedState(DateTimeOffset createdAt, DateTimeOffset lastModified, string etag)` | `void` | Restores audit timestamps and the optimistic-concurrency token, and clears uncommitted domain events. `etag` must be a valid unquoted RFC 9110 opaque tag; throws `ArgumentNullException` for null and `ArgumentException` for empty/whitespace or non-opaque-tag characters. |
 
 ### `IDomainEvent`
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1656,7 +1656,7 @@ Persistence-infrastructure seam for stamping an aggregate's optimistic-concurren
 public interface IReconstitutionStampable
 ```
 
-Persistence-infrastructure seam for restoring a reconstituted aggregate's persistence-managed metadata without exposing setters to domain code. `Aggregate<TId>` implements it **explicitly**. The aggregate author rebuilds *domain* state via its own `Reconstitute(...)` factory (private constructor + assigning get-only properties and private child collections); a non-EF adapter then casts to `IReconstitutionStampable` to restore the *infrastructure* metadata it loaded from storage. Post-conditions: timestamps and ETag restored, no uncommitted domain events (so `IsChanged == false` under the default event-based change tracking). The EF Core integration does the equivalent via its materializer and interceptors.
+Persistence-infrastructure seam for restoring a reconstituted aggregate's persistence-managed metadata (audit timestamps and the optimistic-concurrency token) and clearing its uncommitted domain events, through an explicit infra-only method. `Aggregate<TId>` implements it **explicitly**. The aggregate author rebuilds *domain* state via its own `Reconstitute(...)` factory (private constructor + assigning get-only properties and private child collections); a non-EF adapter then casts to `IReconstitutionStampable` to restore the *infrastructure* metadata it loaded from storage. Post-conditions: timestamps and ETag restored, no uncommitted domain events (so `IsChanged == false` under the default event-based change tracking). The EF Core integration does the equivalent via its materializer and interceptors.
 
 | Signature | Returns | Description |
 | --- | --- | --- |


### PR DESCRIPTION
## Issue
A non-EF persistence adapter (Dapper, raw ADO, a Cosmos SDK repository) has no blessed way to reconstitute an aggregate from already-persisted state. Going through the aggregate's `Create`/`TryCreate` factory is wrong for a load: it re-validates invariants, mints a new identity, and raises creation events. EF Core handles this in its materializer; non-EF adapters were left to reflection or to exposing encapsulation-breaking public setters.

## Fix
Add a public `IReconstitutionStampable` interface, implemented **explicitly** by `Aggregate<TId>`:

```csharp
void StampReconstitutedState(DateTimeOffset createdAt, DateTimeOffset lastModified, string etag);
```

It restores the audit timestamps and the optimistic-concurrency token (validated as an RFC 9110 opaque tag, reusing the existing ETag-stamp validation) and clears any uncommitted domain events — in one infrastructure-only call. Explicit implementation keeps the method off the aggregate's domain surface (callers cast to `IReconstitutionStampable`).

Division of labour: the aggregate author rebuilds **domain** state through a private reconstitution constructor and a `Reconstitute(...)` factory (assigning get-only properties and private child collections — reflection-free); the adapter then stamps the **infrastructure** metadata. A new cookbook recipe documents the full pattern.

This is purely additive and parallels the existing `IETagStampable` seam; the EF Core integration is unchanged.