### PR TITLE
chore(deps): consolidate dependency updates and raise SDK floor to 10.0.300

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         fetch-depth: 0
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
         

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         global-json-file: global.json
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0 # depth is needed for nbgv
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
 

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         fetch-depth: 0 # depth is needed for nbgv
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,45 +11,45 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />
     <PackageVersion Include="Mediator.SourceGenerator" Version="3.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-    <PackageVersion Include="Asp.Versioning.OpenApi" Version="10.0.0-rc.1" />
-    <!-- Security pin (transitive): Microsoft.AspNetCore.OpenApi 10.0.9 / Asp.Versioning.OpenApi
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageVersion Include="Asp.Versioning.OpenApi" Version="10.0.1" />
+    <!-- Security pin (transitive): Microsoft.AspNetCore.OpenApi 10.0.10 / Asp.Versioning.OpenApi
          pull Microsoft.OpenApi 2.0.0, which has a high-severity DoS vuln
          (GHSA-v5pm-xwqc-g5wc / CVE-2026-49451 / NU1903; a circular schema reference can
          stack-overflow the parser; 2.0.0-preview11..2.7.4 affected). 2.7.5 is the patched 2.x
          release and stays ABI-compatible with the 2.x consumers above. -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
-    <PackageVersion Include="Asp.Versioning.Http" Version="10.0.0" />
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
-    <!-- Security pin (transitive): Microsoft.EntityFrameworkCore.Sqlite 10.0.9 pulls
+    <PackageVersion Include="Asp.Versioning.Http" Version="10.0.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <!-- Security pin (transitive): Microsoft.EntityFrameworkCore.Sqlite 10.0.10 pulls
          SQLitePCLRaw.lib.e_sqlite3 2.1.11, which has a high-severity vuln
          (GHSA-2m69-gcr7-jv3q / NU1903; <= 2.1.11 affected). 3.50.3 is the next published
          release and bundles patched SQLite. Only the native lib is bumped; the managed
          provider/core stay at 2.1.x and remain compatible (SQLite C ABI is stable). -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.85.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.87.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.85" />
-    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Api" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Stateless" Version="5.20.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.16.8" />
@@ -61,7 +61,7 @@
     <PackageVersion Include="FluentAssertions" Version="7.2.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ return EmailAddress.TryCreate(request.Email)
 
 > **AOT:** per-package APIs are trim- and AOT-safe; `Trellis.ServiceDefaults` exposes both AOT-safe per-type overloads and assembly-scanning overloads (annotated so the AOT analyzer flags the choice). `Trellis.EntityFrameworkCore` follows EF Core's own AOT policy. See the [docs](https://xavierjohn.github.io/Trellis/) for details.
 
+## Requirements
+
+Trellis requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+).
+
+`Trellis.Core`, `Trellis.Asp`, and `Trellis.EntityFrameworkCore` ship source generators, and `Trellis.Analyzers` ships analyzers, all compiled against Roslyn 5.6. On an older SDK the compiler reports `CS9057` and skips them — the generated members simply never appear, which surfaces as confusing "missing member" build errors rather than an obvious version complaint.
+
 ## Quick Start
 
 **Add the library:**

--- a/Trellis.Analyzers/NUGET_README.md
+++ b/Trellis.Analyzers/NUGET_README.md
@@ -6,7 +6,7 @@ Roslyn analyzers that keep Trellis usage safe, idiomatic, and review-friendly.
 
 ## Requirements
 
-Requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+). The analyzers are compiled against Roslyn 5.6; on an older host the compiler reports `CS9057` and silently skips them, so the `TRLS` diagnostics stop firing.
+Requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+). The analyzers are compiled against Roslyn 5.6; on an older host the compiler reports `CS9057` and skips them, so the `TRLS` diagnostics stop firing.
 
 ## Installation
 

--- a/Trellis.Analyzers/NUGET_README.md
+++ b/Trellis.Analyzers/NUGET_README.md
@@ -4,6 +4,10 @@
 
 Roslyn analyzers that keep Trellis usage safe, idiomatic, and review-friendly.
 
+## Requirements
+
+Requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+). The analyzers are compiled against Roslyn 5.6; on an older host the compiler reports `CS9057` and silently skips them, so the `TRLS` diagnostics stop firing.
+
 ## Installation
 
 The analyzers are **opt-in** and ship separately — installing `Trellis.Core` does not include them.

--- a/Trellis.Analyzers/README.md
+++ b/Trellis.Analyzers/README.md
@@ -6,7 +6,7 @@ Roslyn analyzers that keep Trellis usage safe, idiomatic, and review-friendly.
 
 ## Requirements
 
-Requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+). The analyzers are compiled against Roslyn 5.6; on an older host the compiler reports `CS9057` and silently skips them, so the `TRLS` diagnostics stop firing.
+Requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+). The analyzers are compiled against Roslyn 5.6; on an older host the compiler reports `CS9057` and skips them, so the `TRLS` diagnostics stop firing.
 
 ## Installation
 

--- a/Trellis.Analyzers/README.md
+++ b/Trellis.Analyzers/README.md
@@ -4,6 +4,10 @@
 
 Roslyn analyzers that keep Trellis usage safe, idiomatic, and review-friendly.
 
+## Requirements
+
+Requires the **.NET SDK 10.0.300 or later** (Roslyn 5.6+). The analyzers are compiled against Roslyn 5.6; on an older host the compiler reports `CS9057` and silently skips them, so the `TRLS` diagnostics stop firing.
+
 ## Installation
 
 The analyzers are **opt-in** and ship separately — installing `Trellis.Core` does not include them.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "10.0.203",
+    "version": "10.0.300",
     "rollForward": "latestFeature"
   },
   "test": {


### PR DESCRIPTION
Consolidates the six open Dependabot dependency PRs into a single change, plus the follow-up work needed to make one of them safe.

Closes #686, closes #687, closes #688, closes #689, closes #690, closes #680.

## Package updates

| Group | PR | Change |
| --- | --- | --- |
| microsoft-platform | #686 | `Microsoft.Extensions.*` / `Microsoft.AspNetCore.*` `10.0.9` → `10.0.10`; `Microsoft.Identity.Client` `4.85.2` → `4.87.0`; `Microsoft.Extensions.TimeProvider.Testing` `10.7.0` → `10.8.0` |
| ef-core | #687 | `Microsoft.EntityFrameworkCore*` `10.0.9` → `10.0.10` |
| roslyn | #688 | `Microsoft.CodeAnalysis.*` `5.3.0` → `5.6.0` |
| opentelemetry | #689 | `OpenTelemetry*` `1.16.0` → `1.17.0` |
| api-versioning | #690 | `Asp.Versioning.*` `10.0.0` → `10.0.1`; `Asp.Versioning.OpenApi` `10.0.0-rc.1` → `10.0.1` (prerelease → stable) |
| github-actions | #680 | `actions/setup-dotnet` `v5` → `v6` across 5 workflows |

### Version-skew fixes beyond Dependabot

The Dependabot groups left six packages behind at `10.0.9` even though their patterns matched. All six are direct `PackageReference`s in lockstep-versioned Microsoft families, so they are aligned to `10.0.10` here to avoid intra-family skew: `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Hosting.Abstractions`, `Microsoft.AspNetCore.Mvc.Testing`, `Microsoft.EntityFrameworkCore.Sqlite`, `Microsoft.EntityFrameworkCore.SqlServer`.

## ⚠️ Breaking change: minimum .NET SDK is now 10.0.300

The Roslyn bump is not a routine patch. Roslyn ships **+3 minor per SDK feature band** — NuGet publishes exactly `5.0.0`, `5.3.0`, `5.6.0`, and SDK `10.0.400` was measured shipping Roslyn `5.9.0`:

| Roslyn | SDK band |
| --- | --- |
| 5.0 | 10.0.1xx |
| 5.3 (previous) | 10.0.2xx |
| **5.6 (this PR)** | **10.0.3xx** |
| 5.9 | 10.0.4xx |

`Trellis.Analyzers.dll` now binds `Microsoft.CodeAnalysis, Version=5.6.0.0`, and because Roslyn is referenced with `PrivateAssets="all"` the **compiler host** must supply it.

This is broader than the opt-in analyzer package: `Trellis.Core`, `Trellis.Asp`, and `Trellis.EntityFrameworkCore` all ship **source generators** compiled against the same Roslyn. On an SDK 10.0.2xx host the compiler emits `CS9057` and silently skips them, so generated members never appear — surfacing as confusing "missing member" build errors rather than an obvious version complaint.

Accordingly:
- `global.json` raised `10.0.203` → `10.0.300` (`rollForward: latestFeature` retained, so 10.0.3xx and 10.0.4xx both satisfy it).
- New `## Requirements` sections in `README.md`, `Trellis.Analyzers/README.md`, and `Trellis.Analyzers/NUGET_README.md`.

## Security pins retained

The two deliberate transitive pins are unchanged — `Microsoft.OpenApi` `2.7.5` (GHSA-v5pm-xwqc-g5wc) and `SQLitePCLRaw.lib.e_sqlite3` `3.50.3` (GHSA-2m69-gcr7-jv3q). Only the version numbers quoted in their rationale comments were refreshed. `dotnet restore` reports no `NU1605` downgrade and no `NU1903` advisory, so both pins still resolve cleanly against the new versions.

`actions/setup-dotnet@v6` was checked for input-contract changes: v6.0.0 is an ESM/dependency migration only, so `dotnet-version`, `global-json-file`, and `source-url` all still work. The one behavioural change (`global.json` rollForward validation) landed in v5.4.0 and the fully-qualified `10.0.300` pin satisfies it.

## Validation

- `dotnet restore` — clean, 0 NuGet warnings
- `dotnet build Trellis.slnx -c Release --no-incremental` — **0 warnings, 0 errors**
- `dotnet test Trellis.slnx -c Release` — **7366 total, 7351 succeeded, 15 skipped, 0 failed** (exactly matches the pre-change baseline)