### PR TITLE
Bump Microsoft.Identity.Client, Nerdbank.GitVersioning, and Scalar packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,15 +45,15 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.85.1" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.85.2" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.85" />
     <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Stateless" Version="5.20.1" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.5" />
-    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.16.5" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.8" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.16.8" />
     <PackageVersion Include="T4.Build" Version="0.2.5" />
   </ItemGroup>
   <!-- Test -->


### PR DESCRIPTION
Combines three Dependabot NuGet updates into a single change to `Directory.Packages.props` to avoid mutual merge conflicts.

## Updates
| Package | From | To |
|---|---|---|
| Microsoft.Identity.Client | 4.85.1 | 4.85.2 |
| Nerdbank.GitVersioning | 3.9.50 | 3.10.85 |
| Scalar.AspNetCore | 2.16.5 | 2.16.8 |
| Scalar.AspNetCore.Microsoft | 2.16.5 | 2.16.8 |

## Validation
- `dotnet build Trellis.slnx -c Release` succeeded (0 warnings, `TreatWarningsAsErrors=true`).
- `dotnet test Trellis.slnx -c Release` passed: 7241 total, 0 failed, 15 skipped (SQL Server LocalDB unavailable).

Supersedes and closes the individual Dependabot PRs #669, #670, and #671.