### PR TITLE
Remove RequiredEnum.TryFromName in favor of TryCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed — `RequiredEnum<TSelf>.TryFromName` (use `TryCreate`)
+
+`RequiredEnum<TSelf>.TryFromName(...)` has been removed. An enum's creation is a uniform symbolic
+lookup, so `TryCreate` now lives on the `RequiredEnum<TSelf>` base (it is no longer generated per
+type), and an enum value object's public creation surface is identical to `RequiredString` /
+`RequiredInt` / etc. Direct callers of `SomeEnum.TryFromName(name)` switch to `SomeEnum.TryCreate(name)`
+— same signature, same `Result<TSelf>`, same case-insensitive lookup and error message. The JSON
+converter, EF Core converter, and `Parse` / `TryParse` already route through `TryCreate`.
+
 ### Added — Mediator lifetime guardrail for the authorization pipeline
 
 `AddTrellisBehaviors()` now fails fast with a clear `InvalidOperationException` when the Mediator (`IMediator` or

--- a/Trellis.Analyzers/tests/AnalyzerTestHelper.cs
+++ b/Trellis.Analyzers/tests/AnalyzerTestHelper.cs
@@ -90,7 +90,7 @@ public static class AnalyzerTestHelper
             {
                 public string Value => string.Empty;
 
-                public static Result<TSelf> TryFromName(string? name, string? fieldName = null) => default;
+                public static Result<TSelf> TryCreate(string? value, string? fieldName = null) => default;
             }
 
             // IScalarValue interface stub

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -44,7 +44,7 @@ using Trellis.PrimitiveValueObjectGenerator;
 /// <item><c>RequiredBool</c> — accepts true/false; rejects null</item>
 /// <item><c>RequiredDateTime</c> — rejects <c>DateTime.MinValue</c> only when <c>[NotDefault]</c> is applied; ISO 8601 round-trip <c>ToString</c></item>
 /// <item><c>RequiredDateTimeOffset</c> — rejects <c>DateTimeOffset.MinValue</c> only when <c>[NotDefault]</c> is applied; ISO 8601 round-trip <c>ToString</c></item>
-/// <item><c>RequiredEnum</c> — smart enum; delegates to <c>TryFromName</c></item>
+/// <item><c>RequiredEnum</c> — smart enum; <c>TryCreate</c> is inherited from the base, only <c>Parse</c>/<c>TryParse</c>/<c>Create</c> are generated</item>
 /// </list>
 /// </para>
 /// <para>
@@ -605,30 +605,6 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
     [JsonConverter(typeof(RequiredEnumJsonConverter<{g.ClassName}>))]
     {g.Accessibility} partial class {g.ClassName} : IScalarValue<{g.ClassName}, string>, IParsable<{g.ClassName}>
     {{{privateConstructor}
-        /// <summary>
-        /// Creates a validated instance from a string by looking up the enum member by symbolic value.
-        /// Required by IScalarValue interface for model binding and JSON deserialization.
-        /// </summary>
-        /// <param name=""value"">The symbolic value to look up.</param>
-        /// <returns>Success with the enum member, or Failure with validation errors.</returns>
-        public static Result<{g.ClassName}> TryCreate(string value)
-        {{
-            using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            return TryFromName(value, null);
-        }}
-
-        /// <summary>
-        /// Creates a validated instance from a string by looking up the enum member by symbolic value.
-        /// </summary>
-        /// <param name=""value"">The symbolic value to look up.</param>
-        /// <param name=""fieldName"">Optional field name for validation error messages.</param>
-        /// <returns>Success with the enum member, or Failure with validation errors.</returns>
-        public static Result<{g.ClassName}> TryCreate(string? value, string? fieldName = null)
-        {{
-            using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
-            return TryFromName(value, fieldName);
-        }}
-
         /// <summary>
         /// Parses the input into a <see cref=""{g.ClassName}""/> by symbolic name lookup,
         /// or throws <see cref=""FormatException""/> when no member matches.

--- a/Trellis.Core/generator/RequiredPartialClassInfo.cs
+++ b/Trellis.Core/generator/RequiredPartialClassInfo.cs
@@ -124,7 +124,7 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     /// <item><c>RequiredString</c>: Generates TryCreate(string?)</item>
     /// <item><c>RequiredInt</c>: Generates TryCreate(int?), TryParse(string?)</item>
     /// <item><c>RequiredDecimal</c>: Generates TryCreate(decimal?), TryParse(string?)</item>
-    /// <item><c>RequiredEnum</c>: Generates TryCreate(string?) delegating to TryFromName()</item>
+    /// <item><c>RequiredEnum</c>: Generates Parse/TryParse/Create; TryCreate is inherited from the base</item>
     /// </list>
     /// </remarks>
     public readonly string ClassBase;

--- a/Trellis.Core/src/Primitives/RequiredEnum.cs
+++ b/Trellis.Core/src/Primitives/RequiredEnum.cs
@@ -197,24 +197,38 @@ public abstract class RequiredEnum<[DynamicallyAccessedMembers(DynamicallyAccess
     public static IReadOnlyCollection<TSelf> GetAll() => GetCache().Members;
 
     /// <summary>
-    /// Attempts to find a member by its symbolic value (case-insensitive).
+    /// Creates a validated member from its symbolic value (case-insensitive). This is the public
+    /// factory every <c>Required*</c> primitive exposes; the JSON converter, EF converter, and
+    /// <c>Parse</c>/<c>TryParse</c> all route through it. Provided by the base because an enum's
+    /// creation is a uniform name lookup, so — unlike the scalar primitives — it needs no
+    /// per-derived-type generation.
     /// </summary>
-    /// <param name="name">The symbolic value to search for.</param>
+    /// <param name="value">The symbolic value to look up.</param>
+    /// <returns>A <see cref="Result{TSelf}"/> containing the matching member or a validation error.</returns>
+    public static Result<TSelf> TryCreate(string value) => TryCreate(value, null);
+
+    /// <summary>
+    /// Creates a validated member from its symbolic value (case-insensitive), reporting validation
+    /// failures against <paramref name="fieldName"/>.
+    /// </summary>
+    /// <param name="value">The symbolic value to look up.</param>
     /// <param name="fieldName">Optional field name for validation error messages.</param>
     /// <returns>A <see cref="Result{TSelf}"/> containing the matching member or a validation error.</returns>
-    public static Result<TSelf> TryFromName(string? name, string? fieldName = null)
+    public static Result<TSelf> TryCreate(string? value, string? fieldName = null)
     {
+        using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity($"{typeof(TSelf).Name}.TryCreate");
+
         var field = NormalizeFieldName(fieldName, typeof(TSelf).Name);
 
-        if (string.IsNullOrWhiteSpace(name))
+        if (string.IsNullOrWhiteSpace(value))
             return Result.Fail<TSelf>(Error.InvalidInput.ForField(field, "validation.error", $"{typeof(TSelf).Name} cannot be empty."));
 
         var cache = GetCache();
-        if (cache.ByName.TryGetValue(name, out var member))
+        if (cache.ByName.TryGetValue(value, out var member))
             return Result.Ok(member);
 
         var validNames = string.Join(", ", cache.ByName.Keys.OrderBy(n => n));
-        return Result.Fail<TSelf>(Error.InvalidInput.ForField(field, "validation.error", $"'{name}' is not a valid {typeof(TSelf).Name}. Valid values: {validNames}"));
+        return Result.Fail<TSelf>(Error.InvalidInput.ForField(field, "validation.error", $"'{value}' is not a valid {typeof(TSelf).Name}. Valid values: {validNames}"));
     }
 
     /// <summary>

--- a/Trellis.Core/src/Primitives/RequiredEnum.cs
+++ b/Trellis.Core/src/Primitives/RequiredEnum.cs
@@ -227,7 +227,7 @@ public abstract class RequiredEnum<[DynamicallyAccessedMembers(DynamicallyAccess
         if (cache.ByName.TryGetValue(value, out var member))
             return Result.Ok(member);
 
-        var validNames = string.Join(", ", cache.ByName.Keys.OrderBy(n => n));
+        var validNames = string.Join(", ", cache.ByName.Keys.OrderBy(n => n, StringComparer.Ordinal));
         return Result.Fail<TSelf>(Error.InvalidInput.ForField(field, "validation.error", $"'{value}' is not a valid {typeof(TSelf).Name}. Valid values: {validNames}"));
     }
 

--- a/Trellis.Core/src/Primitives/RequiredEnumJsonConverter.cs
+++ b/Trellis.Core/src/Primitives/RequiredEnumJsonConverter.cs
@@ -60,7 +60,7 @@ public sealed class RequiredEnumJsonConverter<[DynamicallyAccessedMembers(Dynami
     private static TRequiredEnum ReadFromString(ref Utf8JsonReader reader)
     {
         var name = reader.GetString();
-        return RequiredEnum<TRequiredEnum>.TryFromName(name).Match(
+        return TRequiredEnum.TryCreate(name).Match(
             onSuccess: value => value,
             onFailure: _ =>
             {

--- a/Trellis.Core/tests/Primitives/RequiredEnumJsonConverterTests.cs
+++ b/Trellis.Core/tests/Primitives/RequiredEnumJsonConverterTests.cs
@@ -78,7 +78,4 @@ public sealed class RequiredEnumJsonConverterTestState :
 {
     public static readonly RequiredEnumJsonConverterTestState Active = new();
     public static readonly RequiredEnumJsonConverterTestState Archived = new();
-
-    public static Result<RequiredEnumJsonConverterTestState> TryCreate(string? value, string? fieldName = null) =>
-        TryFromName(value, fieldName);
 }

--- a/Trellis.EntityFrameworkCore/src/TrellisScalarConverter.cs
+++ b/Trellis.EntityFrameworkCore/src/TrellisScalarConverter.cs
@@ -19,9 +19,9 @@ public class TrellisScalarConverter<TModel, TProvider> : ValueConverter<TModel, 
 {
     private static readonly TrellisValueObjectInfo s_valueObject = ResolveValueObject();
     private static readonly Func<TProvider, Result<TModel>>? s_tryCreate =
-        s_valueObject.Category == TrellisValueObjectCategory.Scalar ? BuildTryCreateDelegate() : null;
-    private static readonly Func<string, Result<TModel>>? s_tryFromName =
-        s_valueObject.Category == TrellisValueObjectCategory.Symbolic ? BuildTryFromNameDelegate() : null;
+        s_valueObject.Category is TrellisValueObjectCategory.Scalar or TrellisValueObjectCategory.Symbolic
+            ? BuildTryCreateDelegate()
+            : null;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TrellisScalarConverter{TModel, TProvider}"/> class.
@@ -149,20 +149,6 @@ public class TrellisScalarConverter<TModel, TProvider> : ValueConverter<TModel, 
         return Expression.Lambda<Func<TProvider, Result<TModel>>>(body, param).Compile();
     }
 
-    private static Func<string, Result<TModel>> BuildTryFromNameDelegate()
-    {
-        var param = Expression.Parameter(typeof(string), "v");
-        var tryFromNameMethod = typeof(TModel).GetMethod(
-                "TryFromName",
-                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy,
-                [typeof(string), typeof(string)])
-            ?? throw new InvalidOperationException(
-                $"{typeof(TModel).Name} must have a static TryFromName(string, string?) method.");
-
-        var body = Expression.Call(tryFromNameMethod, param, Expression.Constant(null, typeof(string)));
-        return Expression.Lambda<Func<string, Result<TModel>>>(body, param).Compile();
-    }
-
     private static TModel MaterializeScalar(TProvider value)
     {
         try
@@ -193,11 +179,11 @@ public class TrellisScalarConverter<TModel, TProvider> : ValueConverter<TModel, 
                 throw new TrellisPersistenceMappingException(
                     typeof(TModel),
                     null,
-                    "TryFromName",
+                    "TryCreate",
                     "Received null from database for non-nullable symbolic value object.");
 
-            var result = s_tryFromName!((string)(object)value);
-            return MaterializeResult(result, value, "TryFromName");
+            var result = s_tryCreate!(value);
+            return MaterializeResult(result, value, "TryCreate");
         }
         catch (TrellisPersistenceMappingException)
         {
@@ -208,7 +194,7 @@ public class TrellisScalarConverter<TModel, TProvider> : ValueConverter<TModel, 
             throw new TrellisPersistenceMappingException(
                 typeof(TModel),
                 value,
-                "TryFromName",
+                "TryCreate",
                 "The factory threw an exception before returning a validation result.",
                 ex);
         }

--- a/Trellis.EntityFrameworkCore/tests/ApplyTrellisConventionsTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/ApplyTrellisConventionsTests.cs
@@ -158,7 +158,7 @@ public class ApplyTrellisConventionsTests : IDisposable
         var ex = await act.Should().ThrowAsync<TrellisPersistenceMappingException>();
         ex.Which.Message.Should().Contain("TestOrderStatus");
         ex.Which.Message.Should().Contain("NotAStatus");
-        ex.Which.Message.Should().Contain("TryFromName");
+        ex.Which.Message.Should().Contain("TryCreate");
         ex.Which.Message.Should().Contain("Valid values");
     }
 
@@ -175,7 +175,7 @@ public class ApplyTrellisConventionsTests : IDisposable
         // Assert
         var ex = act.Should().Throw<TrellisPersistenceMappingException>();
         ex.Which.Message.Should().Contain("TestOrderStatus");
-        ex.Which.Message.Should().Contain("TryFromName");
+        ex.Which.Message.Should().Contain("TryCreate");
         ex.Which.Message.Should().Contain("null");
     }
 

--- a/Trellis.EntityFrameworkCore/tests/MaybePropertyTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/MaybePropertyTests.cs
@@ -592,7 +592,7 @@ public class MaybePropertyTests : IDisposable
         var ex = await act.Should().ThrowAsync<TrellisPersistenceMappingException>();
         ex.Which.Message.Should().Contain("TestOrderStatus");
         ex.Which.Message.Should().Contain("NotAStatus");
-        ex.Which.Message.Should().Contain("TryFromName");
+        ex.Which.Message.Should().Contain("TryCreate");
     }
 
     #endregion

--- a/Trellis.Primitives/tests/RequiredEnumTests.cs
+++ b/Trellis.Primitives/tests/RequiredEnumTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Trellis.Primitives.Tests;
 
+using System.Reflection;
 using System.Text.Json;
 using Trellis;
 using Trellis.Testing;
@@ -629,6 +630,29 @@ public class RequiredEnumTests
     public void RequiredEnum_WithParameterizedConstructor_ExposesNoPublicConstructor() =>
         typeof(TestPaymentMethod).GetConstructors()
             .Should().BeEmpty("a behavior enum's own constructor must be non-public so non-member instances cannot be created");
+
+    #endregion
+
+    #region Public Surface Tests
+
+    [Fact]
+    public void RequiredEnum_DoesNotDeclareTryFromName_AtAnyVisibility() =>
+        typeof(TestOrderState)
+            .GetMethod("TryFromName", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Should().BeNull("TryFromName was removed entirely; TryCreate is the factory, matching the other Required* primitives");
+
+    [Fact]
+    public void RequiredEnum_InheritsPublicTryCreate_FromBase()
+    {
+        var tryCreate = typeof(TestOrderState).GetMethod(
+            "TryCreate",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy,
+            [typeof(string), typeof(string)]);
+
+        tryCreate.Should().NotBeNull();
+        tryCreate!.DeclaringType.Should().Be<RequiredEnum<TestOrderState>>(
+            "TryCreate is provided by the RequiredEnum base, not generated per-type");
+    }
 
     #endregion
 }

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -3116,7 +3116,7 @@ public sealed class DapperOrderRepository(IDbConnection db) : IOrderRepository
         var order = Order.Reconstitute(
             OrderId.TryCreate(row.Id).GetValueOrThrow($"Corrupt Order.Id in row {row.Id}"),
             CustomerId.TryCreate(row.CustomerId).GetValueOrThrow($"Corrupt Order.CustomerId in row {row.Id}"),
-            OrderStatus.TryFromName(row.Status).GetValueOrThrow($"Corrupt Order.Status in row {row.Id}"),
+            OrderStatus.TryCreate(row.Status).GetValueOrThrow($"Corrupt Order.Status in row {row.Id}"),
             lines);
 
         // Restore the infrastructure metadata loaded from the row. A store-native quoted token (e.g. a

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1840,7 +1840,7 @@ Every `Required*<TSelf>` base is **lenient by default**. The generated `TryCreat
 | `RequiredLong<TSelf>` | `null` only (accepts `0L`) | `[NotDefault]` rejects `0L` |
 | `RequiredDecimal<TSelf>` | `null` only (accepts `0m`) | `[NotDefault]` rejects `0m` |
 | `RequiredBool<TSelf>` | `null` | (no sentinel — `false` remains valid) |
-| `RequiredEnum<TSelf>` | `null`, undeclared member names | (smart-enum lookup via `TryFromName`) |
+| `RequiredEnum<TSelf>` | `null`, undeclared member names | (smart-enum lookup via `TryCreate`) |
 
 `RequiredString<TSelf>` validation order: `null` check → trim (only if `[Trim]` present) → empty check (only if `[NotDefault]` present) → `[StringLength]` → `ValidateAdditional`. `[Trim]` without `[NotDefault]` trims the value before storage but does not reject `""` or whitespace-only input. Combine `[Trim, NotDefault]` for trim-then-reject-empty behavior.
 
@@ -1992,7 +1992,7 @@ public sealed class RequiredEnumJsonConverter<[DynamicallyAccessedMembers(Dynami
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public override bool HandleNull` | `bool` | `true`; routes JSON `null` tokens through the converter so required enums can reject them explicitly. |
-| `public override TRequiredEnum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)` | `TRequiredEnum?` | Accepts only JSON `string`; string values are resolved through `RequiredEnum<TRequiredEnum>.TryFromName(name)`, and `null` throws `JsonException`. |
+| `public override TRequiredEnum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)` | `TRequiredEnum?` | Accepts only JSON `string`; string values are resolved through `TRequiredEnum.TryCreate(name)`, and `null` throws `JsonException`. |
 | `public override void Write(Utf8JsonWriter writer, TRequiredEnum value, JsonSerializerOptions options)` | `void` | Writes `value.Value` as a JSON string. |
 
 ### `RequiredString<TSelf>`
@@ -2141,7 +2141,6 @@ public abstract class RequiredEnum<[DynamicallyAccessedMembers(DynamicallyAccess
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public static IReadOnlyCollection<TSelf> GetAll()` | `IReadOnlyCollection<TSelf>` | Returns all discovered public static readonly members. |
-| `public static Result<TSelf> TryFromName(string? name, string? fieldName = null)` | `Result<TSelf>` | Case-insensitive symbolic lookup. |
 | `public bool Is(params TSelf[] values)` | `bool` | True when this instance matches any provided member. |
 | `public bool IsNot(params TSelf[] values)` | `bool` | Negation of `Is(params TSelf[])`. |
 | `public override string ToString()` | `string` | Returns `Value`. |
@@ -2344,8 +2343,8 @@ public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? prov
 public static TSelf Create(string value)
 ```
 
-- Generated `TryCreate` delegates only to `TryFromName`.
-- The enum JSON converter also uses only `TryFromName`; there is no `TryFromValue` path.
+- `TryCreate(string)` / `TryCreate(string?, string?)` are inherited from the `RequiredEnum<TSelf>` base — an enum's creation is a uniform symbolic lookup, so it is not generated per type. `Create`, `Parse`, and `TryParse` are generated and route through `TryCreate`.
+- The enum JSON converter resolves through `TryCreate`; there is no `TryFromValue` or `TryFromName` API.
 
 ### Building your own primitive
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -467,7 +467,7 @@ where TModel : class
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public TrellisScalarConverter()` | — | Builds expressions that persist `Value` and materialize via `TryCreate` or `TryFromName`; invalid persisted data throws `TrellisPersistenceMappingException`. |
+| `public TrellisScalarConverter()` | — | Builds expressions that persist `Value` and materialize via `TryCreate`; invalid persisted data throws `TrellisPersistenceMappingException`. |
 
 ### `OwnedEntityAttribute`
 

--- a/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
+++ b/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
@@ -93,7 +93,7 @@ Single-`DateTimeOffset` value object; prefer over `RequiredDateTime<TSelf>` when
 
 ### `RequiredEnum<TSelf>`
 
-**Symbolic** smart-enum that replaces a C# `enum`; members are `public static readonly` singletons. Identity is the string `Value` (equality is case-insensitive); ordering (`IComparable`) is by `Ordinal` = **declaration order**, like the underlying enum it replaces. String-backed in JSON and EF Core. Use `GetAll()` / `TryFromName(...)` for lookup and `[EnumValue("...")]` to override a member's external name. Stands apart from `ScalarValueObject<TSelf, T>`.
+**Symbolic** smart-enum that replaces a C# `enum`; members are `public static readonly` singletons. Identity is the string `Value` (equality is case-insensitive); ordering (`IComparable`) is by `Ordinal` = **declaration order**, like the underlying enum it replaces. String-backed in JSON and EF Core. Use `GetAll()` / `TryCreate(...)` for lookup and `[EnumValue("...")]` to override a member's external name. Stands apart from `ScalarValueObject<TSelf, T>`.
 
 ### `MonetaryAmount`
 
@@ -142,7 +142,7 @@ Concrete **structured** value object (`Amount` + `Currency`) for multi-currency;
 
 ## Source-generated members
 
-For a `partial` `Required*<TSelf>` type the primitive generator emits the `IScalarValue<TSelf, T>` implementation, the `TryCreate` primitive and string factories (plus a culture-aware `IFormatProvider` overload for the numeric and date/time families), `Create`, `Parse` / `TryParse`, an explicit cast operator, and a `ValidateAdditional(...)` extension hook. `RequiredGuid<TSelf>` additionally gets `NewUniqueV4()` / `NewUniqueV7()`; `RequiredEnum<TSelf>` creation routes through `TryFromName`. See the per-type generated-member entries in [trellis-api-core.md](trellis-api-core.md#primitive-value-object-base-classes) for the exact emitted signatures.
+For a `partial` `Required*<TSelf>` type the primitive generator emits the `IScalarValue<TSelf, T>` implementation, the `TryCreate` primitive and string factories (plus a culture-aware `IFormatProvider` overload for the numeric and date/time families), `Create`, `Parse` / `TryParse`, an explicit cast operator, and a `ValidateAdditional(...)` extension hook. `RequiredGuid<TSelf>` additionally gets `NewUniqueV4()` / `NewUniqueV7()`; `RequiredEnum<TSelf>` creation routes through `TryCreate`. See the per-type generated-member entries in [trellis-api-core.md](trellis-api-core.md#primitive-value-object-base-classes) for the exact emitted signatures.
 
 ## Built-in primitives table
 
@@ -198,7 +198,7 @@ public static class Example
         var amount = MonetaryAmount.TryCreate("12.34", CultureInfo.InvariantCulture).Value;
 
         // Symbolic
-        var status = OrderStatus.TryFromName("awaiting-payment").Value;
+        var status = OrderStatus.TryCreate("awaiting-payment").Value;
         var isOpen = status.Is(OrderStatus.Draft, OrderStatus.AwaitingPayment);
 
         // Structured

--- a/docs/docfx_project/articles/primitives.md
+++ b/docs/docfx_project/articles/primitives.md
@@ -133,7 +133,7 @@ A custom primitive is a `partial class` that inherits the appropriate `Required*
 | `RequiredBool<TSelf>` | `bool` | `null` rejected for nullable inputs; `false` is valid | string parsing of `"true"`/`"false"` |
 | `RequiredDateTime<TSelf>` | `DateTime` | `null` and `DateTime.MinValue` rejected | invariant round-trip `"O"` formatting |
 | `RequiredDateTimeOffset<TSelf>` | `DateTimeOffset` | `null` and `DateTimeOffset.MinValue` rejected | invariant round-trip `"O"` formatting |
-| `RequiredEnum<TSelf>` | `string` | `TryFromName` lookup against `public static readonly TSelf` fields; undeclared names rejected | `[EnumValue("...")]` on each field overrides the wire name |
+| `RequiredEnum<TSelf>` | `string` | `TryCreate` lookup against `public static readonly TSelf` fields; undeclared names rejected | `[EnumValue("...")]` on each field overrides the wire name |
 
 > [!NOTE]
 > The base contracts (`IScalarValue<TSelf, TPrimitive>`, `IFormattableScalarValue<TSelf, TPrimitive>`) and shared bases (`ValueObject`, `ScalarValueObject<TSelf, T>`) live in `Trellis.Core`. `ScalarValueObject<TSelf, T>` implements `IConvertible` and `IFormattable` so scalar primitives behave naturally in formatting and conversion scenarios.
@@ -208,7 +208,7 @@ public partial class OrderState : RequiredEnum<OrderState>
 }
 ```
 
-`EnumValueAttribute` is the only Trellis primitive attribute that targets a field (each `public static readonly TSelf`). Without it, the wire name is the field identifier. See [trellis-api-core.md](../api_reference/trellis-api-core.md#requiredenumtself) for `GetAll`, `TryFromName`, `Is(...)`, and equality semantics, and the dedicated [required-enum.md](required-enum.md) article for usage patterns.
+`EnumValueAttribute` is the only Trellis primitive attribute that targets a field (each `public static readonly TSelf`). Without it, the wire name is the field identifier. See [trellis-api-core.md](../api_reference/trellis-api-core.md#requiredenumtself) for `GetAll`, `Is(...)`, and equality semantics, and the dedicated [required-enum.md](required-enum.md) article for usage patterns.
 
 ## Validation
 
@@ -275,7 +275,7 @@ Every non-enum `Required*<TSelf>` partial gets `[JsonConverter(typeof(ParsableJs
 - Writes JSON numbers for numeric scalars and JSON strings for everything else.
 - Throws on JSON `null` because Trellis scalars are non-nullable.
 
-The enum converter is string in, string out via `TryFromName`.
+The enum converter is string in, string out via `TryCreate`.
 
 ### Composite value objects — opt in
 

--- a/docs/docfx_project/articles/required-enum.md
+++ b/docs/docfx_project/articles/required-enum.md
@@ -18,7 +18,7 @@ audience: [developer]
 | Override the wire / serialized name for one member | `[EnumValue("...")]` on the field | [Symbolic value names](#symbolic-value-names) |
 | Parse user input safely (nullable, with field name) | `TryCreate(string?, fieldName?)` → `Result<TSelf>` | [Parsing and creation](#parsing-and-creation) |
 | Throwing factory for trusted input | `Create(string)` | [Parsing and creation](#parsing-and-creation) |
-| Look up by symbolic name (case-insensitive) | `TryFromName(string?, fieldName?)` | [Parsing and creation](#parsing-and-creation) |
+| Look up by symbolic name (case-insensitive) | `TryCreate(string?, fieldName?)` | [Parsing and creation](#parsing-and-creation) |
 | `IParsable<TSelf>` for ASP.NET binding pipelines | `Parse(s, provider)` / `TryParse(s, provider, out)` | [Parsing and creation](#parsing-and-creation) |
 | JSON round-trip in `System.Text.Json` | Auto-applied `[JsonConverter(typeof(RequiredEnumJsonConverter<TSelf>))]` | [JSON serialization](#json-serialization) |
 | Membership and negated membership | `Is(params TSelf[])` / `IsNot(params TSelf[])` | [Equality and membership](#equality-and-membership) |
@@ -40,10 +40,9 @@ audience: [developer]
 | `Value` (`string`) | base | Canonical symbolic identity. Defaults to the field name unless `[EnumValue]` overrides it. |
 | `Ordinal` (`int`) | base | Declaration-order metadata. Not a wire / storage identity. |
 | `static GetAll()` | base | All discovered `public static readonly TSelf` members, in declaration order. |
-| `static TryFromName(string? name, string? fieldName = null)` | base | Case-insensitive lookup → `Result<TSelf>`. |
 | `Is(params TSelf[])` / `IsNot(params TSelf[])` | base | Membership / negated membership. |
 | `Equals` / `==` / `!=` / `GetHashCode` | base | Case-insensitive symbolic equality on `Value`. |
-| `static TryCreate(string)` and `static TryCreate(string?, string? fieldName = null)` | generated | Result-returning factories; both delegate to `TryFromName`. |
+| `static TryCreate(string)` and `static TryCreate(string?, string? fieldName = null)` | base | Result-returning factories; the public entry point for symbolic creation and case-insensitive name lookup. Inherited from the base, not generated per type. |
 | `static Create(string)` | generated | Throwing factory. |
 | `static Parse(string, IFormatProvider?)` / `TryParse(...)` | generated | `IParsable<TSelf>` implementation for binding pipelines. |
 | `[JsonConverter(typeof(RequiredEnumJsonConverter<TSelf>))]` | generated | Applied to the derived class — no manual registration needed. |
@@ -51,7 +50,7 @@ audience: [developer]
 Full signatures: [`trellis-api-core.md` → `RequiredEnum<TSelf>`](../api_reference/trellis-api-core.md#requiredenumtself) and the [source-generated members section](../api_reference/trellis-api-core.md#requiredenumtself-1). Package scope: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md).
 
 > [!NOTE]
-> Generated `TryCreate` delegates only to `TryFromName`. There is no `TryFromValue` API path; the JSON converter and parser also resolve through `TryFromName`.
+> `TryCreate` is the public result-returning factory — the replacement for the old `TryFromName`, and the same lookup surface every other `Required*` primitive exposes. It is provided by the `RequiredEnum<TSelf>` base (an enum's creation is a uniform symbolic lookup), not generated per type. There is no `TryFromValue` or `TryFromName` API; the JSON converter and parser resolve the symbolic name through `TryCreate`.
 
 ## Installation
 
@@ -113,7 +112,7 @@ Members are `public static readonly` fields of type `TSelf`. The base type disco
 | Class must be `partial` | The generator augments it with `IScalarValue<TSelf, string>`, the factories, and the `[JsonConverter]` attribute. |
 | Fields must be `public static readonly TSelf` | Reflection inspects only `Public \| Static \| DeclaredOnly` init-only fields whose type equals `TSelf`. |
 | Constructors should be `private` (or `protected`) | Prevents external instantiation outside the declared set. |
-| Each `Value` must be unique (case-insensitive) | Duplicate detection runs the first time `GetAll` / `TryFromName` / `Value` is touched and throws `InvalidOperationException` naming the duplicate. |
+| Each `Value` must be unique (case-insensitive) | Duplicate detection runs the first time `GetAll` / `TryCreate` / `Value` is touched and throws `InvalidOperationException` naming the duplicate. |
 
 `Ordinal` is assigned during discovery in declaration order (0, 1, 2, …). Reordering fields changes ordinals — do not persist or transmit them.
 
@@ -138,13 +137,12 @@ OrderStatus.AwaitingPayment.Value == "awaiting-payment"; // true
 
 ## Parsing and creation
 
-The generator emits five entry points; all of them resolve through the base-type `TryFromName`.
+`TryCreate` is inherited from the base; the generator emits `Create`, `Parse`, and `TryParse`, all of which route through it.
 
 | API | Returns | Failure mode |
 |---|---|---|
 | `TryCreate(string value)` | `Result<TSelf>` | `Fail` with `Error.InvalidInput` for null, empty, whitespace, or unknown name. |
 | `TryCreate(string? value, string? fieldName = null)` | `Result<TSelf>` | Same; `fieldName` is included in the field violation. |
-| `TryFromName(string? name, string? fieldName = null)` | `Result<TSelf>` | Base-type lookup that all generated factories delegate to. |
 | `Create(string value)` | `TSelf` | Throws on failure. Use only for trusted, internally-known names. |
 | `Parse(string s, IFormatProvider? provider)` / `TryParse(...)` | `TSelf` / `bool` | `IParsable<TSelf>` for ASP.NET model binding pipelines. |
 
@@ -164,7 +162,7 @@ The generator emits `[JsonConverter(typeof(RequiredEnumJsonConverter<TSelf>))]` 
 
 | Direction | Behavior |
 |---|---|
-| Read | Accepts JSON `string`; resolves the string through `TryFromName`. JSON `null` and other token types (number, object, array, bool) throw `JsonException`. |
+| Read | Accepts JSON `string`; resolves the string through `TryCreate`. JSON `null` and other token types (number, object, array, bool) throw `JsonException`. |
 | Write | Emits `value.Value` as a JSON string. |
 
 ```csharp
@@ -197,7 +195,7 @@ bool notDone = paid.IsNot(OrderStatus.Cancelled);
 
 | Input or condition | Outcome |
 |---|---|
-| `null` or whitespace name passed to `TryCreate` / `TryFromName` | `Fail` with `Error.InvalidInput.ForField(field, "validation.error", "{Type} cannot be empty.")` |
+| `null` or whitespace name passed to `TryCreate` | `Fail` with `Error.InvalidInput.ForField(field, "validation.error", "{Type} cannot be empty.")` |
 | Unknown name | `Fail` with message `'{name}' is not a valid {Type}. Valid values: {alphabetised list}` |
 | Two members declared with the same `Value` (case-insensitive) | `InvalidOperationException` thrown by the base class on first cache build, naming the duplicate symbol |
 | `[EnumValue]` on a non-`TSelf` field, an instance member, or a non-`readonly` field | Silently ignored — only `public static readonly TSelf` init-only fields are discovered |


### PR DESCRIPTION
## The issue

`RequiredEnum<TSelf>` exposed a public `TryFromName` factory alongside `TryCreate`. The generated
`TryCreate` just delegated to it, so the two did the same thing — and an enum value object's public
creation surface differed from every other `Required*` primitive (which expose only `TryCreate`) for
no reason.

## The fix

An enum's creation is a uniform symbolic lookup, so `TryCreate` now lives on the `RequiredEnum<TSelf>`
base and is no longer generated per type. `TryFromName` is removed.

- `Create`, `Parse`, `TryParse`, the JSON converter, and the EF Core converter already route through
  `TryCreate`, so they are unaffected.
- Callers of `SomeEnum.TryFromName(name)` switch to `SomeEnum.TryCreate(name)` — same signature, same
  `Result<TSelf>`, same case-insensitive lookup and error message.

The public surface of an enum value object now matches `RequiredString` / `RequiredInt` / etc.:
`TryCreate` is the result-returning factory.
