### PR TITLE
Add a pull-consumer checkpoint store (IConsumerCheckpointStore)

### DIFF
--- a/Trellis.EntityFrameworkCore.Inbox/NUGET_README.md
+++ b/Trellis.EntityFrameworkCore.Inbox/NUGET_README.md
@@ -46,6 +46,7 @@ The dispatcher deduplicates on `(ConsumerId, MessageId)` so the event's handlers
 - **Store-agnostic seam** — `IInboxStore` is an SPI, so the same idempotency guarantee can be backed by a non-EF store. `EfInboxStore<TContext>` is the shipped implementation.
 - **Stable dedup key** — use the producer's outbox `OutboxMessage.Id` (a UUIDv7) carried verbatim by the transport as the `MessageId`.
 - **Pull-consumer ready** — `DispatchAsync` returns `Processed` vs `SkippedDuplicate`, and `IInboxStore.FilterUnprocessedAsync(consumerId, ids, ct)` returns a window's not-yet-processed ids for the gap-free inbox-as-cursor / anti-join model — no fragile high-water cursor.
+- **Resume cursor (optional)** — `IConsumerCheckpointStore` (`AddTrellisConsumerCheckpointStore<TContext>()` + `AddTrellisConsumerCheckpoints()`) durably remembers a pull consumer's position so it resumes instead of rescanning the whole feed. A performance optimization, not a dedup substitute — pair it with an overlap window and `FilterUnprocessedAsync` for correctness.
 
 ## Delivery & idempotency notes
 - The guarantee covers **local transactional side effects only** — writes through the injected `DbContext`. External calls (emails, downstream APIs) happen outside the transaction and still need their own idempotency (an idempotency key, or push them back out through an outbox).

--- a/Trellis.EntityFrameworkCore.Inbox/README.md
+++ b/Trellis.EntityFrameworkCore.Inbox/README.md
@@ -53,6 +53,7 @@ The dispatcher deduplicates on `(ConsumerId, MessageId)` so the event's handlers
 - **Store-agnostic seam** — `IInboxStore` is an SPI, so the same idempotency guarantee can be backed by a non-EF store. `EfInboxStore<TContext>` is the shipped implementation.
 - **Stable dedup key** — use the producer's outbox `OutboxMessage.Id` (a UUIDv7) carried verbatim by the transport as the `MessageId`.
 - **Pull-consumer ready** — `DispatchAsync` returns `Processed` vs `SkippedDuplicate`, and `IInboxStore.FilterUnprocessedAsync(consumerId, ids, ct)` returns a window's not-yet-processed ids for the gap-free inbox-as-cursor / anti-join model — no fragile high-water cursor.
+- **Resume cursor (optional)** — `IConsumerCheckpointStore` (`AddTrellisConsumerCheckpointStore<TContext>()` + `AddTrellisConsumerCheckpoints()`) durably remembers a pull consumer's position so it resumes instead of rescanning the whole feed. A performance optimization, not a dedup substitute — pair it with an overlap window and `FilterUnprocessedAsync` for correctness.
 
 ## Delivery & idempotency notes
 - The guarantee covers **local transactional side effects only** — writes through the injected `DbContext`. External calls (emails, downstream APIs) happen outside the transaction and still need their own idempotency (an idempotency key, or push them back out through an outbox).

--- a/Trellis.EntityFrameworkCore.Inbox/src/CheckpointRegistrationExtensions.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/CheckpointRegistrationExtensions.cs
@@ -1,0 +1,52 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+/// <summary>
+/// Registers the pull-consumer checkpoint store for a <see cref="DbContext"/>.
+/// </summary>
+public static class CheckpointServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the EF Core <see cref="IConsumerCheckpointStore"/> backed by <typeparamref name="TContext"/>.
+    /// Pair this with
+    /// <see cref="CheckpointModelBuilderExtensions.AddTrellisConsumerCheckpoints(ModelBuilder)"/> in the
+    /// context's <c>OnModelCreating</c>. The store is a durable resume cursor — a performance optimization;
+    /// once-effective processing stays with the inbox anti-join
+    /// (<see cref="IInboxStore.FilterUnprocessedAsync"/>) and dedup row, not the checkpoint.
+    /// </summary>
+    /// <typeparam name="TContext">The consumer's <see cref="DbContext"/> that owns the checkpoint table.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddTrellisConsumerCheckpointStore<TContext>(this IServiceCollection services)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<IConsumerCheckpointStore, EfConsumerCheckpointStore<TContext>>();
+
+        return services;
+    }
+}
+
+/// <summary>
+/// EF Core model hook for the pull-consumer checkpoint table.
+/// </summary>
+public static class CheckpointModelBuilderExtensions
+{
+    /// <summary>
+    /// Maps the <see cref="ConsumerCheckpoint"/> table (<c>TrellisConsumerCheckpoints</c>) onto the model.
+    /// Call from <c>OnModelCreating</c>.
+    /// </summary>
+    /// <param name="modelBuilder">The model builder.</param>
+    /// <returns>The same model builder for chaining.</returns>
+    public static ModelBuilder AddTrellisConsumerCheckpoints(this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+        modelBuilder.ApplyConfiguration(new ConsumerCheckpointConfiguration());
+        return modelBuilder;
+    }
+}

--- a/Trellis.EntityFrameworkCore.Inbox/src/ConsumerCheckpoint.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/ConsumerCheckpoint.cs
@@ -1,0 +1,44 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+/// <summary>
+/// A persisted resume cursor: the last <see cref="Position"/> a pull consumer (<see cref="ConsumerId"/>) has
+/// advanced past in its source feed.
+/// </summary>
+/// <remarks>
+/// Performance state, not a domain aggregate. Losing or resetting it only forces a wider rescan — the inbox
+/// anti-join still guarantees once-effective processing — never incorrect processing.
+/// </remarks>
+public sealed class ConsumerCheckpoint
+{
+    // EF Core materialization constructor.
+    private ConsumerCheckpoint()
+    {
+        ConsumerId = null!;
+        Position = null!;
+    }
+
+    private ConsumerCheckpoint(string consumerId, string position, DateTimeOffset updatedAt)
+    {
+        ConsumerId = consumerId;
+        Position = position;
+        UpdatedAt = updatedAt;
+    }
+
+    /// <summary>The stable subscriber identifier; the primary key.</summary>
+    public string ConsumerId { get; private set; }
+
+    /// <summary>The opaque resume cursor into the source feed (the consumer's own encoding).</summary>
+    public string Position { get; private set; }
+
+    /// <summary>When this checkpoint was last advanced.</summary>
+    public DateTimeOffset UpdatedAt { get; private set; }
+
+    internal static ConsumerCheckpoint Create(string consumerId, string position, DateTimeOffset updatedAt) =>
+        new(consumerId, position, updatedAt);
+
+    internal void Advance(string position, DateTimeOffset updatedAt)
+    {
+        Position = position;
+        UpdatedAt = updatedAt;
+    }
+}

--- a/Trellis.EntityFrameworkCore.Inbox/src/ConsumerCheckpointConfiguration.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/ConsumerCheckpointConfiguration.cs
@@ -1,0 +1,27 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// EF Core mapping for <see cref="ConsumerCheckpoint"/>. Applied to a consumer's model via
+/// <see cref="CheckpointModelBuilderExtensions.AddTrellisConsumerCheckpoints(ModelBuilder)"/>.
+/// </summary>
+public sealed class ConsumerCheckpointConfiguration : IEntityTypeConfiguration<ConsumerCheckpoint>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<ConsumerCheckpoint> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("TrellisConsumerCheckpoints");
+
+        // One row per consumer — the resume cursor is single-valued per subscriber.
+        builder.HasKey(c => c.ConsumerId);
+
+        // Same width as the inbox dedup key so a consumer that uses both keys them consistently.
+        builder.Property(c => c.ConsumerId).HasMaxLength(InboxOptions.MaxConsumerIdLength).IsRequired();
+        builder.Property(c => c.Position).IsRequired();
+        builder.Property(c => c.UpdatedAt).IsRequired();
+    }
+}

--- a/Trellis.EntityFrameworkCore.Inbox/src/ConsumerCheckpointConfiguration.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/ConsumerCheckpointConfiguration.cs
@@ -19,7 +19,7 @@ public sealed class ConsumerCheckpointConfiguration : IEntityTypeConfiguration<C
         // One row per consumer — the resume cursor is single-valued per subscriber.
         builder.HasKey(c => c.ConsumerId);
 
-        // Same width as the inbox dedup key so a consumer that uses both keys them consistently.
+        // Same width as the inbox dedup key, so the same ConsumerId keys both tables consistently.
         builder.Property(c => c.ConsumerId).HasMaxLength(InboxOptions.MaxConsumerIdLength).IsRequired();
         builder.Property(c => c.Position).IsRequired();
         builder.Property(c => c.UpdatedAt).IsRequired();

--- a/Trellis.EntityFrameworkCore.Inbox/src/EfConsumerCheckpointStore.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/EfConsumerCheckpointStore.cs
@@ -1,0 +1,81 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// EF Core <see cref="IConsumerCheckpointStore"/>: reads and writes the resume cursor in its own short unit of
+/// work on a fresh DI scope, so advancing the checkpoint is durable on return and isolated from any work the
+/// caller has staged on its own <typeparamref name="TContext"/>. The checkpoint is performance state, so it is
+/// deliberately decoupled from the caller's correctness transaction rather than enrolled in it (unlike the
+/// inbox dedup row).
+/// </summary>
+/// <typeparam name="TContext">The consumer's <see cref="DbContext"/> that owns the checkpoint table.</typeparam>
+internal sealed class EfConsumerCheckpointStore<TContext> : IConsumerCheckpointStore
+    where TContext : DbContext
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _timeProvider;
+
+    public EfConsumerCheckpointStore(IServiceScopeFactory scopeFactory, TimeProvider timeProvider)
+    {
+        _scopeFactory = scopeFactory;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public async Task<Maybe<string>> GetAsync(string consumerId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerId);
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        var position = await context.Set<ConsumerCheckpoint>()
+            .AsNoTracking()
+            .Where(c => c.ConsumerId == consumerId)
+            .Select(c => c.Position)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return Maybe<string>.From(position);
+    }
+
+    /// <inheritdoc />
+    public async Task SetAsync(string consumerId, string position, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(position);
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var context = scope.ServiceProvider.GetRequiredService<TContext>();
+        var checkpoints = context.Set<ConsumerCheckpoint>();
+
+        var existing = await checkpoints
+            .FirstOrDefaultAsync(c => c.ConsumerId == consumerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            existing.Advance(position, _timeProvider.GetUtcNow());
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        checkpoints.Add(ConsumerCheckpoint.Create(consumerId, position, _timeProvider.GetUtcNow()));
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (DbExceptionClassifier.IsDuplicateKey(ex))
+        {
+            // A concurrent first write inserted the row between our read and save. Re-read the committed row
+            // and advance it so SetAsync resolves to last-writer-wins rather than surfacing the race.
+            context.ChangeTracker.Clear();
+            var winner = await checkpoints
+                .FirstAsync(c => c.ConsumerId == consumerId, cancellationToken)
+                .ConfigureAwait(false);
+            winner.Advance(position, _timeProvider.GetUtcNow());
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/Trellis.EntityFrameworkCore.Inbox/src/EfConsumerCheckpointStore.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/EfConsumerCheckpointStore.cs
@@ -23,10 +23,19 @@ internal sealed class EfConsumerCheckpointStore<TContext> : IConsumerCheckpointS
         _timeProvider = timeProvider;
     }
 
+    private static void ValidateConsumerId(string consumerId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerId);
+        if (consumerId.Length > InboxOptions.MaxConsumerIdLength)
+            throw new ArgumentException(
+                $"consumerId must be at most {InboxOptions.MaxConsumerIdLength} characters; it is stored in a fixed-width key column.",
+                nameof(consumerId));
+    }
+
     /// <inheritdoc />
     public async Task<Maybe<string>> GetAsync(string consumerId, CancellationToken cancellationToken)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(consumerId);
+        ValidateConsumerId(consumerId);
 
         await using var scope = _scopeFactory.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<TContext>();
@@ -43,7 +52,7 @@ internal sealed class EfConsumerCheckpointStore<TContext> : IConsumerCheckpointS
     /// <inheritdoc />
     public async Task SetAsync(string consumerId, string position, CancellationToken cancellationToken)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(consumerId);
+        ValidateConsumerId(consumerId);
         ArgumentException.ThrowIfNullOrWhiteSpace(position);
 
         await using var scope = _scopeFactory.CreateAsyncScope();

--- a/Trellis.EntityFrameworkCore.Inbox/src/IConsumerCheckpointStore.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/src/IConsumerCheckpointStore.cs
@@ -1,0 +1,53 @@
+﻿namespace Trellis.EntityFrameworkCore;
+
+/// <summary>
+/// Store seam for a pull consumer's durable resume cursor — a service-provider interface (SPI) for the
+/// per-<c>ConsumerId</c> position in a source feed, so a consumer resumes where it left off instead of
+/// rescanning the whole log on every poll or restart. The shipped EF Core implementation keeps one row per
+/// consumer; an alternative store (Redis, a key-value table, the broker's own offset API) may replace it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Performance, not correctness.</b> The checkpoint is an optimization that narrows the scan window; it is
+/// NOT the deduplication boundary. A high-water cursor can skip a row that was assigned a low position but
+/// committed late — after the cursor had already advanced past it — which a cursor alone can never recover.
+/// Correctness stays with the inbox anti-join (<see cref="IInboxStore.FilterUnprocessedAsync"/>) plus the
+/// dedup row: scan a window that <i>overlaps</i> the checkpoint (re-read a visibility-lag margin behind it)
+/// and let the anti-join skip whatever is already processed. Advance the checkpoint only to a position whose
+/// predecessors are all known processed.
+/// </para>
+/// <para>
+/// <b>Opaque position.</b> Trellis does not interpret the <c>position</c> — it is whatever cursor the
+/// source feed uses (a sequence number, a UUIDv7 high-water mark, a timestamp, a composite token) serialized
+/// to a string. The store persists and returns it verbatim.
+/// </para>
+/// <para>
+/// <b>Last-writer-wins.</b> The cursor is single-valued per <c>ConsumerId</c>. <see cref="SetAsync"/> is an
+/// upsert that absorbs a concurrent first write — it retries as an update on a duplicate-key race — so
+/// concurrent advancers resolve to last-writer-wins rather than throwing. A shared cursor is still not a
+/// coordination primitive (concurrent advances can lose an update); the typical shape is one logical
+/// advancer per consumer.
+/// </para>
+/// </remarks>
+public interface IConsumerCheckpointStore
+{
+    /// <summary>
+    /// Returns the last persisted resume position for <paramref name="consumerId"/>, or
+    /// <see cref="Maybe{T}.None"/> if the consumer has never checkpointed (start from the beginning of the
+    /// feed).
+    /// </summary>
+    /// <param name="consumerId">The stable subscriber identifier.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The resume cursor, or <see cref="Maybe{T}.None"/> if none has been recorded.</returns>
+    Task<Maybe<string>> GetAsync(string consumerId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Durably records <paramref name="position"/> as the resume cursor for <paramref name="consumerId"/>,
+    /// overwriting any previous value. Call this only once every row at or before <paramref name="position"/>
+    /// (minus the overlap margin) is known processed — see the type remarks.
+    /// </summary>
+    /// <param name="consumerId">The stable subscriber identifier.</param>
+    /// <param name="position">The opaque resume cursor to persist.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task SetAsync(string consumerId, string position, CancellationToken cancellationToken);
+}

--- a/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointSqlServerIntegrationTests.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointSqlServerIntegrationTests.cs
@@ -7,8 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 /// <summary>
 /// SQL Server integration coverage for the pull-consumer checkpoint store. The in-memory SQLite unit tests
-/// cover the read/upsert logic; this exercises the round-trip and the advance-updates-in-place behavior
-/// against a real provider (where the upsert is a separate UPDATE rather than a SQLite in-memory write).
+/// cover the read/upsert logic but serialize on a single connection; this verifies the round-trip against a
+/// real SQL Server and the concurrent first-write duplicate-key race the in-memory tests cannot exercise.
 /// Excluded from default runs — use <c>dotnet test -- --filter-trait "Category=Integration"</c>
 /// (requires SQL Server LocalDB).
 /// </summary>

--- a/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointSqlServerIntegrationTests.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointSqlServerIntegrationTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 /// SQL Server integration coverage for the pull-consumer checkpoint store. The in-memory SQLite unit tests
 /// cover the read/upsert logic; this exercises the round-trip and the advance-updates-in-place behavior
 /// against a real provider (where the upsert is a separate UPDATE rather than a SQLite in-memory write).
-/// Excluded from default runs — use <c>dotnet test --filter-trait "Category=Integration"</c>
+/// Excluded from default runs — use <c>dotnet test -- --filter-trait "Category=Integration"</c>
 /// (requires SQL Server LocalDB).
 /// </summary>
 [Trait("Category", "Integration")]

--- a/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointSqlServerIntegrationTests.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointSqlServerIntegrationTests.cs
@@ -1,0 +1,88 @@
+﻿namespace Trellis.EntityFrameworkCore.Inbox.Tests;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CA1707 // readable xUnit test names
+
+/// <summary>
+/// SQL Server integration coverage for the pull-consumer checkpoint store. The in-memory SQLite unit tests
+/// cover the read/upsert logic; this exercises the round-trip and the advance-updates-in-place behavior
+/// against a real provider (where the upsert is a separate UPDATE rather than a SQLite in-memory write).
+/// Excluded from default runs — use <c>dotnet test --filter-trait "Category=Integration"</c>
+/// (requires SQL Server LocalDB).
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class ConsumerCheckpointSqlServerIntegrationTests : IAsyncLifetime
+{
+    private const string ConnectionString =
+        "Server=(localdb)\\MSSQLLocalDB;Database=TrellisCheckpointIntegrationTests;Trusted_Connection=True;TrustServerCertificate=True";
+
+    private static DbContextOptions<InboxTestDbContext> SchemaOptions() =>
+        new DbContextOptionsBuilder<InboxTestDbContext>().UseSqlServer(ConnectionString).Options;
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var context = new InboxTestDbContext(SchemaOptions());
+        await context.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await using var context = new InboxTestDbContext(SchemaOptions());
+        await context.Database.EnsureDeletedAsync();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task Round_trips_and_advances_the_checkpoint_in_place()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var provider = BuildProvider();
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        (await store.GetAsync("billing", ct)).HasValue.Should().BeFalse("no checkpoint yet");
+
+        await store.SetAsync("billing", "cursor-1", ct);
+        (await store.GetAsync("billing", ct)).GetValueOrDefault("").Should().Be("cursor-1");
+
+        await store.SetAsync("billing", "cursor-2", ct);
+        (await store.GetAsync("billing", ct)).GetValueOrDefault("").Should().Be("cursor-2");
+
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InboxTestDbContext>();
+        (await db.Set<ConsumerCheckpoint>().CountAsync(ct)).Should().Be(1, "the advance updates the single row");
+    }
+
+    [Fact]
+    public async Task Concurrent_first_writes_resolve_to_last_writer_wins_without_throwing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var provider = BuildProvider();
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        // Many parallel first writes for the SAME new consumer — the upsert must absorb the duplicate-key race
+        // (one inserts, the rest retry as updates) rather than throwing.
+        var positions = Enumerable.Range(0, 12).Select(i => $"cursor-{i}").ToList();
+        var write = async () => await Task.WhenAll(positions.Select(p => store.SetAsync("billing", p, ct)));
+
+        await write.Should().NotThrowAsync();
+
+        (await store.GetAsync("billing", ct)).HasValue.Should().BeTrue();
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InboxTestDbContext>();
+        (await db.Set<ConsumerCheckpoint>().CountAsync(ct)).Should().Be(1, "exactly one checkpoint row exists for the consumer");
+    }
+
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<InboxTestDbContext>(o => o.UseSqlServer(ConnectionString));
+        services.AddTrellisConsumerCheckpointStore<InboxTestDbContext>();
+        return services.BuildServiceProvider();
+    }
+}
+
+#pragma warning restore CA1707

--- a/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointTests.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointTests.cs
@@ -1,0 +1,180 @@
+﻿namespace Trellis.EntityFrameworkCore.Inbox.Tests;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+#pragma warning disable CA1707 // readable xUnit test names
+
+public sealed class ConsumerCheckpointTests
+{
+    [Fact]
+    public async Task GetAsync_returns_None_when_the_consumer_has_never_checkpointed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        var position = await store.GetAsync("billing", ct);
+
+        position.HasValue.Should().BeFalse("no checkpoint has been written");
+    }
+
+    [Fact]
+    public async Task SetAsync_then_GetAsync_returns_the_persisted_position()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        await store.SetAsync("billing", "cursor-1", ct);
+
+        (await store.GetAsync("billing", ct)).GetValueOrDefault("").Should().Be("cursor-1");
+    }
+
+    [Fact]
+    public async Task SetAsync_advances_an_existing_checkpoint_without_adding_a_row()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        await store.SetAsync("billing", "cursor-1", ct);
+        await store.SetAsync("billing", "cursor-2", ct);
+
+        (await store.GetAsync("billing", ct)).GetValueOrDefault("").Should().Be("cursor-2", "the latest write wins");
+
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InboxTestDbContext>();
+        (await db.Set<ConsumerCheckpoint>().CountAsync(ct)).Should().Be(1, "advancing updates the single row, not inserts");
+    }
+
+    [Fact]
+    public async Task Checkpoints_are_isolated_per_consumer()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        await store.SetAsync("consumer-a", "a-1", ct);
+
+        (await store.GetAsync("consumer-b", ct)).HasValue.Should().BeFalse("consumer-b has its own cursor");
+        (await store.GetAsync("consumer-a", ct)).GetValueOrDefault("").Should().Be("a-1");
+    }
+
+    [Fact]
+    public async Task SetAsync_persists_durably_so_a_fresh_context_sees_it()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+
+        await provider.GetRequiredService<IConsumerCheckpointStore>().SetAsync("billing", "cursor-1", ct);
+
+        // A different context instance reads the committed row — proving SetAsync saved rather than only staged.
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InboxTestDbContext>();
+        var row = await db.Set<ConsumerCheckpoint>().AsNoTracking().SingleAsync(ct);
+        row.Position.Should().Be("cursor-1");
+        row.UpdatedAt.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task GetAsync_requires_a_consumerId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        var act = async () => await store.GetAsync(" ", ct);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task SetAsync_requires_a_consumerId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        var act = async () => await store.SetAsync(" ", "cursor-1", ct);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task SetAsync_requires_a_position()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+
+        var act = async () => await store.SetAsync("billing", " ", ct);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddTrellisConsumerCheckpointStore_registers_the_store()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<InboxTestDbContext>(o => o.UseSqlite(connection));
+        services.AddTrellisConsumerCheckpointStore<InboxTestDbContext>();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<IConsumerCheckpointStore>().Should().NotBeNull();
+    }
+
+    private static async Task EnsureCreatedAsync(IServiceProvider provider, CancellationToken ct)
+    {
+        await using var scope = provider.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<InboxTestDbContext>();
+        await db.Database.EnsureCreatedAsync(ct);
+    }
+
+    private static ServiceProvider BuildProvider(SqliteConnection connection)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<InboxTestDbContext>(o => o.UseSqlite(connection));
+        services.AddTrellisConsumerCheckpointStore<InboxTestDbContext>();
+        return services.BuildServiceProvider();
+    }
+}
+
+#pragma warning restore CA1707

--- a/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointTests.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/tests/ConsumerCheckpointTests.cs
@@ -147,6 +147,40 @@ public sealed class ConsumerCheckpointTests
     }
 
     [Fact]
+    public async Task GetAsync_rejects_a_consumerId_longer_than_the_key_column()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+        var tooLong = new string('x', InboxOptions.MaxConsumerIdLength + 1);
+
+        var act = async () => await store.GetAsync(tooLong, ct);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage($"*{InboxOptions.MaxConsumerIdLength}*");
+    }
+
+    [Fact]
+    public async Task SetAsync_rejects_a_consumerId_longer_than_the_key_column()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        await using var provider = BuildProvider(connection);
+        await EnsureCreatedAsync(provider, ct);
+        var store = provider.GetRequiredService<IConsumerCheckpointStore>();
+        var tooLong = new string('x', InboxOptions.MaxConsumerIdLength + 1);
+
+        var act = async () => await store.SetAsync(tooLong, "cursor-1", ct);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage($"*{InboxOptions.MaxConsumerIdLength}*");
+    }
+
+    [Fact]
     public void AddTrellisConsumerCheckpointStore_registers_the_store()
     {
         using var connection = new SqliteConnection("DataSource=:memory:");

--- a/Trellis.EntityFrameworkCore.Inbox/tests/InboxTests.cs
+++ b/Trellis.EntityFrameworkCore.Inbox/tests/InboxTests.cs
@@ -388,6 +388,7 @@ internal sealed class InboxTestDbContext(DbContextOptions<InboxTestDbContext> op
             b.HasIndex(l => l.Entry).IsUnique();
         });
         modelBuilder.AddTrellisInbox();
+        modelBuilder.AddTrellisConsumerCheckpoints();
     }
 }
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore-inbox.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore-inbox.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.EntityFrameworkCore.Inbox
 namespaces: [Trellis.EntityFrameworkCore]
-types: [InboxMessage, InboxOptions, IntegrationEnvelope, InboxDispatchOutcome, IInboxStore, IInboxDispatcher, InboxServiceCollectionExtensions, InboxModelBuilderExtensions]
+types: [InboxMessage, InboxOptions, IntegrationEnvelope, InboxDispatchOutcome, IInboxStore, IInboxDispatcher, InboxServiceCollectionExtensions, InboxModelBuilderExtensions, IConsumerCheckpointStore, ConsumerCheckpoint, ConsumerCheckpointConfiguration, CheckpointServiceCollectionExtensions, CheckpointModelBuilderExtensions]
 version: v1
 last_verified: 2026-06-21
 audience: [llm]
@@ -29,6 +29,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#trellis-cross-packag
 | Make a consumer idempotent against redeliveries | `services.AddTrellisInbox<TContext>(o => o.ConsumerId = "...")` or `trellis.UseInbox<TContext>(...)` + `modelBuilder.AddTrellisInbox()` | [Wiring: two required calls](#wiring-two-required-calls), [InboxServiceCollectionExtensions](#inboxservicecollectionextensions) |
 | Hand a received message to the inbox | `IInboxDispatcher.DispatchAsync(envelope, ct)` from your transport adapter — returns `Processed` or `SkippedDuplicate` | [IInboxDispatcher](#iinboxdispatcher), [InboxDispatchOutcome](#inboxdispatchoutcome) |
 | Drive a gap-free pull / anti-join consumer | `IInboxStore.FilterUnprocessedAsync(consumerId, ids, ct)` to skip already-processed feed rows | [IInboxStore](#iinboxstore) |
+| Resume a pull consumer without rescanning the whole feed | `services.AddTrellisConsumerCheckpointStore<TContext>()` + `modelBuilder.AddTrellisConsumerCheckpoints()`; `IConsumerCheckpointStore.GetAsync` / `SetAsync` | [Pull-consumer checkpoint](#pull-consumer-checkpoint-resume-cursor) |
 | Map the deduplication table | `modelBuilder.AddTrellisInbox()` in `OnModelCreating` | [InboxModelBuilderExtensions](#inboxmodelbuilderextensions), [InboxMessage](#inboxmessage) |
 | Identify this subscriber for per-consumer dedup | `InboxOptions.ConsumerId` (required) | [InboxOptions](#inboxoptions) |
 | Supply the same guarantee over a non-EF store | Implement `IInboxStore` | [IInboxStore](#iinboxstore) |
@@ -43,6 +44,7 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#trellis-cross-packag
 - **The guarantee is local-side-effects-only.** The dedup row and the handlers' writes through the injected `TContext` commit in one `SaveChanges`. Effects that are *not* part of that save — sending an email, calling a downstream API, writing through a different `DbContext`/connection — are not covered and need their own idempotency. A handler that writes through a second context escapes the dedup unit of work.
 - **Handlers run before the save and must propagate failures.** Unlike the default `IIntegrationEventPublisher` (which logs and swallows handler exceptions), the inbox dispatcher is non-swallowing: a handler throw aborts the unit of work before anything is saved — no dedup row, no side effects — and propagates so the transport redelivers. Make handlers safe to re-run, and do not call `SaveChanges` inside a handler (it would break the single-save atomicity).
 - **An absent `ConsumerId` fails fast at registration.** `AddTrellisInbox` calls `InboxOptions.Validate()`, which throws `InvalidOperationException` if `ConsumerId` is blank, so the misconfiguration surfaces at startup rather than on the first message.
+- **The checkpoint is not a dedup substitute.** `IConsumerCheckpointStore` is a performance resume cursor, not the correctness boundary — a high-water cursor can skip a row committed out of order. Always pair it with an overlap window **and** `FilterUnprocessedAsync`; never advance it past rows that aren't known processed. See [Pull-consumer checkpoint](#pull-consumer-checkpoint-resume-cursor).
 
 ## How the inbox works
 
@@ -174,6 +176,40 @@ public interface IInboxStore
 `TryRecordAsync` records the message as processed by `consumerId` **inside the caller's current unit of work**, so the dedup record and the handler side effects commit together. Returns `true` if newly recorded, or `false` if the `(ConsumerId, MessageId)` pair was already processed — a duplicate the dispatcher skips. `EfInboxStore` does an existence check for the fast path and stages an `InboxMessage` for the slow path; the composite primary key is the authoritative guard under concurrency.
 
 `FilterUnprocessedAsync` returns the subset of `messageIds` that `consumerId` has **not** yet processed (those without a dedup row), preserving the input order. It powers the gap-free **inbox-as-cursor / anti-join** pull model: read a window of the source feed and dispatch every row whose `MessageId` this query returns, rather than tracking a fragile high-water cursor that can skip a row committed out of sequence order. It is an optimization, not the correctness boundary — a row may be processed by another worker between this query and `DispatchAsync`, which still deduplicates — and it is a pure read that stages nothing. `EfInboxStore` runs it as a single anti-join query (`AsNoTracking`); it throws `ArgumentException` if `consumerId` is blank.
+
+## Pull-consumer checkpoint (resume cursor)
+
+`IConsumerCheckpointStore` is an optional, durable **resume cursor** for a pull consumer — it remembers per-`ConsumerId` where in the source feed the consumer last advanced to, so it resumes there instead of rescanning the whole log on every poll or restart.
+
+```csharp
+public interface IConsumerCheckpointStore
+{
+    Task<Maybe<string>> GetAsync(string consumerId, CancellationToken cancellationToken);
+    Task SetAsync(string consumerId, string position, CancellationToken cancellationToken);
+}
+```
+
+**Performance, not correctness.** The checkpoint narrows the scan window; it is **not** the deduplication boundary. A high-water cursor can skip a row that was assigned a low position but committed *late* — after the cursor advanced past it — which a cursor alone can never recover. Correctness stays with `FilterUnprocessedAsync` (the anti-join) plus the dedup row. The safe pattern:
+
+1. `GetAsync(consumerId)` → the resume position (`Maybe.None` the first time → start from the feed's beginning).
+2. Scan a window that **overlaps** the checkpoint — re-read a visibility-lag margin *behind* it, so a late-committed row is still inside the window.
+3. `FilterUnprocessedAsync(consumerId, window.Ids, ct)` → the not-yet-processed ids; `DispatchAsync` each.
+4. `SetAsync(consumerId, position)` → advance the cursor, only to a position whose predecessors are all known processed.
+
+```csharp
+var resume = await checkpoints.GetAsync(consumerId, ct);              // Maybe<string>
+var since = resume.GetValueOrDefault(FeedStart);
+var window = await feed.ReadFrom(Rewind(since, overlapMargin), ct);   // overlap behind the checkpoint
+var todo = await inbox.FilterUnprocessedAsync(consumerId, window.Ids, ct);
+foreach (var id in todo)
+    await dispatcher.DispatchAsync(window.Envelope(id), ct);
+await checkpoints.SetAsync(consumerId, window.HighWaterMark, ct);     // advance the cursor
+```
+
+- **Opaque `position`.** Trellis does not interpret it — encode whatever cursor the feed uses (a sequence number, a UUIDv7 high-water mark, a timestamp, a composite token) as a string. The store round-trips it verbatim.
+- **Wiring (two calls).** `services.AddTrellisConsumerCheckpointStore<TContext>()` registers the store; `modelBuilder.AddTrellisConsumerCheckpoints()` maps the `TrellisConsumerCheckpoints` table (PK `ConsumerId`, width matching the inbox key). It is a **leaf store** — no `TrellisServiceBuilder` slot, like `AddInMemoryIdempotencyStore`.
+- **Durable + isolated.** `EfConsumerCheckpointStore<TContext>` reads and upserts on its own fresh DI scope and `SaveChanges`, so an advance is persisted on return and never entangles the caller's unit of work. One logical advancer per `ConsumerId` is assumed (the usual pull-consumer shape); the cursor is not a coordination primitive.
+- `GetAsync` / `SetAsync` throw `ArgumentException` for a blank `consumerId`; `SetAsync` also for a blank `position`.
 
 ## IntegrationEnvelope
 

--- a/docs/docfx_project/articles/integration-inbox.md
+++ b/docs/docfx_project/articles/integration-inbox.md
@@ -198,6 +198,21 @@ foreach (var row in window.Where(r => todo.Contains(r.MessageId)))
 
 `FilterUnprocessedAsync` is an optimization, not the correctness boundary — between the query and `DispatchAsync` another worker may process a row, and `DispatchAsync` still deduplicates it (returning `SkippedDuplicate`). Correctness always lives in the committed dedup row; the filter just keeps you from invoking handlers for messages you can already see are done.
 
+### Optional: a resume checkpoint
+
+The anti-join keeps a scanned window gap-free, but on each poll you still choose where the window starts — and rescanning a large feed from the beginning every time is wasteful. `IConsumerCheckpointStore` is an optional, durable resume cursor — `GetAsync(consumerId)` / `SetAsync(consumerId, position)` — that remembers where you advanced to. Register it with `services.AddTrellisConsumerCheckpointStore<TContext>()` plus `modelBuilder.AddTrellisConsumerCheckpoints()`.
+
+```csharp
+var since = (await checkpoints.GetAsync(consumerId, ct)).GetValueOrDefault(FeedStart);
+var window = await feed.ReadFrom(Rewind(since, overlapMargin), ct);   // overlap BEHIND the checkpoint
+var todo = (await store.FilterUnprocessedAsync(consumerId, window.Ids, ct)).ToHashSet();
+foreach (var msg in window.Where(m => todo.Contains(m.Id)))
+    await dispatcher.DispatchAsync(msg.Envelope, ct);
+await checkpoints.SetAsync(consumerId, window.HighWaterMark, ct);     // advance the cursor
+```
+
+The checkpoint is **performance, not correctness** — it is the *same* kind of cursor the anti-join frees you from depending on for gap-freedom. A high-water cursor can skip a row assigned a low position but committed late, so always scan a window that **overlaps** the checkpoint (rewind a visibility-lag margin) and let `FilterUnprocessedAsync` + the dedup row provide once-effective processing. Used that way the checkpoint can only widen or narrow a rescan, never skip a row. The `position` is opaque — encode whatever cursor your feed uses (a sequence number, a UUIDv7 high-water mark, a timestamp) as a string.
+
 ## Operating the inbox
 
 - **Prune old rows.** `TrellisInboxMessages` grows by one row per processed message per consumer. Once a row is older than the transport's maximum redelivery window it can never be hit by a redelivery, so a periodic job can delete rows whose `ProcessedAt` is older than that window (the column is indexed for exactly this). Delete too eagerly and a late redelivery would reprocess.


### PR DESCRIPTION
## The problem

A pull consumer that scans a source feed (rather than receiving pushed messages) needs durable per-consumer resume state, so on each poll or restart it resumes where it left off instead of rescanning the whole log. The inbox's anti-join (`FilterUnprocessedAsync`) makes a scanned window gap-free, but there was no store for the cursor itself.

## The fix

Add `IConsumerCheckpointStore` - an opaque, durable per-`ConsumerId` resume cursor - with an EF Core default:

- `GetAsync(consumerId)` returns `Maybe<string>` (the resume position, or `None` the first time); `SetAsync(consumerId, position)` records it. The `position` is opaque - the consumer encodes whatever cursor its feed uses (a sequence number, a UUIDv7 high-water mark, a timestamp) as a string.
- `ConsumerCheckpoint` maps to table `TrellisConsumerCheckpoints` (PK `ConsumerId`), wired with `services.AddTrellisConsumerCheckpointStore<TContext>()` + `modelBuilder.AddTrellisConsumerCheckpoints()`. It is a leaf store, so (like `AddInMemoryIdempotencyStore`) it has no `TrellisServiceBuilder` slot.
- `EfConsumerCheckpointStore<TContext>` reads and upserts on its own fresh DI scope and `SaveChanges`, so an advance is durable on return and isolated from the caller's unit of work. A concurrent first write is absorbed as last-writer-wins (retry-as-update on a duplicate-key race).

**Performance, not correctness.** The checkpoint narrows the scan window; it is not the dedup boundary. A high-water cursor can skip a row assigned a low position but committed late, so correctness stays with the inbox anti-join + dedup row. The consumer scans a window that overlaps the checkpoint (rewinds a visibility-lag margin) and lets the anti-join skip processed rows; the checkpoint can only widen or narrow a rescan, never cause a row to be skipped. The XML docs and the API reference make this unmistakable.

Lives in `Trellis.EntityFrameworkCore.Inbox`, alongside the pull-consumer anti-join it pairs with.