### PR TITLE
Add implicit string conversion to RequiredEnum

### DIFF
--- a/Trellis.Core/src/Primitives/RequiredEnum.cs
+++ b/Trellis.Core/src/Primitives/RequiredEnum.cs
@@ -271,6 +271,17 @@ public abstract class RequiredEnum<[DynamicallyAccessedMembers(DynamicallyAccess
     public static bool operator !=(RequiredEnum<TSelf>? left, RequiredEnum<TSelf>? right) => !(left == right);
 
     /// <summary>
+    /// Implicitly converts the enum value object to its symbolic <see cref="Value"/>. This mirrors the
+    /// implicit unwrap that <see cref="ScalarValueObject{TSelf, T}"/>-derived primitives provide, so every
+    /// <c>Required*</c> value object can be used transparently as its underlying primitive. Member-to-member
+    /// equality is unaffected: the <c>==</c> operator above is an exact match and wins over a double
+    /// conversion to <see cref="string"/>, so it keeps its case-insensitive <see cref="Value"/> semantics.
+    /// </summary>
+    /// <param name="value">The enum value object to convert.</param>
+    /// <returns>The member's symbolic <see cref="Value"/>.</returns>
+    public static implicit operator string(RequiredEnum<TSelf> value) => value.Value;
+
+    /// <summary>
     /// Compares this instance with another by <see cref="Ordinal"/> (declaration order), so members
     /// sort in the order they are declared — matching how the C# <see langword="enum"/> this type
     /// replaces would sort by its underlying value. Equality remains keyed on <see cref="Value"/>;

--- a/Trellis.Primitives/tests/RequiredEnumTests.cs
+++ b/Trellis.Primitives/tests/RequiredEnumTests.cs
@@ -317,6 +317,41 @@ public class RequiredEnumTests
 
     #endregion
 
+    #region Implicit Conversion Tests
+
+    [Fact]
+    public void ImplicitConversion_ToString_ReturnsValue()
+    {
+        // Act
+        string value = TestOrderState.Confirmed;
+
+        // Assert
+        value.Should().Be("Confirmed");
+    }
+
+    [Fact]
+    public void ImplicitConversion_OverriddenMember_ReturnsExternalName()
+    {
+        // Act
+        string value = TestOverriddenOrderState.AwaitingPayment;
+
+        // Assert
+        value.Should().Be("payment-pending");
+    }
+
+    [Fact]
+    public void ImplicitConversion_FlowsThroughStringParameter()
+    {
+        // A RequiredEnum can be passed wherever a string is expected, matching the implicit unwrap that
+        // ScalarValueObject-derived primitives provide.
+        static string Echo(string value) => value;
+
+        // Assert
+        Echo(TestOrderState.Shipped).Should().Be("Shipped");
+    }
+
+    #endregion
+
     #region Create Tests
 
     [Fact]

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -2149,6 +2149,7 @@ public abstract class RequiredEnum<[DynamicallyAccessedMembers(DynamicallyAccess
 | `public bool Equals(RequiredEnum<TSelf>? other)` | `bool` | Case-insensitive symbolic equality. |
 | `public static bool operator ==(RequiredEnum<TSelf>? left, RequiredEnum<TSelf>? right)` | `bool` | Equality operator. |
 | `public static bool operator !=(RequiredEnum<TSelf>? left, RequiredEnum<TSelf>? right)` | `bool` | Inequality operator. |
+| `public static implicit operator string(RequiredEnum<TSelf> value)` | `string` | Unwraps the member to its symbolic `Value`, matching the implicit unwrap on `ScalarValueObject<TSelf, T>`-derived primitives so every `Required*` value object converts to its primitive transparently. Member-to-member `==` keeps its case-insensitive `Value` semantics — the exact-match operator above wins over a double conversion to `string`. |
 | `public int CompareTo(RequiredEnum<TSelf>? other)` | `int` | Orders by `Ordinal` (declaration order), like the C# `enum` it replaces; stays consistent with `Value`-based equality (`Value` and `Ordinal` are both unique per member); `null` sorts first. |
 | `int IComparable.CompareTo(object? obj)` | `int` | Non-generic comparison; enables members to be used as composite `ValueObject` equality components and sorted by the default comparer. Throws `ArgumentException` when `obj` is non-null and not a `RequiredEnum<TSelf>` (consistent with `Equals(object?)`). |
 | `public static bool operator <(RequiredEnum<TSelf>? left, RequiredEnum<TSelf>? right)` | `bool` | Less-than by declaration order. |

--- a/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
+++ b/docs/docfx_project/api_reference/trellis-value-object-taxonomy.md
@@ -93,7 +93,7 @@ Single-`DateTimeOffset` value object; prefer over `RequiredDateTime<TSelf>` when
 
 ### `RequiredEnum<TSelf>`
 
-**Symbolic** smart-enum that replaces a C# `enum`; members are `public static readonly` singletons. Identity is the string `Value` (equality is case-insensitive); ordering (`IComparable`) is by `Ordinal` = **declaration order**, like the underlying enum it replaces. String-backed in JSON and EF Core. Use `GetAll()` / `TryCreate(...)` for lookup and `[EnumValue("...")]` to override a member's external name. Stands apart from `ScalarValueObject<TSelf, T>`.
+**Symbolic** smart-enum that replaces a C# `enum`; members are `public static readonly` singletons. Identity is the string `Value` (equality is case-insensitive); ordering (`IComparable`) is by `Ordinal` = **declaration order**, like the underlying enum it replaces. String-backed in JSON and EF Core. Use `GetAll()` / `TryCreate(...)` for lookup and `[EnumValue("...")]` to override a member's external name. Stands apart from `ScalarValueObject<TSelf, T>` architecturally, but — like the scalar primitives — provides an implicit unwrap to its `string` `Value`.
 
 ### `MonetaryAmount`
 
@@ -134,7 +134,7 @@ Concrete **structured** value object (`Amount` + `Currency`) for multi-currency;
     - `Slug`
     - `Url`
 - **Symbolic value objects**
-  - `RequiredEnum<TSelf>` is separate from `ScalarValueObject<TSelf, T>` but still uses `Value` as its canonical public identity.
+  - `RequiredEnum<TSelf>` is separate from `ScalarValueObject<TSelf, T>` but still uses `Value` as its canonical public identity and implicitly unwraps to it.
 - **Structured value objects**
   - `Money` -> `ValueObject`
 - **Optionality wrappers**


### PR DESCRIPTION
## The issue

`RequiredEnum<TSelf>` stands apart from `ScalarValueObject<TSelf, T>` — it is a reflection-discovered singleton smart-enum rather than a value-constructed wrapper — and as a side effect it was the only `Required*` value object that did not implicitly unwrap to its underlying primitive. Callers had to write `.Value` to pass an enum where a `string` is expected, while the scalar primitives (`RequiredString`, `RequiredGuid`, …) convert transparently.

## The fix

Add `public static implicit operator string(RequiredEnum<TSelf> value) => value.Value;`, mirroring the implicit unwrap on `ScalarValueObject`. Every `Required*` value object now converts to its primitive consistently.

Member-to-member equality is unchanged: the exact-match `operator ==` (case-insensitive on `Value`) wins over a double conversion to `string`, so `enum1 == enum2` keeps its semantics. The conversion is a trivial property read with no reflection, so it does not affect the type's AOT/trim compatibility.