### PR TITLE
Document the Trellis.Unit / Mediator.Unit global-using alias

### DIFF
--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -43,6 +43,7 @@ Conventions used throughout:
 - `Result.Ok` / `Result.Fail` are *the* construction APIs. `default(Result<T>)` is a typed failure; do not rely on it as success.
 - Every async pipeline uses `*Async` extensions; mixing sync chain methods with `Task<Result<T>>` triggers `TRLS009`.
 - Examples reference an `OrderId : RequiredGuid<OrderId>` value object and an `Order` aggregate. Substitute your own types without changing the structure.
+- A command without a payload returns `Result<Trellis.Unit>` — qualified because a file that imports both `Trellis` and `Mediator` has two `Unit` types in scope (`Trellis.Unit` and `Mediator.Unit`). Add `global using TrellisUnit = Trellis.Unit;` (or `global using Unit = Trellis.Unit;`, since Trellis code never references `Mediator.Unit`) to your `GlobalUsings.cs` to drop the qualification.
 
 ## LLM preflight: load the smallest correct reference set
 

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -104,7 +104,16 @@ public sealed class PublishDocumentHandler : ICommandHandler<PublishDocumentComm
 ```
 
 > [!IMPORTANT]
-> Pass `opts => opts.ServiceLifetime = ServiceLifetime.Scoped`. The Trellis behaviors depend on per-request services (`IActorProvider`, `IUnitOfWork`, `IMessageValidator<>` adapters). Mediator's default lifetime is `Singleton`, which fails ASP.NET's root-scope validation as soon as a behavior tries to resolve a scoped dependency.
+> Pass `opts => opts.ServiceLifetime = ServiceLifetime.Scoped`. The Trellis behaviors depend on per-request services (`IActorProvider`, `IUnitOfWork`, `IMessageValidator<>` adapters). Mediator's default lifetime is `Singleton`, which fails ASP.NET's root-scope validation as soon as a behavior tries to resolve a scoped dependency. `AddTrellisBehaviors()` fails fast with an actionable message if it sees a `Singleton` Mediator.
+
+> [!NOTE]
+> A file that imports both the `Trellis` and `Mediator` namespaces has two `Unit` types in scope — `Trellis.Unit` (the success-without-payload value a command returns) and `Mediator.Unit` — so a bare `Result<Unit>` is *ambiguous*. The examples here abbreviate it; in real code either qualify it as `Result<Trellis.Unit>` (what the compiled samples do) or add a one-line alias to your `GlobalUsings.cs` so the short form keeps working:
+>
+> ```csharp
+> global using TrellisUnit = Trellis.Unit;   // then write Result<TrellisUnit>
+> // or, since Trellis consumers never reference Mediator.Unit directly:
+> global using Unit = Trellis.Unit;           // then write Result<Unit>
+> ```
 
 ## Pipeline order
 


### PR DESCRIPTION
## Issue

A file that imports both the `Trellis` and `Mediator` namespaces has two `Unit` types in scope — `Trellis.Unit` (the success-without-payload value a command returns) and `Mediator.Unit` — so a bare `Result<Unit>` is ambiguous and does not compile. The docs use the short form without explaining how to make it resolve.

## Fix

Document the collision and its mitigation:

- **Mediator integration article** — a `NOTE` showing the two ways to resolve the ambiguity: qualify as `Result<Trellis.Unit>`, or add a one-line global-using alias to `GlobalUsings.cs` (`global using TrellisUnit = Trellis.Unit;`, or `global using Unit = Trellis.Unit;` since Trellis consumers never reference `Mediator.Unit`). The same callout now also notes that `AddTrellisBehaviors()` fails fast on a `Singleton` Mediator registration.
- **Cookbook conventions** — a matching bullet explaining why payload-free commands are written `Result<Trellis.Unit>` and how the alias removes the qualification.

Docs-only; no framework surface change.
