### PR TITLE
Stop Nerdbank.GitVersioning from corrupting $GITHUB_ENV during parallel builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,26 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!--
+      Stop Nerdbank.GitVersioning from exporting cloud build variables from MSBuild.
+
+      Its SetCloudBuildVersionVars target runs once per project and appends to the file named by
+      $GITHUB_ENV. Because .NET resolves FileMode.Append on Linux to a seek-to-end at open time
+      rather than the O_APPEND flag, parallel MSBuild nodes write at the same stale offset and tear
+      each other's lines, which the runner rejects with "Unable to process file command 'env'".
+
+      The workflows that need these variables already run `nbgv cloud` (or dotnet/nbgv) as a
+      dedicated single-threaded step, so the per-project export is redundant work that only adds
+      the race. Nothing in this repo reads GitAssemblyInformationalVersion or GitBuildVersion as an
+      MSBuild property, and version stamping is unaffected: it comes from GetBuildVersion, not from
+      this target.
+
+      Upstream added a file lock in dotnet/Nerdbank.GitVersioning@329154d7, but as of 3.10.91 no
+      stable release carries it. Keep this set regardless of version — the export stays redundant
+      once the fix ships, and the lock only serializes writes we do not need to make.
+    -->
+    <NBGV_SetCloudBuildVersionVars>false</NBGV_SetCloudBuildVersionVars>
   </PropertyGroup>
 
   <PropertyGroup Label="Coverage">


### PR DESCRIPTION
## Problem

The `Build` workflow failed on #685 with:

```
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '9+41dbad4753'
```

The AOT publish it was running had **already succeeded** with zero warnings under `TreatWarningsAsErrors=true`. The commit under test changed two XML doc-comment lines and nothing else, so a green build was reported red.

## Root cause

`Nerdbank.GitVersioning` is a `PackageReference` in every project (`Directory.Build.props`), so its `SetCloudBuildVersionVars` target runs `AfterTargets=""GetBuildVersion""` **once per project** and appends to the file named by `$GITHUB_ENV`.

.NET resolves `FileMode.Append` on Linux to a seek-to-end *at open time* rather than to the `O_APPEND` flag, so parallel MSBuild nodes write at the same stale offset and tear each other's lines. `dotnet publish` of `Showcase.MinimalApi` builds ~16 dependency projects concurrently, and one line was split mid-value:

```
GitAssemblyInformationalVersion=3.0.0-alpha.43   <- torn here
9+41dbad4753                                     <- orphan, no '=' -> "Invalid format"
```

The race is timing dependent, which is why this was the first failure in thirty runs.

## Fix

Set `NBGV_SetCloudBuildVersionVars=false` — NBGV's own documented opt-out, and the exact gate in that target's `Condition`.

The workflows that need these variables already run `nbgv cloud` (or `dotnet/nbgv`) as a dedicated single-threaded step, so the per-project export is **redundant work that adds only the race**.

It lives in `Directory.Build.props` rather than in workflow `env:` blocks because all five workflows build under Actions and are exposed. Two of them — `codeql.yml` and `documentation.yml` — build *without* an `nbgv cloud` step, so a workflow-level fix would have to be repeated five times and would silently regress the moment a sixth workflow is added.

## Verification

**Version stamping is untouched.** `GetBuildVersion` reports byte-identical values with the export enabled and disabled:

| Property | Enabled | Disabled |
|---|---|---|
| `AssemblyInformationalVersion` | `3.0.0-alpha.440+ad50c96b35` | `3.0.0-alpha.440+ad50c96b35` |
| `Version` / `PackageVersion` / `NuGetPackageVersion` | `3.0.0-alpha.440.gad50c96b35` | `3.0.0-alpha.440.gad50c96b35` |
| `AssemblyVersion` | `3.0.0.0` | `3.0.0.0` |
| `FileVersion` | `3.0` | `3.0` |

`dotnet pack` still produces correctly versioned `3.0.0-alpha.440.gad50c96b35` packages, so the publish pipeline is safe.

**The suppression works.** Running the target with `GITHUB_ACTIONS=true` and `$GITHUB_ENV` pointed at a temp file:

- **Enabled** — writes `GitAssemblyInformationalVersion`, `GitBuildVersion`, `GitBuildVersionSimple`, the same three variables in the failing job's `env:` block.
- **Disabled** — writes **zero bytes**.

**Nothing consumes them.** No `.props`, `.targets`, `.csproj`, `.yml`, `.ps1` or `.sh` in the repo reads `GitAssemblyInformationalVersion` or `GitBuildVersion` as an MSBuild property.

Release build: 0 warnings, 0 errors.

## Upstream

Fixed with a file lock in dotnet/Nerdbank.GitVersioning@329154d7 (2026-07-26, one day before our failure); its XML doc names this exact runner error. No stable release carries it — `3.10.91` predates the commit and only `3.11.93-beta` includes it. Moving the tool that stamps published packages onto a beta is a worse trade than disabling a redundant export, and the export stays redundant after the fix ships, so this stays regardless of version.
