### PR TITLE
Add typed actor attribute accessors for value-object claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — typed actor attribute accessors (`Actor.GetRequiredAttribute<TVo>` / `TryGetAttribute<TVo>`)
+
+`Trellis.Authorization.Actor` gains two generic accessors that parse an actor attribute (an ABAC claim) into
+a string-backed scalar value object through its own `TryCreate`, removing the `GetAttribute(...)` +
+`TryCreate(...)` ceremony and the magic-string key at every call site:
+
+- **`Result<TVo> GetRequiredAttribute<TVo>(string key)`** returns the typed value when the attribute is
+  present and valid, or a failed `Result` carrying the value object's `Error.InvalidInput` (the error's field
+  is `key`; a missing attribute fails the same way) — suited to railway composition in a handler.
+- **`bool TryGetAttribute<TVo>(string key, out TVo? value)`** returns `true` with the parsed value when
+  present and valid, `false` otherwise — deny-closes naturally in an authorization gate.
+
+Both constrain `TVo` to `class, IScalarValue<TVo, string>` (a `RequiredString<T>` subclass — the natural
+model for a string claim). The existing `string? GetAttribute(string)` is unchanged. New cookbook Recipe 38
+demonstrates the tenant-isolation use: a per-command scope check with no base type.
+
 ### Added — inbox pull-consumer ergonomics (`FilterUnprocessedAsync`, dispatch outcome)
 
 `Trellis.EntityFrameworkCore.Inbox` gains two additions that unlock the gap-free pull / anti-join consumer

--- a/Examples/CookbookSnippets/Recipe38_TenantScopedAuthorization.cs
+++ b/Examples/CookbookSnippets/Recipe38_TenantScopedAuthorization.cs
@@ -1,0 +1,49 @@
+﻿// Cookbook Recipe 38 — Tenant-scoped resource authorization with a typed actor attribute.
+namespace CookbookSnippets.Recipe38;
+
+using global::Mediator;
+using Trellis;
+using Trellis.Authorization;
+using Trellis.Mediator;
+
+// String-backed tenant identifier, sourced from the actor's "tid" claim. Because it is a
+// RequiredString<TenantId>, Actor.GetRequiredAttribute<TenantId>/TryGetAttribute<TenantId> can
+// parse the claim string through its TryCreate, applying the same validation as request input.
+public sealed partial class TenantId : RequiredString<TenantId>;
+
+public sealed partial class DocumentId : RequiredGuid<DocumentId>;
+
+// The loaded resource the authorization pipeline hands to Authorize(actor, resource). In a real
+// app this is the aggregate (or a projection) produced by the resource loader; it carries the
+// tenant the row belongs to.
+public sealed class TenantDocument
+{
+    public required DocumentId Id { get; init; }
+    public required TenantId TenantId { get; init; }
+}
+
+public sealed record ArchiveDocumentCommand(DocumentId DocumentId)
+    : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<TenantDocument>, IIdentifyResource<TenantDocument, DocumentId>
+{
+    public DocumentId GetResourceId() => DocumentId;
+
+    // TENANT ISOLATION — the per-command scope check that would otherwise be copy-pasted across
+    // every command in every service. There is deliberately no base class: the rule stays explicit
+    // and lives with the command. The typed accessor removes the GetAttribute(...) + TenantId.TryCreate(...)
+    // ceremony, and the gate deny-closes (Forbidden) on a missing, malformed, or mismatched tenant claim.
+    public Trellis.IResult Authorize(Actor actor, TenantDocument resource) =>
+        actor.TryGetAttribute<TenantId>(ActorAttributes.TenantId, out var tenant) && tenant == resource.TenantId
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden(
+                PolicyId: "tenant.isolation",
+                Resource: ResourceRef.For<TenantDocument>(resource.Id)));
+}
+
+internal static class Recipe38TenantSurface
+{
+    // When a handler needs the tenant as a Result to compose with other steps (railway style),
+    // GetRequiredAttribute returns Result<TenantId> instead of a bool — a missing or invalid claim
+    // becomes a failed Result whose error field is the attribute key.
+    public static Result<TenantId> ReadTenant(Actor actor) =>
+        actor.GetRequiredAttribute<TenantId>(ActorAttributes.TenantId);
+}

--- a/Trellis.Authorization/src/Actor.cs
+++ b/Trellis.Authorization/src/Actor.cs
@@ -1,6 +1,7 @@
 ﻿namespace Trellis.Authorization;
 
 using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -293,6 +294,58 @@ public sealed class Actor : IEquatable<Actor>
     {
         ArgumentNullException.ThrowIfNull(key);
         return Attributes.TryGetValue(key, out var value) ? value : null;
+    }
+
+    /// <summary>
+    /// Returns the attribute identified by <paramref name="key"/> parsed into the string-backed scalar
+    /// value object <typeparamref name="TVo"/> through its <c>TryCreate</c> factory, so a claim-sourced
+    /// value is validated by the same domain rule that guards request input.
+    /// </summary>
+    /// <typeparam name="TVo">
+    /// A string-backed scalar value object — for example a <c>RequiredString&lt;T&gt;</c> subclass such as
+    /// <see cref="ActorId"/>. The attribute string is run through the type's own <c>TryCreate</c>.
+    /// </typeparam>
+    /// <param name="key">The attribute key. Use <see cref="ActorAttributes"/> constants for well-known keys.</param>
+    /// <returns>
+    /// A success <see cref="Result{T}"/> with the typed value when the attribute is present and valid;
+    /// otherwise a failed <see cref="Result{T}"/> carrying the value object's <see cref="Error.InvalidInput"/>.
+    /// A missing attribute is treated as a missing value and fails the same way. The error's field is the
+    /// attribute <paramref name="key"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is null.</exception>
+    public Result<TVo> GetRequiredAttribute<TVo>(string key)
+        where TVo : class, IScalarValue<TVo, string>
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        return TVo.TryCreate(GetAttribute(key), key);
+    }
+
+    /// <summary>
+    /// Attempts to parse the attribute identified by <paramref name="key"/> into the string-backed scalar
+    /// value object <typeparamref name="TVo"/> through its <c>TryCreate</c> factory.
+    /// </summary>
+    /// <typeparam name="TVo">
+    /// A string-backed scalar value object — for example a <c>RequiredString&lt;T&gt;</c> subclass.
+    /// </typeparam>
+    /// <param name="key">The attribute key. Use <see cref="ActorAttributes"/> constants for well-known keys.</param>
+    /// <param name="value">When this method returns <see langword="true"/>, the parsed value; otherwise <see langword="null"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> when the attribute is present and valid; <see langword="false"/> when it is
+    /// absent or fails the value object's validation.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is null.</exception>
+    public bool TryGetAttribute<TVo>(string key, [NotNullWhen(true)] out TVo? value)
+        where TVo : class, IScalarValue<TVo, string>
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (TVo.TryCreate(GetAttribute(key), key).TryGetValue(out var created))
+        {
+            value = created;
+            return true;
+        }
+
+        value = null;
+        return false;
     }
 
     /// <summary>

--- a/Trellis.Authorization/tests/ActorTypedAttributeTests.cs
+++ b/Trellis.Authorization/tests/ActorTypedAttributeTests.cs
@@ -1,0 +1,110 @@
+namespace Trellis.Authorization.Tests;
+
+using Trellis.Testing;
+
+#pragma warning disable CA1707 // readable xUnit test names
+
+/// <summary>
+/// Tests for the typed actor-attribute accessors that parse an attribute string into a
+/// string-backed scalar value object through its <c>TryCreate</c> factory.
+/// </summary>
+public class ActorTypedAttributeTests
+{
+    private const string ScopeKey = "scope";
+
+    private static Actor WithAttribute(string key, string value) =>
+        new("user-1", new HashSet<string>(), new HashSet<string>(), new Dictionary<string, string> { [key] = value });
+
+    private static Actor WithNoAttributes() =>
+        new("user-1", new HashSet<string>(), new HashSet<string>(), new Dictionary<string, string>());
+
+    [Fact]
+    public void GetRequiredAttribute_present_and_valid_returns_typed_value()
+    {
+        var actor = WithAttribute(ScopeKey, "tenant-7");
+
+        var result = actor.GetRequiredAttribute<ActorId>(ScopeKey);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Unwrap().Value.Should().Be("tenant-7");
+    }
+
+    [Fact]
+    public void GetRequiredAttribute_missing_returns_failure_referencing_the_key()
+    {
+        var actor = WithNoAttributes();
+
+        var result = actor.GetRequiredAttribute<ActorId>(ScopeKey);
+
+        result.IsFailure.Should().BeTrue();
+        var invalid = result.Error.Should().BeOfType<Error.InvalidInput>().Subject;
+        invalid.Fields[0].Field.Path.Should().Be("/scope", "the failed attribute key identifies the error field");
+    }
+
+    [Fact]
+    public void GetRequiredAttribute_present_but_invalid_returns_failure()
+    {
+        // ActorId is [Trim, NotDefault]: whitespace trims to empty and is rejected.
+        var actor = WithAttribute(ScopeKey, "   ");
+
+        var result = actor.GetRequiredAttribute<ActorId>(ScopeKey);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().BeOfType<Error.InvalidInput>();
+    }
+
+    [Fact]
+    public void GetRequiredAttribute_null_key_throws()
+    {
+        var actor = WithNoAttributes();
+
+        var act = () => actor.GetRequiredAttribute<ActorId>(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryGetAttribute_present_and_valid_returns_true_and_value()
+    {
+        var actor = WithAttribute(ScopeKey, "tenant-7");
+
+        var ok = actor.TryGetAttribute<ActorId>(ScopeKey, out var scope);
+
+        ok.Should().BeTrue();
+        scope!.Value.Should().Be("tenant-7");
+    }
+
+    [Fact]
+    public void TryGetAttribute_missing_returns_false_and_null()
+    {
+        var actor = WithNoAttributes();
+
+        var ok = actor.TryGetAttribute<ActorId>(ScopeKey, out var scope);
+
+        ok.Should().BeFalse();
+        scope.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetAttribute_present_but_invalid_returns_false_and_null()
+    {
+        var actor = WithAttribute(ScopeKey, "   ");
+
+        var ok = actor.TryGetAttribute<ActorId>(ScopeKey, out var scope);
+
+        ok.Should().BeFalse();
+        scope.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetAttribute_null_key_throws()
+    {
+        var actor = WithNoAttributes();
+
+        var act = () => actor.TryGetAttribute<ActorId>(null!, out _);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}
+
+#pragma warning restore CA1707

--- a/docs/docfx_project/api_reference/trellis-api-authorization.md
+++ b/docs/docfx_project/api_reference/trellis-api-authorization.md
@@ -3,7 +3,7 @@ package: Trellis.Authorization
 namespaces: [Trellis.Authorization]
 types: [Actor, ActorAttributes, ActorId, IActorProvider, IAuthorize, "IAuthorizeResource<TResource>", "IAuthorizeResourceVia<TOwner>", "IIdentifyResource<TResource,TId>", "IIdentifyRelatedResource<TRelated,TId>", "IIdentifyRelatedResources<TRelated,TId>", "IResourceLoader<TMessage,TResource>", "ResourceLoaderById<TMessage,TResource,TId>", "SharedResourceLoaderById<TResource,TId>"]
 version: v3
-last_verified: 2026-06-17
+last_verified: 2026-06-21
 audience: [llm]
 ---
 # Trellis.Authorization — API Reference
@@ -150,6 +150,8 @@ public sealed class Actor : IEquatable<Actor>
 | `public bool IsOwner(string resourceOwnerId)` | `bool` | Convenience overload that compares `Id.Value` and `resourceOwnerId` with `StringComparison.Ordinal`. |
 | `public bool HasAttribute(string key)` | `bool` | `true` when `Attributes` contains `key`. |
 | `public string? GetAttribute(string key)` | `string?` | Returns the attribute value or `null` when absent. |
+| `public Result<TVo> GetRequiredAttribute<TVo>(string key) where TVo : class, IScalarValue<TVo, string>` | `Result<TVo>` | Parses the attribute through the string-backed value object's `TryCreate`: a success `Result` with the typed value when present and valid, otherwise a failed `Result` carrying the value object's `Error.InvalidInput` (a missing attribute fails the same way). The error's field is `key`. Throws `ArgumentNullException` when `key` is null. |
+| `public bool TryGetAttribute<TVo>(string key, out TVo? value) where TVo : class, IScalarValue<TVo, string>` | `bool` | `true` with the parsed `value` when the attribute is present and valid; `false` (and `value` is null) when absent or invalid — deny-closes naturally in an authorization gate. Throws `ArgumentNullException` when `key` is null. |
 
 ### `ActorId`
 
@@ -518,6 +520,11 @@ var actor = new Actor(
 bool canCancel = actor.HasPermission("orders:cancel");
 bool canViewTenant = actor.HasPermission("orders:view", "tenant-1");
 string? tenant = actor.GetAttribute(ActorAttributes.TenantId);
+
+// Typed accessors parse the claim through a string-backed value object's TryCreate
+// (where: public sealed partial class TenantId : RequiredString<TenantId>;):
+Result<TenantId> tenantVo = actor.GetRequiredAttribute<TenantId>(ActorAttributes.TenantId);
+bool hasTenant = actor.TryGetAttribute<TenantId>(ActorAttributes.TenantId, out var typedTenant);
 ```
 
 ## Cross-references

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -3150,7 +3150,7 @@ using Trellis.Mediator;
 public sealed partial class TenantId : RequiredString<TenantId>;
 
 public sealed record ArchiveDocumentCommand(DocumentId DocumentId)
-    : ICommand<Result<Unit>>, IAuthorizeResource<TenantDocument>, IIdentifyResource<TenantDocument, DocumentId>
+    : ICommand<Result<Trellis.Unit>>, IAuthorizeResource<TenantDocument>, IIdentifyResource<TenantDocument, DocumentId>
 {
     public DocumentId GetResourceId() => DocumentId;
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -91,6 +91,7 @@ Use this table before writing code. If a task matches a row, read that recipe fi
 | Map primitive DTO fields to value objects | [Recipe 18](#recipe-18--dto-primitives-to-value-object-command-no-test-only-unwrap) |
 | Add resource authorization | [Recipe 7](#recipe-7--authorization-iactorprovider--iauthorize--resource-based-auth) |
 | Authorize against a related resource one or more navigation hops away (cricket-style fan-out, owner chains) | [Recipe 24](#recipe-24--indirect-multi-hop-resource-authorization) |
+| Enforce tenant isolation on a command (per-command scope check, no base type) | [Recipe 38](#recipe-38--tenant-scoped-resource-authorization-with-a-typed-actor-attribute) |
 | Map `Maybe<T>` or composite value objects with EF Core | [Recipe 8](#recipe-8--ef-core-maybepropertymapping-for-nullable-value-objects), [Recipe 13](#recipe-13--composite-value-object-end-to-end-domain--api-json-binding--ef-core-ownership) |
 | Add optional request/response fields | [Recipe 14](#recipe-14--optional-fields-in-request-dtos-maybetscalar-vs-nullable-transport) |
 | Read optional HTTP resources where 404 means absent | [Recipe 19](#recipe-19--http-client-result-safety-and-optional-reads) |
@@ -3133,6 +3134,45 @@ On **save**, generate a fresh token and stamp it the same way (or via `IETagStam
 - The reconstitution constructor must be pure assignment: no `Create`, no behavior methods, no events. `StampReconstitutedState` clears any uncommitted events defensively, but relying on that hides a modeling bug.
 - Reconstitution does **not** re-validate domain invariants — correct for trusted outbound reads (see [Recipe 30](#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track)). Value-object-level checks still run through each `TryCreate`.
 - Child entities follow the same pattern: a private reconstitution constructor + `Reconstitute` factory; the parent copies them into its backing collection.
+
+## Recipe 38 — Tenant-scoped resource authorization with a typed actor attribute
+
+**Problem.** A multi-tenant service must reject any command whose target row belongs to a different tenant than the caller. The check is the same in every command — read the tenant from the actor's claim, compare it to the resource's tenant — so it gets copy-pasted, and each copy re-does the `actor.GetAttribute("tid")` string lookup plus a manual `TenantId.TryCreate(...)`. A shared base class is tempting, but tenant isolation is **policy**, not configuration: a base type either rigidly assumes one scope shape or grows so many hooks it saves nothing, and it hides a security decision inside a hierarchy. Keep the rule explicit per command; remove only the parsing ceremony.
+
+```csharp
+using Mediator;
+using Trellis;
+using Trellis.Authorization;
+using Trellis.Mediator;
+
+// String-backed tenant id, sourced from the actor's "tid" claim. DocumentId and TenantDocument
+// (the loaded resource, carrying the tenant it belongs to) are your own types — see Recipe 1.
+public sealed partial class TenantId : RequiredString<TenantId>;
+
+public sealed record ArchiveDocumentCommand(DocumentId DocumentId)
+    : ICommand<Result<Unit>>, IAuthorizeResource<TenantDocument>, IIdentifyResource<TenantDocument, DocumentId>
+{
+    public DocumentId GetResourceId() => DocumentId;
+
+    // The per-command scope check. No base class — the rule stays explicit and lives with the
+    // command. Actor.TryGetAttribute<TenantId> parses the "tid" claim through TenantId.TryCreate,
+    // so the gate deny-closes (Forbidden) on a missing, malformed, or mismatched tenant claim.
+    public IResult Authorize(Actor actor, TenantDocument resource) =>
+        actor.TryGetAttribute<TenantId>(ActorAttributes.TenantId, out var tenant) && tenant == resource.TenantId
+            ? Result.Ok()
+            : Result.Fail(new Error.Forbidden(
+                PolicyId: "tenant.isolation",
+                Resource: ResourceRef.For<TenantDocument>(resource.Id)));
+}
+
+// When a handler needs the tenant as a Result to compose with other steps, the Result-returning
+// overload carries the value object forward (or a failed Result whose error field is the key):
+Result<TenantId> tenant = actor.GetRequiredAttribute<TenantId>(ActorAttributes.TenantId);
+```
+
+**What it shows.** `Actor.GetRequiredAttribute<TVo>(key)` and `Actor.TryGetAttribute<TVo>(key, out vo)` parse an actor attribute (an ABAC claim) into a string-backed scalar value object through its own `TryCreate` — the same validation that guards request input now guards claim-sourced values, with no `GetAttribute(...)` + `TryCreate(...)` boilerplate and no magic strings. `TryGetAttribute` is the natural fit for an authorization gate (deny-close on `false`); `GetRequiredAttribute` returns `Result<TVo>` for railway composition in a handler, failing with an `Error.InvalidInput` whose field is the attribute key when the claim is absent or invalid. The value object must be string-backed (a `RequiredString<T>` subclass) — the natural model for a string claim. Wiring is identical to [Recipe 7](#recipe-7--authorization-iactorprovider--iauthorize--resource-based-auth); the tenant check lives in `Authorize(actor, resource)`, which the resource-authorization pipeline runs after the loader produces the resource.
+
+**Why no `TenantScopedCommand` base type.** The variable part of a tenant guard — what "scope" means, which resources are scoped, how the resource exposes its tenant — is domain policy. A reusable base class is either too rigid or needs enough hooks to beat the three explicit lines it replaces, and inheritance hides a security decision. The typed accessor removes the *ceremony* (parsing) while leaving the *policy* (the comparison) visible and per-command.
 
 ## Cross-references
 


### PR DESCRIPTION
## The issue

Every command in a multi-tenant service reads a typed value out of the actor's claims — the tenant id, a scope id — and each call site repeats the same two steps: `actor.GetAttribute("tid")` (a magic-string lookup returning a raw `string?`) followed by a manual `TenantId.TryCreate(...)` to validate and type it. The validation that already guards request input is re-implemented by hand for claim-sourced values, and the raw key is duplicated at every site.

## The fix

`Trellis.Authorization.Actor` gains two generic accessors that parse an attribute into a string-backed scalar value object through the value object's own `TryCreate`:

- **`Result<TVo> GetRequiredAttribute<TVo>(string key)`** — the typed value when the attribute is present and valid, or a failed `Result` carrying the value object's `Error.InvalidInput` (the error's field is `key`; a missing attribute fails the same way). Suited to railway composition in a handler.
- **`bool TryGetAttribute<TVo>(string key, out TVo? value)`** — `true` with the parsed value when present and valid, `false` otherwise. Deny-closes naturally in an authorization gate.

Both constrain `TVo` to `class, IScalarValue<TVo, string>` — a `RequiredString<T>` subclass, the natural model for a string claim. The existing `string? GetAttribute(string)` is unchanged.

A new cookbook recipe demonstrates the primary use: per-command **tenant isolation** — `Authorize(actor, resource)` reads the tenant through `TryGetAttribute<TenantId>` and denies on a missing, malformed, or mismatched claim. It keeps the scope check explicit per command rather than hiding it in a base type, because what "scope" means is domain policy, not configuration.
