### PR TITLE
Report index-precise field paths for nested value-object validation

### DIFF
--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -194,6 +194,12 @@ public static class ServiceCollectionExtensions
             // scalar value object. Wrapping it pushes the property name (and, for collections, the
             // element index) onto the validation ancestor path so a nested value-object failure reports
             // an index-precise field path (e.g. /members/0/email) instead of just the leaf name.
+            // Respect an explicit property-level converter (e.g. a [JsonConverter] attribute): only
+            // install the wrapper when the property uses default, type-based conversion, so a consumer's
+            // converter is never silently bypassed.
+            if (property.CustomConverter is not null)
+                continue;
+
             var containerConverter = CreatePathTrackingContainerConverter(property);
             if (containerConverter is not null)
                 property.CustomConverter = containerConverter;

--- a/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -164,28 +165,38 @@ public static class ServiceCollectionExtensions
                 continue;
             }
 
-            // Check if it's a direct value object (IScalarValue<TSelf, T>)
-            if (!IsScalarValueProperty(property))
-                continue;
-
-            // Create a validating converter for this value object
-            var innerScalarConverter = CreateValidatingConverter(propertyType);
-            if (innerScalarConverter is null)
-                continue;
-
-            // Wrap it with property name awareness. In Native AOT this returns null because
-            // runtime closed-generic converter construction is disabled; source-generated
-            // converters are expected to own scalar JSON conversion there.
-            var wrappedScalarConverter = CreatePropertyNameAwareConverter(innerScalarConverter, property.Name, propertyType);
-            if (wrappedScalarConverter is not null)
-                property.CustomConverter = wrappedScalarConverter;
-
-            // Track non-nullable scalar VO properties for missing-property detection
-            if (!property.IsGetNullable && property.Get is not null)
+            // Direct scalar value object (IScalarValue<TSelf, T>)?
+            if (IsScalarValueProperty(property))
             {
-                requiredScalarProperties ??= [];
-                requiredScalarProperties.Add((property.Name, property.Get));
+                // Create a validating converter for this value object
+                var innerScalarConverter = CreateValidatingConverter(propertyType);
+                if (innerScalarConverter is null)
+                    continue;
+
+                // Wrap it with property name awareness. In Native AOT this returns null because
+                // runtime closed-generic converter construction is disabled; source-generated
+                // converters are expected to own scalar JSON conversion there.
+                var wrappedScalarConverter = CreatePropertyNameAwareConverter(innerScalarConverter, property.Name, propertyType);
+                if (wrappedScalarConverter is not null)
+                    property.CustomConverter = wrappedScalarConverter;
+
+                // Track non-nullable scalar VO properties for missing-property detection
+                if (!property.IsGetNullable && property.Get is not null)
+                {
+                    requiredScalarProperties ??= [];
+                    requiredScalarProperties.Add((property.Name, property.Get));
+                }
+
+                continue;
             }
+
+            // A container property (collection or nested object) whose graph transitively contains a
+            // scalar value object. Wrapping it pushes the property name (and, for collections, the
+            // element index) onto the validation ancestor path so a nested value-object failure reports
+            // an index-precise field path (e.g. /members/0/email) instead of just the leaf name.
+            var containerConverter = CreatePathTrackingContainerConverter(property);
+            if (containerConverter is not null)
+                property.CustomConverter = containerConverter;
         }
 
         // Add post-deserialization callback to detect missing required scalar VO properties.
@@ -219,7 +230,7 @@ public static class ServiceCollectionExtensions
     /// Used to avoid double-reporting when an explicit JSON null was already caught by the converter.
     /// </summary>
     private static bool HasExistingErrorForField(string fieldName) =>
-        ValidationErrorsContext.Current?.HasErrorForField(fieldName) ?? false;
+        ValidationErrorsContext.HasErrorForField(fieldName);
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "PropertyType comes from JSON serialization infrastructure which preserves type information")]
     [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "PropertyType comes from JSON serialization infrastructure which preserves type information")]
@@ -265,6 +276,126 @@ public static class ServiceCollectionExtensions
         var wrapperType = typeof(PropertyNameAwareConverter<>).MakeGenericType(type);
         return Activator.CreateInstance(wrapperType, innerConverter, propertyName) as JsonConverter;
     }
+
+    // Wraps a container property (collection or nested object) whose graph transitively contains a
+    // scalar value object so its path segment(s) are pushed during deserialization. Returns null under
+    // Native AOT (no runtime generic construction) and for containers with no value object inside.
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported; Native AOT returns null before constructing a closed generic wrapper.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "Reflection-enabled fallback only; constructed for property/element types already present in JSON serialization metadata.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Property and element types come from JSON serialization metadata which preserves type information.")]
+    private static JsonConverter? CreatePathTrackingContainerConverter(JsonPropertyInfo property)
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return null;
+
+        var propertyType = property.PropertyType;
+        if (!ContainsScalarValueTransitively(propertyType, []))
+            return null;
+
+        var elementType = GetWrappableCollectionElementType(propertyType);
+        if (elementType is not null)
+        {
+            var collectionWrapper = typeof(PathTrackingCollectionConverter<,>).MakeGenericType(propertyType, elementType);
+            return Activator.CreateInstance(collectionWrapper, property.Name) as JsonConverter;
+        }
+
+        if (!IsUserObjectType(propertyType))
+            return null;
+
+        // Nested object: the wrapper pushes the property name and deserializes the object through
+        // JsonSerializer (its own type converter), so a self-referential DTO graph cannot re-enter
+        // metadata resolution while this converter is being constructed.
+        var objectWrapper = typeof(PathTrackingObjectConverter<>).MakeGenericType(propertyType);
+        return Activator.CreateInstance(objectWrapper, property.Name) as JsonConverter;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "Reflection-mode-only DTO graph walk; ScalarValueTypeHelper.IsScalarValue inspects interfaces preserved by JSON metadata.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Walks the public properties of user DTO types to decide whether to install a path-tracking wrapper; reflection-mode fallback only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072",
+        Justification = "Walks the public properties of user DTO types to decide whether to install a path-tracking wrapper; reflection-mode fallback only.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "Walks the public properties of user DTO types to decide whether to install a path-tracking wrapper; reflection-mode fallback only.")]
+    private static bool ContainsScalarValueTransitively(Type type, HashSet<Type> visited)
+    {
+        if (!visited.Add(type))
+            return false;
+
+        if (ScalarValueTypeHelper.IsScalarValue(type) || ScalarValueTypeHelper.IsMaybeScalarValue(type))
+            return true;
+
+        var element = GetEnumerableElementType(type);
+        if (element is not null)
+            return ContainsScalarValueTransitively(element, visited);
+
+        if (!IsUserObjectType(type))
+            return false;
+
+        foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (prop.GetIndexParameters().Length != 0)
+                continue;
+
+            if (ContainsScalarValueTransitively(prop.PropertyType, visited))
+                return true;
+        }
+
+        return false;
+    }
+
+    // The element type to wrap for index tracking — only when a List<element> is assignable back to the
+    // property type (List<T> itself, an array, or the IList/ICollection/IEnumerable/IReadOnlyList/
+    // IReadOnlyCollection<T> interfaces). Other collection shapes are left to STJ (leaf-only paths).
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Reflection-mode-only; reached only when RuntimeFeature.IsDynamicCodeSupported via CreatePathTrackingContainerConverter.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2055",
+        Justification = "Reflection-mode-only; List<element> is built only to test assignability to the property type already present in JSON metadata.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Reflection-mode-only inspection of collection property types from JSON metadata.")]
+    private static Type? GetWrappableCollectionElementType(Type type)
+    {
+        if (type.IsArray)
+            return type.GetElementType();
+
+        var element = GetEnumerableElementType(type);
+        if (element is null)
+            return null;
+
+        var listType = typeof(List<>).MakeGenericType(element);
+        return type.IsAssignableFrom(listType) ? element : null;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Inspects generic IEnumerable<T> interfaces on collection property types from JSON metadata; reflection-mode fallback only.")]
+    private static Type? GetEnumerableElementType(Type type)
+    {
+        if (type == typeof(string))
+            return null;
+
+        if (type.IsArray)
+            return type.GetElementType();
+
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            return type.GetGenericArguments()[0];
+
+        foreach (var iface in type.GetInterfaces())
+        {
+            if (iface.IsGenericType && iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                return iface.GetGenericArguments()[0];
+        }
+
+        return null;
+    }
+
+    private static bool IsUserObjectType(Type type) =>
+        type is { IsClass: true, IsArray: false }
+        && type != typeof(string)
+        && type != typeof(object)
+        && (type.Namespace is null || !type.Namespace.StartsWith("System", StringComparison.Ordinal));
 
     /// <summary>
     /// Adds automatic value object validation for both MVC Controllers and Minimal APIs.

--- a/Trellis.Asp/src/Validation/PathTrackingCollectionConverter.cs
+++ b/Trellis.Asp/src/Validation/PathTrackingCollectionConverter.cs
@@ -1,0 +1,89 @@
+﻿namespace Trellis.Asp.Validation;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Reads a JSON array element-by-element, pushing the collection property name and each element index
+/// onto the validation ancestor path, so a scalar value object nested inside a collection reports an
+/// index-precise field path (e.g. <c>/members/0/email</c>) instead of just the leaf property name.
+/// </summary>
+/// <typeparam name="TCollection">The collection property type (e.g. <c>List&lt;T&gt;</c> or <c>T[]</c>).</typeparam>
+/// <typeparam name="TElement">The element type.</typeparam>
+/// <remarks>
+/// System.Text.Json's built-in collection converters give no per-element hook, so the modifier installs
+/// this wrapper for collection properties whose element graph transitively contains a value object. It is
+/// never constructed under Native AOT (runtime closed-generic construction is disabled there).
+/// </remarks>
+internal sealed class PathTrackingCollectionConverter<TCollection, TElement> : JsonConverter<TCollection?>
+{
+    private readonly string _propertyName;
+
+    /// <inheritdoc />
+    public override bool HandleNull => true;
+
+    /// <summary>
+    /// Creates a new path-tracking collection wrapper.
+    /// </summary>
+    /// <param name="propertyName">The JSON property name to push onto the ancestor path during reads.</param>
+    public PathTrackingCollectionConverter(string propertyName) => _propertyName = propertyName;
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    public override TCollection? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+            return default;
+
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException($"Expected the start of an array for '{_propertyName}'.");
+
+        var items = new List<TElement?>();
+        using (ValidationErrorsContext.PushPathSegment(_propertyName))
+        {
+            var index = 0;
+            reader.Read();
+            while (reader.TokenType != JsonTokenType.EndArray)
+            {
+                using (ValidationErrorsContext.PushPathSegment(index.ToString(CultureInfo.InvariantCulture)))
+                {
+                    items.Add(JsonSerializer.Deserialize<TElement>(ref reader, options));
+                }
+
+                index++;
+                reader.Read();
+            }
+        }
+
+        return Materialize(items);
+    }
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    public override void Write(Utf8JsonWriter writer, TCollection? value, JsonSerializerOptions options) =>
+        JsonSerializer.Serialize(writer, value, options);
+
+    private static TCollection Materialize(List<TElement?> items)
+    {
+        if (typeof(TCollection).IsArray)
+        {
+            var array = new TElement?[items.Count];
+            items.CopyTo(array);
+            return (TCollection)(object)array;
+        }
+
+        // The modifier only installs this converter when List<TElement> is assignable to TCollection
+        // (List<T> itself or the IList/ICollection/IEnumerable/IReadOnlyList/IReadOnlyCollection<T> it
+        // implements), so this cast is always valid.
+        return (TCollection)(object)items;
+    }
+}

--- a/Trellis.Asp/src/Validation/PathTrackingObjectConverter.cs
+++ b/Trellis.Asp/src/Validation/PathTrackingObjectConverter.cs
@@ -1,0 +1,53 @@
+﻿namespace Trellis.Asp.Validation;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Wraps a non-collection object property whose graph transitively contains a scalar value object,
+/// pushing the property name onto the validation ancestor path so a nested value-object failure reports
+/// an index-precise field path (e.g. <c>/contact/email</c>) instead of just the leaf property name.
+/// </summary>
+/// <typeparam name="T">The property (object) type being wrapped.</typeparam>
+/// <remarks>
+/// Installed by the reflection-mode type-info modifier. It is never constructed under Native AOT, where
+/// runtime closed-generic converter construction is disabled; AOT keeps leaf-only field names. The inner
+/// object is deserialized through <see cref="JsonSerializer"/> (its own type converter), not a converter
+/// captured at modifier time, so a self-referential DTO graph cannot re-enter metadata resolution while
+/// this wrapper is being constructed.
+/// </remarks>
+internal sealed class PathTrackingObjectConverter<T> : JsonConverter<T?>
+{
+    private readonly string _propertyName;
+
+    /// <inheritdoc />
+    public override bool HandleNull => true;
+
+    /// <summary>
+    /// Creates a new path-tracking object wrapper.
+    /// </summary>
+    /// <param name="propertyName">The JSON property name to push onto the ancestor path during reads.</param>
+    public PathTrackingObjectConverter(string propertyName) => _propertyName = propertyName;
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using (ValidationErrorsContext.PushPathSegment(_propertyName))
+        {
+            return JsonSerializer.Deserialize<T>(ref reader, options);
+        }
+    }
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Reflection-mode-only converter; the modifier never installs it under Native AOT.")]
+    public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options) =>
+        JsonSerializer.Serialize(writer, value, options);
+}

--- a/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
+++ b/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
@@ -99,8 +99,19 @@ public static class ValidationErrorsContext
         return new PathSegmentScope(previous);
     }
 
-    // Builds the RFC 6901 JSON Pointer for a leaf field, prefixed with the current ancestor path.
-    private static string BuildPointer(string fieldName) => AncestorPointer() + "/" + EscapeSegment(fieldName);
+    // Builds the RFC 6901 JSON Pointer for a field, prefixed with the current ancestor path. Mirrors
+    // InputPointer.ForProperty so the public AddError(string, ...) contract is preserved: a value that
+    // already starts with '/' is treated as a fully-formed pointer (its segments are not re-escaped),
+    // and an empty value targets the ancestor (the document root when there is no ancestor).
+    private static string BuildPointer(string fieldName)
+    {
+        var ancestor = AncestorPointer();
+        if (string.IsNullOrEmpty(fieldName))
+            return ancestor;
+        if (fieldName[0] == '/')
+            return ancestor + fieldName;
+        return ancestor + "/" + EscapeSegment(fieldName);
+    }
 
     private static string AncestorPointer()
     {

--- a/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
+++ b/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
@@ -1,5 +1,7 @@
 ﻿namespace Trellis.Asp;
 
+using System.Collections.Immutable;
+using System.Text;
 using Trellis;
 
 /// <summary>
@@ -37,6 +39,7 @@ public static class ValidationErrorsContext
 {
     private static readonly AsyncLocal<ErrorCollector?> s_current = new();
     private static readonly AsyncLocal<string?> s_currentPropertyName = new();
+    private static readonly AsyncLocal<ImmutableList<string>?> s_ancestorPath = new();
 
     /// <summary>
     /// Gets the current error collector for the async context, or null if no scope is active.
@@ -72,9 +75,46 @@ public static class ValidationErrorsContext
     {
         var previous = s_current.Value;
         var previousPropertyName = s_currentPropertyName.Value;
+        var previousAncestorPath = s_ancestorPath.Value;
         s_current.Value = new ErrorCollector();
-        return new Scope(previous, previousPropertyName);
+        s_ancestorPath.Value = null;
+        return new Scope(previous, previousPropertyName, previousAncestorPath);
     }
+
+    /// <summary>
+    /// Pushes a path segment (a container property name or a collection index) onto the current
+    /// ancestor path; disposing the returned scope pops it. Container and collection converters use
+    /// this so a value object nested inside a collection or another object reports an index-precise
+    /// field path (e.g. <c>/members/0/email</c>) rather than just the leaf property name.
+    /// </summary>
+    /// <param name="segment">The unescaped path segment to push.</param>
+    /// <returns>An <see cref="IDisposable"/> that pops the segment when disposed.</returns>
+    internal static IDisposable PushPathSegment(string segment)
+    {
+        var previous = s_ancestorPath.Value ?? ImmutableList<string>.Empty;
+        s_ancestorPath.Value = previous.Add(segment);
+        return new PathSegmentScope(previous);
+    }
+
+    // Builds the RFC 6901 JSON Pointer for a leaf field, prefixed with the current ancestor path.
+    private static string BuildPointer(string fieldName) => AncestorPointer() + "/" + EscapeSegment(fieldName);
+
+    private static string AncestorPointer()
+    {
+        var path = s_ancestorPath.Value;
+        if (path is null || path.Count == 0)
+            return string.Empty;
+
+        var sb = new StringBuilder();
+        foreach (var segment in path)
+            sb.Append('/').Append(EscapeSegment(segment));
+
+        return sb.ToString();
+    }
+
+    // RFC 6901 §3: '~' is escaped first (to '~0'), then '/' (to '~1').
+    private static string EscapeSegment(string segment) =>
+        segment.Replace("~", "~0", StringComparison.Ordinal).Replace("/", "~1", StringComparison.Ordinal);
 
     /// <summary>
     /// Adds a validation error for a specific field to the current scope.
@@ -87,7 +127,8 @@ public static class ValidationErrorsContext
     /// failures as 422 responses via <see cref="ScalarValueValidationMiddleware"/>.
     /// </remarks>
     public static void AddError(string fieldName, string errorMessage) =>
-        s_current.Value?.AddError(fieldName, errorMessage);
+        s_current.Value?.AddFieldViolation(
+            new FieldViolation(new InputPointer(BuildPointer(fieldName)), "validation.error") { Detail = errorMessage });
 
     /// <summary>
     /// Adds all field violations and rule violations from an existing <see cref="Error.InvalidInput"/> to the current scope.
@@ -104,8 +145,42 @@ public static class ValidationErrorsContext
     /// rich, structured validation failures.
     /// </para>
     /// </remarks>
-    public static void AddError(Error.InvalidInput unprocessableContent) =>
-        s_current.Value?.AddError(unprocessableContent);
+    public static void AddError(Error.InvalidInput unprocessableContent)
+    {
+        var collector = s_current.Value;
+        if (collector is null)
+            return;
+
+        var ancestor = AncestorPointer();
+        foreach (var fieldViolation in unprocessableContent.Fields)
+        {
+            var prefixed = ancestor.Length == 0
+                ? fieldViolation
+                : fieldViolation with { Field = new InputPointer(ancestor + fieldViolation.Field.Path) };
+            collector.AddFieldViolation(prefixed);
+        }
+
+        foreach (var ruleViolation in unprocessableContent.Rules)
+        {
+            var prefixedRule = ancestor.Length == 0 || ruleViolation.Fields.IsEmpty
+                ? ruleViolation
+                : ruleViolation with
+                {
+                    Fields = ruleViolation.Fields.Items
+                        .Select(pointer => new InputPointer(ancestor + pointer.Path))
+                        .ToImmutableArray(),
+                };
+            collector.AddRuleViolation(prefixedRule);
+        }
+    }
+
+    /// <summary>
+    /// Gets whether an error has already been collected for the given leaf field at the current
+    /// ancestor path. Used to avoid double-reporting a property as both invalid and "required".
+    /// </summary>
+    /// <param name="fieldName">The leaf field name to check.</param>
+    internal static bool HasErrorForField(string fieldName) =>
+        s_current.Value?.HasErrorForPath(BuildPointer(fieldName)) ?? false;
 
     /// <summary>
     /// Gets the aggregated <see cref="Error.InvalidInput"/> from the current scope, or null if no errors were collected.
@@ -126,18 +201,30 @@ public static class ValidationErrorsContext
     {
         private readonly ErrorCollector? _previous;
         private readonly string? _previousPropertyName;
+        private readonly ImmutableList<string>? _previousAncestorPath;
 
-        public Scope(ErrorCollector? previous, string? previousPropertyName)
+        public Scope(ErrorCollector? previous, string? previousPropertyName, ImmutableList<string>? previousAncestorPath)
         {
             _previous = previous;
             _previousPropertyName = previousPropertyName;
+            _previousAncestorPath = previousAncestorPath;
         }
 
         public void Dispose()
         {
             s_current.Value = _previous;
             s_currentPropertyName.Value = _previousPropertyName;
+            s_ancestorPath.Value = _previousAncestorPath;
         }
+    }
+
+    private sealed class PathSegmentScope : IDisposable
+    {
+        private readonly ImmutableList<string> _previous;
+
+        public PathSegmentScope(ImmutableList<string> previous) => _previous = previous;
+
+        public void Dispose() => s_ancestorPath.Value = _previous;
     }
 
     internal sealed class ErrorCollector
@@ -157,57 +244,39 @@ public static class ValidationErrorsContext
             }
         }
 
-        public bool HasErrorForField(string fieldName)
+        public bool HasErrorForPath(string path)
         {
             lock (_lock)
             {
-                return _fieldErrors.ContainsKey(fieldName);
+                return _fieldErrors.ContainsKey(path);
             }
         }
 
-        public void AddError(string fieldName, string errorMessage)
+        public void AddFieldViolation(FieldViolation violation)
         {
             lock (_lock)
             {
-                if (!_fieldErrors.TryGetValue(fieldName, out var errors))
+                var key = violation.Field.Path;
+                if (!_fieldErrors.TryGetValue(key, out var errors))
                 {
                     errors = [];
-                    _fieldErrors[fieldName] = errors;
+                    _fieldErrors[key] = errors;
                 }
 
-                var violation = new FieldViolation(InputPointer.ForProperty(fieldName), "validation.error") { Detail = errorMessage };
-                if (!ContainsByDetail(errors, errorMessage))
+                if (!errors.Contains(violation))
                 {
                     errors.Add(violation);
                 }
             }
         }
 
-        public void AddError(Error.InvalidInput unprocessableContent)
+        public void AddRuleViolation(RuleViolation violation)
         {
             lock (_lock)
             {
-                foreach (var fieldViolation in unprocessableContent.Fields)
+                if (!_ruleErrors.Contains(violation))
                 {
-                    var fieldName = fieldViolation.Field.Path.TrimStart('/');
-                    if (!_fieldErrors.TryGetValue(fieldName, out var errors))
-                    {
-                        errors = [];
-                        _fieldErrors[fieldName] = errors;
-                    }
-
-                    if (!errors.Contains(fieldViolation))
-                    {
-                        errors.Add(fieldViolation);
-                    }
-                }
-
-                foreach (var ruleViolation in unprocessableContent.Rules)
-                {
-                    if (!_ruleErrors.Contains(ruleViolation))
-                    {
-                        _ruleErrors.Add(ruleViolation);
-                    }
+                    _ruleErrors.Add(violation);
                 }
             }
         }
@@ -232,17 +301,6 @@ public static class ValidationErrorsContext
                     Detail = "One or more validation errors occurred.",
                 };
             }
-        }
-
-        private static bool ContainsByDetail(List<FieldViolation> existing, string detail)
-        {
-            foreach (var v in existing)
-            {
-                if (string.Equals(v.Detail, detail, StringComparison.Ordinal))
-                    return true;
-            }
-
-            return false;
         }
     }
 }

--- a/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
+++ b/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
@@ -69,7 +69,9 @@ public static class ValidationErrorsContext
     /// <returns>An <see cref="IDisposable"/> that ends the scope when disposed.</returns>
     /// <remarks>
     /// Always use this in a using statement or block to ensure proper cleanup.
-    /// Nested scopes are supported; each scope maintains its own error collection.
+    /// Nested scopes are supported; each scope maintains its own error collection and starts at the
+    /// document root, so the ambient current-property name and ancestor path are reset for the new
+    /// scope and restored when it is disposed.
     /// </remarks>
     public static IDisposable BeginScope()
     {
@@ -77,6 +79,7 @@ public static class ValidationErrorsContext
         var previousPropertyName = s_currentPropertyName.Value;
         var previousAncestorPath = s_ancestorPath.Value;
         s_current.Value = new ErrorCollector();
+        s_currentPropertyName.Value = null;
         s_ancestorPath.Value = null;
         return new Scope(previous, previousPropertyName, previousAncestorPath);
     }

--- a/Trellis.Asp/tests/NestedPathValidationTests.cs
+++ b/Trellis.Asp/tests/NestedPathValidationTests.cs
@@ -1,0 +1,163 @@
+﻿namespace Trellis.Asp.Tests;
+
+using System.Collections.Generic;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Trellis;
+using Trellis.Asp.Validation;
+using Xunit;
+
+/// <summary>
+/// Issue #658: the scalar value-object auto-validation path must report the index-precise JSON
+/// path (e.g. <c>/members/0/email</c>) for a value object nested inside a collection or another
+/// object, at parity with the FluentValidation integration — not just the leaf property name.
+/// </summary>
+public sealed class NestedPathValidationTests
+{
+    // Hand-written scalar value object (this test project has no source generator).
+    public sealed class TestEmail : ScalarValueObject<TestEmail, string>, IScalarValue<TestEmail, string>
+    {
+        private TestEmail(string value) : base(value) { }
+
+        public static Result<TestEmail> TryCreate(string? value, string? fieldName = null)
+        {
+            var field = fieldName ?? "email";
+            return string.IsNullOrWhiteSpace(value) || !value.Contains('@')
+                ? Result.Fail<TestEmail>(new Error.InvalidInput(EquatableArray.Create(
+                    new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = "Email address is not valid." })))
+                : Result.Ok(new TestEmail(value));
+        }
+    }
+
+    public sealed record MemberDto(TestEmail Email);
+
+    public sealed record CreateMembersCommand(List<MemberDto> Members);
+
+    public sealed record AddressDto(TestEmail Email);
+
+    public sealed record CreatePersonCommand(AddressDto Contact);
+
+    // A node whose property graph references its own type, exercising the cyclic-graph path: the
+    // wrapper must not capture a converter at modifier time (which would re-enter metadata resolution
+    // for a self-referential DTO and recurse forever).
+    public sealed record NodeDto(TestEmail Email, NodeDto? Child = null);
+
+    // A value object that reports its failure as a multi-field RuleViolation carrying a field pointer,
+    // exercising the rule-pointer prefixing path rather than only the FieldViolation path.
+    public sealed class TestRuleEmail : ScalarValueObject<TestRuleEmail, string>, IScalarValue<TestRuleEmail, string>
+    {
+        private TestRuleEmail(string value) : base(value) { }
+
+        public static Result<TestRuleEmail> TryCreate(string? value, string? fieldName = null)
+        {
+            var field = fieldName ?? "email";
+            return string.IsNullOrWhiteSpace(value) || !value.Contains('@')
+                ? Result.Fail<TestRuleEmail>(new Error.InvalidInput(
+                    EquatableArray<FieldViolation>.Empty,
+                    EquatableArray.Create(new RuleViolation(
+                        "email.rule",
+                        EquatableArray.Create(InputPointer.ForProperty(field)),
+                        Detail: "Email address is not valid."))))
+                : Result.Ok(new TestRuleEmail(value));
+        }
+    }
+
+    public sealed record RuleMemberDto(TestRuleEmail Email);
+
+    public sealed record CreateRuleMembersCommand(List<RuleMemberDto> Members);
+
+    private static JsonSerializerOptions BuildOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddScalarValueValidationForMinimalApi();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>>().Value.SerializerOptions;
+    }
+
+    [Fact]
+    public void Value_object_in_a_collection_reports_the_index_precise_path()
+    {
+        var options = BuildOptions();
+        const string json = """{ "members": [ { "email": "not-an-email" }, { "email": "ada@x.com" } ] }""";
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            JsonSerializer.Deserialize<CreateMembersCommand>(json, options);
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            error!.Fields.Items.Should().ContainSingle();
+            error.Fields[0].Field.Path.Should().Be("/members/0/email");
+        }
+    }
+
+    [Fact]
+    public void Value_object_in_a_nested_object_reports_the_dotted_path()
+    {
+        var options = BuildOptions();
+        const string json = """{ "contact": { "email": "not-an-email" } }""";
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            JsonSerializer.Deserialize<CreatePersonCommand>(json, options);
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            error!.Fields.Items.Should().ContainSingle();
+            error.Fields[0].Field.Path.Should().Be("/contact/email");
+        }
+    }
+
+    [Fact]
+    public void Top_level_value_object_path_is_unchanged()
+    {
+        var options = BuildOptions();
+        const string json = """{ "email": "not-an-email" }""";
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            JsonSerializer.Deserialize<MemberDto>(json, options);
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            error!.Fields[0].Field.Path.Should().Be("/email");
+        }
+    }
+
+    [Fact]
+    public void Value_object_in_a_self_referential_object_graph_reports_the_nested_path()
+    {
+        var options = BuildOptions();
+        const string json = """{ "email": "ada@x.com", "child": { "email": "not-an-email" } }""";
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            JsonSerializer.Deserialize<NodeDto>(json, options);
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            error!.Fields.Items.Should().ContainSingle();
+            error.Fields[0].Field.Path.Should().Be("/child/email");
+        }
+    }
+
+    [Fact]
+    public void Rule_violation_field_pointers_are_prefixed_with_the_ancestor_path()
+    {
+        var options = BuildOptions();
+        const string json = """{ "members": [ { "email": "not-an-email" } ] }""";
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            JsonSerializer.Deserialize<CreateRuleMembersCommand>(json, options);
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            error!.Rules.Items.Should().ContainSingle();
+            error.Rules.Items[0].Fields.Items.Should().ContainSingle();
+            error.Rules.Items[0].Fields.Items[0].Path.Should().Be("/members/0/email");
+        }
+    }
+}

--- a/Trellis.Asp/tests/NestedPathValidationTests.cs
+++ b/Trellis.Asp/tests/NestedPathValidationTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -68,6 +69,23 @@ public sealed class NestedPathValidationTests
 
     public sealed record CreateRuleMembersCommand(List<RuleMemberDto> Members);
 
+    // A consumer-supplied converter on a container property: it consumes the value itself, so Trellis
+    // must not overwrite it with a path-tracking wrapper (which would bypass the consumer's converter).
+    private sealed class SkippingAddressConverter : JsonConverter<AddressDto?>
+    {
+        public override AddressDto? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            reader.Skip();
+            return null;
+        }
+
+        public override void Write(Utf8JsonWriter writer, AddressDto? value, JsonSerializerOptions options) =>
+            writer.WriteNullValue();
+    }
+
+    public sealed record PersonWithCustomContact(
+        [property: JsonConverter(typeof(SkippingAddressConverter))] AddressDto? Contact);
+
     private static JsonSerializerOptions BuildOptions()
     {
         var services = new ServiceCollection();
@@ -94,7 +112,7 @@ public sealed class NestedPathValidationTests
     }
 
     [Fact]
-    public void Value_object_in_a_nested_object_reports_the_dotted_path()
+    public void Value_object_in_a_nested_object_reports_the_json_pointer_path()
     {
         var options = BuildOptions();
         const string json = """{ "contact": { "email": "not-an-email" } }""";
@@ -158,6 +176,46 @@ public sealed class NestedPathValidationTests
             error!.Rules.Items.Should().ContainSingle();
             error.Rules.Items[0].Fields.Items.Should().ContainSingle();
             error.Rules.Items[0].Fields.Items[0].Path.Should().Be("/members/0/email");
+        }
+    }
+
+    [Fact]
+    public void Explicit_property_level_converter_on_a_container_is_not_overwritten()
+    {
+        var options = BuildOptions();
+        const string json = """{ "contact": { "email": "not-an-email" } }""";
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            var result = JsonSerializer.Deserialize<PersonWithCustomContact>(json, options);
+
+            // The consumer's [JsonConverter] owns the property, so the path-tracking wrapper is not
+            // installed over it: it consumed the (invalid) nested email without our pipeline validating it.
+            ValidationErrorsContext.GetUnprocessableContent().Should().BeNull();
+            result!.Contact.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void BeginScope_clears_a_stale_current_property_name()
+    {
+        var options = BuildOptions();
+        ValidationErrorsContext.CurrentPropertyName = "stale";
+        try
+        {
+            using (ValidationErrorsContext.BeginScope())
+            {
+                JsonSerializer.Deserialize<TestEmail>("\"not-an-email\"", options);
+
+                var error = ValidationErrorsContext.GetUnprocessableContent();
+                error.Should().NotBeNull();
+                // A new scope starts at the document root: the stale leaf name must not leak into the path.
+                error!.Fields[0].Field.Path.Should().NotContain("stale");
+            }
+        }
+        finally
+        {
+            ValidationErrorsContext.CurrentPropertyName = null;
         }
     }
 }

--- a/Trellis.Asp/tests/NestedPathValidationTests.cs
+++ b/Trellis.Asp/tests/NestedPathValidationTests.cs
@@ -218,4 +218,31 @@ public sealed class NestedPathValidationTests
             ValidationErrorsContext.CurrentPropertyName = null;
         }
     }
+
+    [Fact]
+    public void AddError_with_an_already_formed_pointer_is_not_re_escaped()
+    {
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.AddError("/members/0/email", "bad");
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            // A value already starting with '/' is a fully-formed pointer; its slashes must not be escaped.
+            error!.Fields[0].Field.Path.Should().Be("/members/0/email");
+        }
+    }
+
+    [Fact]
+    public void AddError_with_an_empty_field_name_targets_the_root()
+    {
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.AddError(string.Empty, "bad");
+
+            var error = ValidationErrorsContext.GetUnprocessableContent();
+            error.Should().NotBeNull();
+            error!.Fields[0].Field.Path.Should().Be(string.Empty);
+        }
+    }
 }

--- a/Trellis.Asp/tests/ServiceCollectionExtensionsTests.cs
+++ b/Trellis.Asp/tests/ServiceCollectionExtensionsTests.cs
@@ -526,9 +526,10 @@ public class ServiceCollectionExtensionsTests
             var error = ValidationErrorsContext.GetUnprocessableContent();
             error.Should().NotBeNull();
             error!.Fields.Items.Should().HaveCountGreaterOrEqualTo(2);
-            // Nested properties get their field names from the JSON property names (lowercase)
-            error.Fields.Items.Should().Contain(e => e.Field.Path == "/street");
-            error.Fields.Items.Should().Contain(e => e.Field.Path == "/city");
+            // Nested value objects now report the full path (container property + leaf), from the JSON
+            // property names (camelCase), at parity with the FluentValidation integration.
+            error.Fields.Items.Should().Contain(e => e.Field.Path == "/address/street");
+            error.Fields.Items.Should().Contain(e => e.Field.Path == "/address/city");
         }
     }
 

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -187,6 +187,8 @@ Default mappings: `Error.InvalidInput=422`, `Error.InvariantViolation=422`, `Err
 
 The `Error.InvalidInput` mapping also governs **binder- and JSON-body value-validation failures** (`ScalarValueValidationMiddleware`, `ScalarValueValidationFilter`, and `ScalarValueValidationEndpointFilter`), so a single `MapError<Error.InvalidInput>(status)` applies uniformly to scalar/value-object validation at the route/query binder, the JSON request body, and domain handlers (default `422`). Syntactically malformed JSON is exempt — it stays `400` per RFC 9110 §15.5.1.
 
+JSON-body value-object validation reports an **index-precise field key** for a value object nested inside a collection or another object — e.g. `members[0].email` (RFC 6901 pointer `/members/0/email`) rather than the bare leaf `email` — at parity with the FluentValidation integration. This applies to the reflection-mode pipeline (`List<T>`, arrays, and nested objects whose graph transitively contains a value object); Native-AOT source-generated converters currently report the leaf field name only.
+
 ### Domain → HTTP boundary mapping
 
 Trellis.Core.Error is transport-neutral. The ASP boundary translates domain failures to HTTP per the table below.


### PR DESCRIPTION
Closes #658.

## Issue
Scalar value-object JSON validation reported only the leaf field name (e.g. `email`) for a value object nested inside a collection or another object, so a client could not tell which element failed validation.

## Fix
JSON-body value-object validation now reports the full RFC 6901 pointer for a nested value object — e.g. `/members/0/email` and `/contact/email` — at parity with the FluentValidation integration.

A reflection-mode type-info modifier installs path-tracking wrappers on container properties (lists, arrays, nested objects) whose graph transitively contains a value object. The wrappers push the property name and collection index onto an ancestor path that the error collector prepends to each field and rule pointer. The leaf value-object converter is unchanged.

Scope is the reflection-mode pipeline. Native-AOT source-generated converters continue to report the leaf field name only; AOT parity is tracked separately in #664.