### PR TITLE
feat: add idempotency store conformance suite and Cosmos DB store

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,0 @@
-﻿coverage:
-  status:
-    project:
-      default:
-        target: 80

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ If you cannot answer any of these, stop and load the missing reference before co
 When adding a new `services.AddTrellisXxx()` or `services.AddXxxDispatch()` style extension, first decide whether it needs a builder slot at all:
 
 - **Composition-root features** — anything an application author turns on (pipeline behaviors, dispatchers, actor providers, outbox/inbox) — **must** get a `TrellisServiceBuilder.UseXxx(...)` slot.
-- **Leaf, store, and adapter-author extension points** get **no** slot. These are called by another `AddXxx` that *is* surfaced, or by an adapter author wiring a non-shipped provider. Existing examples: `AddInMemoryIdempotencyStore`, `AddTrellisRouteConstraint`/`AddTrellisRouteConstraints`, and `AddTransactionalCommandBehavior` (provider-neutral; invoked by `AddTrellisUnitOfWork<TContext>()`, which is surfaced as `UseEntityFrameworkUnitOfWork<TContext>()`).
+- **Leaf, store, and adapter-author extension points** get **no** slot. These are called by another `AddXxx` that *is* surfaced, or by an adapter author wiring a non-shipped provider. Existing examples: `AddInMemoryIdempotencyStore`, `AddCosmosIdempotencyStore`, `AddTrellisRouteConstraint`/`AddTrellisRouteConstraints`, and `AddTransactionalCommandBehavior` (provider-neutral; invoked by `AddTrellisUnitOfWork<TContext>()`, which is surfaced as `UseEntityFrameworkUnitOfWork<TContext>()`).
 
 If the new helper falls in the first category, the work is **not complete** until:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `Trellis.Asp.Idempotency.Cosmos`, a production-grade idempotency store
+
+The first durable `IIdempotencyStore` Trellis ships. `InMemoryIdempotencyStore` is documented as unsafe across
+instances and process restarts, so until now every multi-replica deployment had to write its own.
+
+Cosmos DB maps onto the contract unusually well: `CreateItem` returns `409 Conflict` on a duplicate id within a
+partition — decided on the primary replica — which is exactly the atomic reserve the contract needs; native ETags
+give conditional complete and abandon without scripting; and per-item `ttl` reclaims storage with no sweeper
+process. Unlike a Redis cache under `allkeys-lru`, it never silently evicts a live reservation.
+
+Two design points are worth calling out because they are the ones that make it correct rather than merely working:
+
+- **Session consistency is sufficient.** The read following a `409` may be served by a replica that has not yet
+  seen another instance's write. That cannot cause a double execution, because the store never grants a
+  reservation on the strength of a read — only an atomic create or an ETag-conditional replace grants one. A stale
+  read produces `412`/`404` on the follow-up write and the operation retries. The worst observable effect is a
+  spurious `AlreadyInFlight`.
+- **Expiry is enforced in-process.** Cosmos DB deletes expired items on a best-effort background sweep, so an item
+  can outlive its `ttl` and still be returned by a read. The store re-checks its own `reservedAt`/`completedAt`
+  timestamps and treats a TTL-expired snapshot as absent; per-item `ttl` is only a storage backstop. Because
+  deletion may only ever fall on a document the store's own rules have already made unreachable, a *reserved*
+  document never expires — it must keep rejecting a same-key request carrying a different body — while a completed
+  one expires shortly after its TTL.
+
+The store uses the Cosmos DB *stream* APIs rather than the typed overloads, because a `409` is the normal outcome
+of every replay and the typed overloads raise `CosmosException` for it — exception throwing on the hot path.
+
+Registered with `services.AddCosmosIdempotencyStore(...)`, and provisioned with
+`CosmosIdempotencyContainer.CreateIfNotExistsAsync(...)`, which sets the `/scope` partition key and enables TTL
+(per-item `ttl` is ignored on a container without it). As a store registration it deliberately has **no**
+`TrellisServiceBuilder.UseXxx()` slot, matching `AddInMemoryIdempotencyStore()`.
+
+Verified by the new conformance suite against a real Cosmos DB emulator — all 17 rules, plus emulator-free tests
+for the decision ordering and key encoding. Tests requiring the emulator are marked
+`[Trait("Category", "Integration")]` and excluded from CI, matching the existing SQL Server-backed tests.
+Idempotency keys are Base64Url-encoded into item ids because
+client-supplied keys may contain `/`, `\`, `?`, or `#`, which Cosmos DB forbids in an id.
+
+### Added — `Trellis.Testing.Idempotency`, a conformance suite for `IIdempotencyStore`
+
+`Trellis.Asp` ships exactly one `IIdempotencyStore` — `InMemoryIdempotencyStore`, whose own documentation
+states it is "not safe across multiple instances or process restarts". Every multi-replica deployment therefore
+writes its own store over Redis, Cosmos DB, or a relational database. The contract those stores must satisfy is
+subtle and, critically, **every violation fails silently**: a store that reserves non-atomically lets two racing
+callers both execute the handler, and an `AbandonAsync` that deletes unconditionally destroys a response
+`CompleteAsync` already persisted. Nothing throws; the symptom is a customer charged twice, discovered weeks later.
+
+The new package turns the contract into an executable specification. A store author writes one class:
+
+```csharp
+public sealed class RedisIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    protected override TimeSpan ReservationTimeout => TimeSpan.FromSeconds(2);
+    protected override TimeSpan Ttl => TimeSpan.FromSeconds(4);
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new RedisIdempotencyStore(_multiplexer, options));
+}
+```
+
+and inherits 17 rules covering reserve, replay, fingerprint mismatch, scope isolation, reservation takeover, TTL
+expiry, abandon semantics, and atomicity under concurrent load. Time is handled through an `AdvanceAsync` hook, so
+a `TimeProvider`-based store advances a fake clock and runs instantly while a store whose expiry a remote server
+enforces shortens its timeouts and delays for real. Each test instance gets a unique `Scope`, so suites run in
+parallel against shared Redis or Cosmos DB infrastructure.
+
+`InMemoryIdempotencyStore` now runs the published suite, keeping the shipped reference implementation honest
+against the same contract third parties are held to. The suite is itself covered by meta-tests that run individual
+rules against deliberately broken stores and assert each rule fails, so it cannot silently degrade into a suite
+that passes for everything.
+
+One trap the package removes: `IdempotencyResponseSnapshot` is a record whose `Headers` and `Body` compare by
+**reference**, so asserting snapshot equality passes only for a store that returns the very instance it was
+handed. Every serialising store would fail such an assertion for no good reason. The suite exposes `ShouldMatch`,
+which compares field by field.
+
 ### Added — builder slot for indirect (via) resource authorization
 
 `TrellisServiceBuilder` gains `UseRelatedResourceAuthorization<TMessage, TLeaf, TLeafId, TOwner, TOwnerId, TResponse>(extractOwnerId)`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,16 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.62.1" />
+    <!-- The Cosmos DB SDK uses Newtonsoft.Json internally but deliberately omits it from its
+         dependencies so consumers pin the version. Its build target fails without an explicit
+         reference. -->
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <!-- Attributes and extensibility surface only, for libraries that ship tests to consumers
+         rather than run them (Trellis.Testing.Idempotency). The full xunit.v3 package requires
+         OutputType=Exe and so cannot be referenced by a packable library. -->
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
   </ItemGroup>

--- a/Trellis.Asp.Idempotency.Cosmos/NUGET_README.md
+++ b/Trellis.Asp.Idempotency.Cosmos/NUGET_README.md
@@ -1,0 +1,48 @@
+# Trellis.Asp.Idempotency.Cosmos
+
+[![NuGet Package](https://img.shields.io/nuget/v/Trellis.Asp.Idempotency.Cosmos.svg)](https://www.nuget.org/packages/Trellis.Asp.Idempotency.Cosmos)
+
+Cosmos DB-backed `IIdempotencyStore` for the Trellis idempotency middleware — safe across
+instances and process restarts.
+
+## Installation
+```bash
+dotnet add package Trellis.Asp.Idempotency.Cosmos
+```
+
+## Quick Example
+```csharp
+// Provision once at startup: partitioned on /scope, TTL enabled.
+var database = (await cosmosClient.CreateDatabaseIfNotExistsAsync("billing")).Database;
+await CosmosIdempotencyContainer.CreateIfNotExistsAsync(database);
+
+builder.Services.AddSingleton(cosmosClient);
+builder.Services.AddTrellisIdempotency(o => o.MaxResponseBodyBytes = 64 * 1024);
+builder.Services.AddCosmosIdempotencyStore("billing");
+
+app.UseTrellisIdempotency();
+```
+
+## Why Cosmos DB
+
+| Contract requirement | Cosmos DB primitive |
+| --- | --- |
+| Atomic reserve | `CreateItem` → `409 Conflict` on duplicate id, decided on the primary replica |
+| Conditional complete / abandon | Native ETag `IfMatchEtag`, no scripting |
+| Expiry | Per-item `ttl`, no sweeper process |
+| No silent eviction | Never drops a live entry under memory pressure, unlike a Redis cache under `allkeys-lru` |
+
+## Key Features
+- **Correct under Session consistency** — reservations are granted only by an atomic create or an
+  ETag-conditional replace, never on the strength of a read, so a stale replica cannot cause a
+  double execution. Strong consistency is not required.
+- **Expiry enforced in-process** — Cosmos DB's TTL sweep is best-effort and can return an item past
+  its `ttl`, so the store re-checks its own timestamps rather than trusting the service.
+- **No exceptions on the hot path** — uses the stream APIs, because a `409` is the *normal* outcome
+  of every replay.
+- **Verified, not asserted** — passes all 17 rules of the `Trellis.Testing.Idempotency` conformance
+  suite against a real Cosmos DB emulator.
+
+## Documentation
+See the [API reference](https://github.com/xavierjohn/Trellis/blob/main/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md)
+for the document model, partitioning and RU-cost guidance, and the concurrency protocol.

--- a/Trellis.Asp.Idempotency.Cosmos/README.md
+++ b/Trellis.Asp.Idempotency.Cosmos/README.md
@@ -1,0 +1,58 @@
+# Trellis.Asp.Idempotency.Cosmos
+
+[![NuGet Package](https://img.shields.io/nuget/v/Trellis.Asp.Idempotency.Cosmos.svg)](https://www.nuget.org/packages/Trellis.Asp.Idempotency.Cosmos)
+
+Cosmos DB-backed `IIdempotencyStore` for the Trellis idempotency middleware — safe across
+instances and process restarts.
+
+## Installation
+```bash
+dotnet add package Trellis.Asp.Idempotency.Cosmos
+```
+
+## Quick Example
+```csharp
+// Provision once at startup: partitioned on /scope, TTL enabled.
+var database = (await cosmosClient.CreateDatabaseIfNotExistsAsync("billing")).Database;
+await CosmosIdempotencyContainer.CreateIfNotExistsAsync(database);
+
+builder.Services.AddSingleton(cosmosClient);
+builder.Services.AddTrellisIdempotency(o => o.MaxResponseBodyBytes = 64 * 1024);
+builder.Services.AddCosmosIdempotencyStore("billing");
+
+app.UseTrellisIdempotency();
+```
+
+## Why Cosmos DB
+
+| Contract requirement | Cosmos DB primitive |
+| --- | --- |
+| Atomic reserve | `CreateItem` → `409 Conflict` on duplicate id, decided on the primary replica |
+| Conditional complete / abandon | Native ETag `IfMatchEtag`, no scripting |
+| Expiry | Per-item `ttl`, no sweeper process |
+| No silent eviction | Never drops a live entry under memory pressure, unlike a Redis cache under `allkeys-lru` |
+
+## Key Features
+- **Correct under Session consistency** — reservations are granted only by an atomic create or an
+  ETag-conditional replace, never on the strength of a read, so a stale replica cannot cause a
+  double execution. Strong consistency is not required.
+- **Expiry enforced in-process** — Cosmos DB's TTL sweep is best-effort and can return an item past
+  its `ttl`, so the store re-checks its own timestamps rather than trusting the service.
+- **No exceptions on the hot path** — uses the stream APIs, because a `409` is the *normal* outcome
+  of every replay.
+- **Verified, not asserted** — passes all 17 rules of the `Trellis.Testing.Idempotency` conformance
+  suite against a real Cosmos DB emulator.
+
+## Running the tests
+
+Tests needing the emulator are marked `[Trait("Category", "Integration")]` and are excluded from
+default and CI runs. With the Azure Cosmos DB emulator running on `https://localhost:8081/`:
+
+```powershell
+dotnet test Trellis.Asp.Idempotency.Cosmos/tests/Trellis.Asp.Idempotency.Cosmos.Tests.csproj `
+  --filter-trait "Category=Integration"
+```
+
+## Documentation
+See the [API reference](https://github.com/xavierjohn/Trellis/blob/main/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md)
+for the document model, partitioning and RU-cost guidance, and the concurrency protocol.

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyContainer.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyContainer.cs
@@ -1,0 +1,64 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+/// <summary>
+/// Provisioning helper for the container <see cref="CosmosIdempotencyStore"/> expects.
+/// </summary>
+public static class CosmosIdempotencyContainer
+{
+    /// <summary>Partition key path the store requires.</summary>
+    public const string PartitionKeyPath = "/scope";
+
+    /// <summary>
+    /// Creates the idempotency container if it does not already exist, with the partition key and
+    /// TTL configuration the store requires.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per-item <c>ttl</c> is ignored unless the container enables TTL, so a container created
+    /// without <see cref="ContainerProperties.DefaultTimeToLive"/> would accumulate idempotency
+    /// entries forever. This helper sets it to <c>-1</c>, which enables TTL but expires nothing by
+    /// default, leaving each item's own <c>ttl</c> in control.
+    /// </para>
+    /// <para>
+    /// Partitioning by scope keeps every operation for one key inside a single logical partition,
+    /// which is what makes the store's create-or-conditionally-replace protocol atomic. Because
+    /// scope is derived from the actor or tenant, keys spread evenly across partitions in
+    /// multi-tenant hosts. A host that resolves every request to one shared scope — for example by
+    /// mounting the middleware before authentication, so everything falls back to
+    /// <c>anonymous</c> — would concentrate all traffic on one partition and hit its throughput
+    /// limit.
+    /// </para>
+    /// </remarks>
+    /// <param name="database">Database to create the container in.</param>
+    /// <param name="containerId">Container id. Defaults to <c>idempotency</c>.</param>
+    /// <param name="throughput">
+    /// Optional manual throughput in RU/s. Leave <c>null</c> to inherit database-level or
+    /// autoscale throughput.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The existing or newly created container.</returns>
+    public static async Task<Container> CreateIfNotExistsAsync(
+        Database database,
+        string containerId = "idempotency",
+        int? throughput = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(database);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerId);
+
+        var properties = new ContainerProperties(containerId, PartitionKeyPath)
+        {
+            DefaultTimeToLive = -1,
+        };
+
+        var response = await database.CreateContainerIfNotExistsAsync(
+            properties, throughput, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return response.Container;
+    }
+}

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyDecision.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyDecision.cs
@@ -1,0 +1,82 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos;
+
+using System;
+
+/// <summary>
+/// What <see cref="CosmosIdempotencyStore"/> should do with an existing item.
+/// </summary>
+internal enum IdempotencyDocumentAction
+{
+    /// <summary>Return the stored snapshot; the handler must not run again.</summary>
+    Replay,
+
+    /// <summary>The key is in use by a request with a different body.</summary>
+    BodyHashMismatch,
+
+    /// <summary>A live reservation is held by another request.</summary>
+    AlreadyInFlight,
+
+    /// <summary>The reservation has timed out; a same-body retry may claim it.</summary>
+    TakeOver,
+
+    /// <summary>The completed entry has outlived its TTL and must behave as if it were gone.</summary>
+    TreatAsAbsent,
+}
+
+/// <summary>Outcome of classifying an existing item against an incoming request.</summary>
+/// <param name="Action">What the store should do next.</param>
+/// <param name="RetryAfter">
+/// How long the caller should wait, meaningful only for
+/// <see cref="IdempotencyDocumentAction.AlreadyInFlight"/>.
+/// </param>
+internal readonly record struct IdempotencyDocumentDecision(
+    IdempotencyDocumentAction Action,
+    TimeSpan RetryAfter);
+
+/// <summary>
+/// The store's decision logic, kept free of Cosmos DB types so it can be tested exhaustively
+/// without an emulator and so the ordering rules are reviewable in one place.
+/// </summary>
+internal static class CosmosIdempotencyDecision
+{
+    /// <summary>
+    /// Decides how to treat <paramref name="document"/> for a request carrying
+    /// <paramref name="fingerprint"/>.
+    /// </summary>
+    /// <remarks>
+    /// The two branches check fingerprint at deliberately different points, matching the contract:
+    /// a <em>completed</em> entry is tested for TTL expiry first, so an expired snapshot behaves as
+    /// absent and a key may legitimately be reused with a new body; a <em>reserved</em> entry is
+    /// tested for fingerprint first, so a different body is rejected even after the reservation has
+    /// timed out and would otherwise be taken over.
+    /// </remarks>
+    /// <param name="document">The item read from Cosmos DB.</param>
+    /// <param name="fingerprint">Fingerprint of the incoming request.</param>
+    /// <param name="now">Current time.</param>
+    /// <param name="options">Configured TTL and reservation timeout.</param>
+    public static IdempotencyDocumentDecision Classify(
+        CosmosIdempotencyDocument document,
+        string fingerprint,
+        DateTimeOffset now,
+        IdempotencyOptions options)
+    {
+        if (document.Snapshot is not null)
+        {
+            var completedAt = DateTimeOffset.FromUnixTimeMilliseconds(document.CompletedAtUnixMs ?? 0);
+            if (now - completedAt >= options.Ttl)
+                return new(IdempotencyDocumentAction.TreatAsAbsent, TimeSpan.Zero);
+
+            return string.Equals(document.Fingerprint, fingerprint, StringComparison.Ordinal)
+                ? new(IdempotencyDocumentAction.Replay, TimeSpan.Zero)
+                : new(IdempotencyDocumentAction.BodyHashMismatch, TimeSpan.Zero);
+        }
+
+        if (!string.Equals(document.Fingerprint, fingerprint, StringComparison.Ordinal))
+            return new(IdempotencyDocumentAction.BodyHashMismatch, TimeSpan.Zero);
+
+        var elapsed = now - DateTimeOffset.FromUnixTimeMilliseconds(document.ReservedAtUnixMs);
+        return elapsed >= options.ReservationTimeout
+            ? new(IdempotencyDocumentAction.TakeOver, TimeSpan.Zero)
+            : new(IdempotencyDocumentAction.AlreadyInFlight, options.ReservationTimeout - elapsed);
+    }
+}

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyDecision.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyDecision.cs
@@ -27,7 +27,8 @@ internal enum IdempotencyDocumentAction
 /// <param name="Action">What the store should do next.</param>
 /// <param name="RetryAfter">
 /// How long the caller should wait, meaningful only for
-/// <see cref="IdempotencyDocumentAction.AlreadyInFlight"/>.
+/// <see cref="IdempotencyDocumentAction.AlreadyInFlight"/>, where it always falls within
+/// <c>(0, ReservationTimeout]</c>.
 /// </param>
 internal readonly record struct IdempotencyDocumentDecision(
     IdempotencyDocumentAction Action,
@@ -75,8 +76,16 @@ internal static class CosmosIdempotencyDecision
             return new(IdempotencyDocumentAction.BodyHashMismatch, TimeSpan.Zero);
 
         var elapsed = now - DateTimeOffset.FromUnixTimeMilliseconds(document.ReservedAtUnixMs);
-        return elapsed >= options.ReservationTimeout
-            ? new(IdempotencyDocumentAction.TakeOver, TimeSpan.Zero)
-            : new(IdempotencyDocumentAction.AlreadyInFlight, options.ReservationTimeout - elapsed);
+        if (elapsed >= options.ReservationTimeout)
+            return new(IdempotencyDocumentAction.TakeOver, TimeSpan.Zero);
+
+        // A reservation written by a host whose clock runs ahead lands in the future, making
+        // elapsed negative and the remainder longer than the timeout itself. Clamping keeps
+        // RetryAfter within (0, ReservationTimeout] as the contract requires, so a client is never
+        // told to wait longer than the reservation can possibly live.
+        var retryAfter = options.ReservationTimeout - elapsed;
+        return new(
+            IdempotencyDocumentAction.AlreadyInFlight,
+            retryAfter > options.ReservationTimeout ? options.ReservationTimeout : retryAfter);
     }
 }

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyDocument.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyDocument.cs
@@ -1,0 +1,110 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Persisted shape of an idempotency entry. Mirrors the state machine of the in-process
+/// reference store: an entry is <em>reserved</em> while <see cref="Snapshot"/> is <c>null</c> and
+/// <em>completed</em> once it is set.
+/// </summary>
+/// <remarks>
+/// Cosmos DB adds its own <c>_etag</c>, <c>_ts</c>, <c>_rid</c>, and <c>_self</c> properties to
+/// every item. They are deliberately absent here: unknown properties are ignored on read, and the
+/// concurrency token is taken from the response headers rather than the body, so a replace never
+/// has to echo them back.
+/// </remarks>
+internal sealed class CosmosIdempotencyDocument
+{
+    /// <summary>Base64Url-encoded idempotency key. Cosmos DB item ids may not contain <c>/ \ ? #</c>.</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Partition key. The idempotency scope, which already isolates tenants and actors.</summary>
+    [JsonPropertyName("scope")]
+    public string Scope { get; set; } = string.Empty;
+
+    /// <summary>The un-encoded idempotency key, retained so stored items are readable in Data Explorer.</summary>
+    [JsonPropertyName("key")]
+    public string Key { get; set; } = string.Empty;
+
+    /// <summary>Fingerprint of the request that created or currently holds this entry.</summary>
+    [JsonPropertyName("fingerprint")]
+    public string Fingerprint { get; set; } = string.Empty;
+
+    /// <summary>Token identifying the outstanding reservation; <c>null</c> once completed.</summary>
+    [JsonPropertyName("reservationId")]
+    public string? ReservationId { get; set; }
+
+    /// <summary>When the current reservation was taken, in Unix milliseconds.</summary>
+    [JsonPropertyName("reservedAt")]
+    public long ReservedAtUnixMs { get; set; }
+
+    /// <summary>When the response was recorded, in Unix milliseconds; <c>null</c> while reserved.</summary>
+    [JsonPropertyName("completedAt")]
+    public long? CompletedAtUnixMs { get; set; }
+
+    /// <summary>The captured response; <c>null</c> while reserved.</summary>
+    [JsonPropertyName("snapshot")]
+    public CosmosResponseSnapshotDocument? Snapshot { get; set; }
+
+    /// <summary>
+    /// Cosmos DB per-item time-to-live in seconds, or <see cref="NeverExpires"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A storage-reclamation backstop only — the store never trusts it for correctness, because
+    /// Cosmos DB deletes expired items on a best-effort background sweep and can still return one.
+    /// <see cref="ReservedAtUnixMs"/> and <see cref="CompletedAtUnixMs"/> are authoritative.
+    /// </para>
+    /// <para>
+    /// Consequently, deletion may only ever be applied to a document that the store's own rules
+    /// have already made unreachable. That holds for a <em>completed</em> document, which is
+    /// treated as absent once it outlives the configured TTL, but not for a <em>reserved</em> one:
+    /// a reserved document is answerable forever, because a request reusing the key with a
+    /// different body must keep being rejected. A reserved document therefore carries
+    /// <see cref="NeverExpires"/>; were it given a finite value, the store's answer would come to
+    /// depend on whether a background sweep had happened to run.
+    /// </para>
+    /// </remarks>
+    [JsonPropertyName("ttl")]
+    public int Ttl { get; set; }
+
+    /// <summary>
+    /// The Cosmos DB per-item <c>ttl</c> meaning "never expire", which overrides the container's
+    /// <c>DefaultTimeToLive</c>.
+    /// </summary>
+    public const int NeverExpires = -1;
+}
+
+/// <summary>Persisted form of <see cref="IdempotencyResponseSnapshot"/>.</summary>
+internal sealed class CosmosResponseSnapshotDocument
+{
+    /// <summary>HTTP status code of the captured response.</summary>
+    [JsonPropertyName("statusCode")]
+    public int StatusCode { get; set; }
+
+    /// <summary>Captured response headers.</summary>
+    [JsonPropertyName("headers")]
+    public Dictionary<string, string[]> Headers { get; set; } = [];
+
+    /// <summary>Captured response body. Serialized as base64 by System.Text.Json.</summary>
+    [JsonPropertyName("body")]
+    public byte[] Body { get; set; } = [];
+
+    /// <summary>
+    /// Fingerprint recorded on the snapshot. Stored separately from
+    /// <see cref="CosmosIdempotencyDocument.Fingerprint"/> so a replay returns exactly what
+    /// <see cref="IIdempotencyStore.CompleteAsync"/> was handed rather than a reconstruction.
+    /// </summary>
+    [JsonPropertyName("fingerprint")]
+    public string Fingerprint { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Source-generated serialization context. Reflection-based serialization would trip the
+/// repository-wide AOT and trim analyzers, which are errors here.
+/// </summary>
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(CosmosIdempotencyDocument))]
+internal sealed partial class CosmosIdempotencyJsonContext : JsonSerializerContext;

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyServiceCollectionExtensions.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyServiceCollectionExtensions.cs
@@ -1,0 +1,76 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos;
+
+using System;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Service-registration extensions for the Cosmos DB idempotency store.
+/// </summary>
+/// <remarks>
+/// These are store registrations, not composition-root features, so they deliberately have no
+/// matching <c>TrellisServiceBuilder.UseXxx()</c> slot — exactly like
+/// <c>AddInMemoryIdempotencyStore()</c>. Choosing a backing store is a one-line decision an
+/// application makes alongside <c>AddTrellisIdempotency()</c>; it does not participate in pipeline
+/// ordering, so a builder slot would add surface without removing a decision.
+/// </remarks>
+public static class CosmosIdempotencyServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers <see cref="CosmosIdempotencyStore"/> as the <see cref="IIdempotencyStore"/>,
+    /// resolving its container through <paramref name="containerFactory"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload when the container is provisioned at startup, shared with other
+    /// components, or configured in a way the id-based overload cannot express. The container must
+    /// be partitioned on <see cref="CosmosIdempotencyContainer.PartitionKeyPath"/> with TTL
+    /// enabled; <see cref="CosmosIdempotencyContainer.CreateIfNotExistsAsync"/> does both.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="containerFactory">Resolves the container to store entries in.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddCosmosIdempotencyStore(
+        this IServiceCollection services,
+        Func<IServiceProvider, Container> containerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(containerFactory);
+
+        services.AddSingleton<IIdempotencyStore>(sp => new CosmosIdempotencyStore(
+            containerFactory(sp),
+            sp.GetRequiredService<IOptions<IdempotencyOptions>>().Value,
+            sp.GetService<TimeProvider>()));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers <see cref="CosmosIdempotencyStore"/> against a container addressed by database
+    /// and container id, resolving <see cref="CosmosClient"/> from the container.
+    /// </summary>
+    /// <remarks>
+    /// This overload only addresses the container; it does not create it. Cosmos DB returns an
+    /// existing container handle without a network call, so a container that was never provisioned
+    /// — or was provisioned without TTL enabled — surfaces as a failure on the first idempotent
+    /// request rather than at startup. Call
+    /// <see cref="CosmosIdempotencyContainer.CreateIfNotExistsAsync"/> during startup, or deploy
+    /// the container as infrastructure.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="databaseId">Cosmos DB database id.</param>
+    /// <param name="containerId">Container id. Defaults to <c>idempotency</c>.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddCosmosIdempotencyStore(
+        this IServiceCollection services,
+        string databaseId,
+        string containerId = "idempotency")
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(databaseId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerId);
+
+        return services.AddCosmosIdempotencyStore(sp =>
+            sp.GetRequiredService<CosmosClient>().GetContainer(databaseId, containerId));
+    }
+}

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyStore.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyStore.cs
@@ -1,0 +1,369 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos;
+
+using System;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+/// <summary>
+/// Cosmos DB-backed <see cref="IIdempotencyStore"/>, safe across instances and process restarts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Atomicity.</b> A reservation is claimed with a single <c>CreateItem</c>: Cosmos DB rejects a
+/// duplicate id within a partition with <c>409 Conflict</c>, executed on the partition's primary
+/// replica, so exactly one concurrent caller can win. Every subsequent mutation — taking over a
+/// timed-out reservation, recording a response, releasing a slot — is an ETag-conditional replace
+/// or delete, so a caller whose view of the item is stale is rejected with <c>412</c> and retries
+/// rather than clobbering a newer state.
+/// </para>
+/// <para>
+/// <b>Session consistency is safe here.</b> Reads on a Session-consistency account may be served
+/// by a replica that has not yet seen another instance's write, so the read following a <c>409</c>
+/// can return a stale item — or, briefly, <c>404</c>. Neither can cause a double execution,
+/// because the store never grants a reservation on the strength of a read: it grants only when an
+/// atomic create succeeds, or when an ETag-conditional replace succeeds. A stale read simply
+/// produces a <c>412</c> or <c>404</c> on the follow-up write, and the operation retries. The
+/// worst observable effect is a spurious <c>AlreadyInFlight</c>, which the caller retries.
+/// </para>
+/// <para>
+/// <b>Expiry is enforced here, not by Cosmos DB.</b> Per-item <c>ttl</c> is set as a storage
+/// reclamation backstop only. Cosmos DB deletes expired items on a best-effort background sweep,
+/// so an item can outlive its <c>ttl</c> and still be returned by a read; the store therefore
+/// re-checks the stored timestamps on every read and treats a TTL-expired snapshot as absent.
+/// Deletion is only ever allowed to fall on a document the store's own rules have already made
+/// unreachable, so a <em>reserved</em> document never expires — see
+/// <see cref="CosmosIdempotencyDocument.Ttl"/>. Reservations are removed by
+/// <see cref="AbandonAsync"/> or superseded on completion, so the only documents that accumulate
+/// are those whose process was killed between reserving and responding.
+/// </para>
+/// <para>
+/// <b>Reservation timeout depends on host clocks.</b> Takeover compares this instance's clock
+/// against a <c>reservedAt</c> written by another instance, so the effective timeout is the
+/// configured <see cref="IdempotencyOptions.ReservationTimeout"/> shifted by the clock skew
+/// between the two hosts. This does not add a failure mode — the timeout is a liveness bound that
+/// already permits taking over a handler that is merely slow rather than dead — but it does move
+/// the boundary. Set <see cref="IdempotencyOptions.ReservationTimeout"/> comfortably above the
+/// slowest expected handler <em>plus</em> the skew tolerated across the fleet, and keep hosts
+/// NTP-synchronised. A single-instance store such as <c>InMemoryIdempotencyStore</c> reads one
+/// clock and is not exposed to this.
+/// </para>
+/// <para>
+/// <b>Cost.</b> Request-unit charge scales with item size, so an idempotency entry costs roughly
+/// what its captured response body costs to write. With
+/// <see cref="IdempotencyOptions.MaxResponseBodyBytes"/> at its 1 MiB default a single completion
+/// can exceed 100 RU. Lower the cap, or keep large payloads out of the snapshot.
+/// </para>
+/// </remarks>
+public sealed class CosmosIdempotencyStore : IIdempotencyStore
+{
+    private const int MaxAttempts = 8;
+
+    private readonly Container _container;
+    private readonly IdempotencyOptions _options;
+    private readonly TimeProvider _time;
+    private readonly int _ttlSeconds;
+
+    /// <summary>
+    /// Creates a store over an existing Cosmos DB container.
+    /// </summary>
+    /// <param name="container">
+    /// Container whose partition key path is <c>/scope</c> and whose <c>DefaultTimeToLive</c> is
+    /// enabled, so per-item <c>ttl</c> takes effect. See
+    /// <see cref="CosmosIdempotencyContainer.CreateIfNotExistsAsync"/>.
+    /// </param>
+    /// <param name="options">Idempotency options supplying TTL and reservation timeout.</param>
+    /// <param name="timeProvider">Clock, defaulting to <see cref="TimeProvider.System"/>.</param>
+    public CosmosIdempotencyStore(
+        Container container, IdempotencyOptions options, TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(container);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _container = container;
+        _options = options;
+        _time = timeProvider ?? TimeProvider.System;
+
+        // Applied only to completed documents, whose logical lifetime is bounded: Classify treats
+        // one as absent once it outlives Ttl measured from completedAt, so deleting it after that
+        // cannot change an answer. A minute of slack absorbs clock skew between the app and the
+        // service. Reserved documents are answerable indefinitely and so never expire; see
+        // CosmosIdempotencyDocument.Ttl.
+        _ttlSeconds = (int)Math.Min(int.MaxValue, Math.Ceiling(_options.Ttl.TotalSeconds) + 60);
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask<IdempotencyReservationOutcome> TryReserveAsync(
+        string scope, string key, string fingerprint, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(fingerprint);
+
+        var id = EncodeId(key);
+        var partitionKey = new PartitionKey(scope);
+
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var reservation = NewReservation(id, scope, key, fingerprint);
+            using (var created = await _container.CreateItemStreamAsync(
+                Serialize(reservation), partitionKey, NoContentResponse, cancellationToken)
+                .ConfigureAwait(false))
+            {
+                if (created.IsSuccessStatusCode)
+                    return new IdempotencyReservationOutcome.Reserved(reservation.ReservationId!);
+
+                if (created.StatusCode != HttpStatusCode.Conflict)
+                    created.EnsureSuccessStatusCode();
+            }
+
+            var existing = await ReadAsync(id, partitionKey, cancellationToken).ConfigureAwait(false);
+            if (existing is null)
+                continue; // Swept or not yet visible on this replica; try to claim it again.
+
+            var (document, etag) = existing.Value;
+            var decision = CosmosIdempotencyDecision.Classify(
+                document, fingerprint, _time.GetUtcNow(), _options);
+
+            switch (decision.Action)
+            {
+                case IdempotencyDocumentAction.Replay:
+                    return new IdempotencyReservationOutcome.Replay(ToSnapshot(document.Snapshot!));
+
+                case IdempotencyDocumentAction.BodyHashMismatch:
+                    return new IdempotencyReservationOutcome.BodyHashMismatch(document.Fingerprint);
+
+                case IdempotencyDocumentAction.AlreadyInFlight:
+                    return new IdempotencyReservationOutcome.AlreadyInFlight(decision.RetryAfter);
+
+                case IdempotencyDocumentAction.TakeOver:
+                case IdempotencyDocumentAction.TreatAsAbsent:
+                    var claim = NewReservation(id, scope, key, fingerprint);
+                    if (await TryReplaceAsync(claim, id, partitionKey, etag, cancellationToken)
+                        .ConfigureAwait(false))
+                    {
+                        return new IdempotencyReservationOutcome.Reserved(claim.ReservationId!);
+                    }
+
+                    continue; // Lost the race; re-read and re-decide.
+
+                default:
+                    throw new InvalidOperationException($"Unhandled decision '{decision.Action}'.");
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not reserve idempotency key after {MaxAttempts} attempts because the entry was " +
+            "concurrently modified on every attempt. This indicates extreme contention on a single key.");
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask CompleteAsync(
+        string scope,
+        string key,
+        string reservationId,
+        IdempotencyResponseSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(reservationId);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var id = EncodeId(key);
+        var partitionKey = new PartitionKey(scope);
+
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var existing = await ReadAsync(id, partitionKey, cancellationToken).ConfigureAwait(false);
+            if (existing is null)
+                return; // Never reserved, or already expired: best-effort, so nothing to do.
+
+            var (document, etag) = existing.Value;
+            if (!OwnsReservation(document, reservationId))
+                return; // Already completed, or this reservation was taken over.
+
+            document.ReservationId = null;
+            document.Snapshot = FromSnapshot(snapshot);
+            document.CompletedAtUnixMs = _time.GetUtcNow().ToUnixTimeMilliseconds();
+            document.Ttl = _ttlSeconds;
+
+            if (await TryReplaceAsync(document, id, partitionKey, etag, cancellationToken)
+                .ConfigureAwait(false))
+            {
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not record the idempotent response after {MaxAttempts} attempts because the " +
+            "entry was concurrently modified on every attempt. Failing loudly rather than silently " +
+            "dropping the snapshot, which would let a retry re-execute the handler.");
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask AbandonAsync(
+        string scope, string key, string reservationId, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentNullException.ThrowIfNull(key);
+        ArgumentNullException.ThrowIfNull(reservationId);
+
+        var id = EncodeId(key);
+        var partitionKey = new PartitionKey(scope);
+
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var existing = await ReadAsync(id, partitionKey, cancellationToken).ConfigureAwait(false);
+            if (existing is null)
+                return;
+
+            var (document, etag) = existing.Value;
+
+            // A completed entry is never deleted here. The middleware calls AbandonAsync from the
+            // failure paths around CompleteAsync, so an unconditional delete would destroy a
+            // response that was already durably recorded and let the retry re-run the handler.
+            if (!OwnsReservation(document, reservationId))
+                return;
+
+            using var deleted = await _container.DeleteItemStreamAsync(
+                id,
+                partitionKey,
+                new ItemRequestOptions { IfMatchEtag = etag },
+                cancellationToken).ConfigureAwait(false);
+
+            if (deleted.IsSuccessStatusCode || deleted.StatusCode == HttpStatusCode.NotFound)
+                return;
+
+            if (deleted.StatusCode != HttpStatusCode.PreconditionFailed)
+                deleted.EnsureSuccessStatusCode();
+        }
+
+        // Deliberately does not throw. The middleware calls AbandonAsync from its failure paths,
+        // so throwing here would mask the error that caused the abandon. Losing the release is
+        // self-healing: the reservation is taken over by the next same-key retry once
+        // ReservationTimeout elapses.
+    }
+
+    private static bool OwnsReservation(CosmosIdempotencyDocument document, string reservationId) =>
+        document.Snapshot is null
+        && string.Equals(document.ReservationId, reservationId, StringComparison.Ordinal);
+
+    private CosmosIdempotencyDocument NewReservation(
+        string id, string scope, string key, string fingerprint) =>
+        new()
+        {
+            Id = id,
+            Scope = scope,
+            Key = key,
+            Fingerprint = fingerprint,
+            ReservationId = Guid.NewGuid().ToString("N"),
+            ReservedAtUnixMs = _time.GetUtcNow().ToUnixTimeMilliseconds(),
+            Ttl = CosmosIdempotencyDocument.NeverExpires,
+        };
+
+    private async ValueTask<(CosmosIdempotencyDocument Document, string ETag)?> ReadAsync(
+        string id, PartitionKey partitionKey, CancellationToken cancellationToken)
+    {
+        using var response = await _container
+            .ReadItemStreamAsync(id, partitionKey, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return null;
+
+        response.EnsureSuccessStatusCode();
+
+        var document = JsonSerializer.Deserialize(
+            response.Content, CosmosIdempotencyJsonContext.Default.CosmosIdempotencyDocument);
+
+        return document is null ? null : (document, response.Headers.ETag);
+    }
+
+    private async ValueTask<bool> TryReplaceAsync(
+        CosmosIdempotencyDocument document,
+        string id,
+        PartitionKey partitionKey,
+        string etag,
+        CancellationToken cancellationToken)
+    {
+        using var response = await _container.ReplaceItemStreamAsync(
+            Serialize(document),
+            id,
+            partitionKey,
+            new ItemRequestOptions { IfMatchEtag = etag, EnableContentResponseOnWrite = false },
+            cancellationToken).ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode)
+            return true;
+
+        if (response.StatusCode is HttpStatusCode.PreconditionFailed or HttpStatusCode.NotFound)
+            return false;
+
+        response.EnsureSuccessStatusCode();
+        return false;
+    }
+
+    private static ItemRequestOptions NoContentResponse { get; } =
+        new() { EnableContentResponseOnWrite = false };
+
+    private static MemoryStream Serialize(CosmosIdempotencyDocument document)
+    {
+        var stream = new MemoryStream();
+        JsonSerializer.Serialize(
+            stream, document, CosmosIdempotencyJsonContext.Default.CosmosIdempotencyDocument);
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static IdempotencyResponseSnapshot ToSnapshot(CosmosResponseSnapshotDocument stored)
+    {
+        var headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, values) in stored.Headers)
+            headers[name] = values;
+
+        return new IdempotencyResponseSnapshot(
+            stored.StatusCode, headers, stored.Body, stored.Fingerprint);
+    }
+
+    private static CosmosResponseSnapshotDocument FromSnapshot(IdempotencyResponseSnapshot snapshot)
+    {
+        var headers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, values) in snapshot.Headers)
+            headers[name] = values;
+
+        return new CosmosResponseSnapshotDocument
+        {
+            StatusCode = snapshot.StatusCode,
+            Headers = headers,
+            Body = snapshot.Body,
+            Fingerprint = snapshot.Fingerprint,
+        };
+    }
+
+    /// <summary>
+    /// Encodes an idempotency key into a legal Cosmos DB item id. Keys are client-supplied and
+    /// may contain <c>/</c>, <c>\</c>, <c>?</c>, or <c>#</c>, none of which are permitted in an id.
+    /// Base64Url is used rather than a hash so the mapping stays collision-free and reversible.
+    /// </summary>
+    /// <param name="key">The idempotency key.</param>
+    internal static string EncodeId(string key) =>
+        Base64Url.EncodeToString(Encoding.UTF8.GetBytes(key));
+
+    /// <summary>Reverses <see cref="EncodeId"/>.</summary>
+    /// <param name="id">A Cosmos DB item id produced by <see cref="EncodeId"/>.</param>
+    internal static string DecodeId(string id) =>
+        Encoding.UTF8.GetString(Base64Url.DecodeFromChars(id.ToCharArray()));
+}

--- a/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyStore.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyStore.cs
@@ -52,7 +52,9 @@ using Microsoft.Azure.Cosmos;
 /// the boundary. Set <see cref="IdempotencyOptions.ReservationTimeout"/> comfortably above the
 /// slowest expected handler <em>plus</em> the skew tolerated across the fleet, and keep hosts
 /// NTP-synchronised. A single-instance store such as <c>InMemoryIdempotencyStore</c> reads one
-/// clock and is not exposed to this.
+/// clock and is not exposed to this. The <c>Retry-After</c> value returned for an in-flight
+/// reservation is clamped so that skew cannot push it beyond
+/// <see cref="IdempotencyOptions.ReservationTimeout"/>.
 /// </para>
 /// <para>
 /// <b>Cost.</b> Request-unit charge scales with item size, so an idempotency entry costs roughly

--- a/Trellis.Asp.Idempotency.Cosmos/src/Trellis.Asp.Idempotency.Cosmos.csproj
+++ b/Trellis.Asp.Idempotency.Cosmos/src/Trellis.Asp.Idempotency.Cosmos.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+    <TrellisApiRefName>asp-idempotency-cosmos</TrellisApiRefName>
+    <Description>Cosmos DB-backed IIdempotencyStore for Trellis.Asp. Safe across instances and process restarts: reservations are claimed with an atomic CreateItem (409 on duplicate id) and every subsequent mutation is an ETag-conditional replace or delete, so Session consistency cannot cause a double execution. Enforces TTL and reservation-timeout expiry in-process rather than trusting Cosmos DB's best-effort background sweep. Verified by the Trellis.Testing.Idempotency conformance suite.</Description>
+    <PackageTags>trellis;idempotency;cosmosdb;azure;asp;http;idempotency-key;distributed;result;railway-oriented</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" />
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+</Project>

--- a/Trellis.Asp.Idempotency.Cosmos/tests/CosmosEmulator.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/CosmosEmulator.cs
@@ -1,0 +1,68 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos.Tests;
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+/// <summary>
+/// Resolves the container the Cosmos DB tests run against, once per test process.
+/// </summary>
+/// <remarks>
+/// The emulator is not present on every machine or CI agent, so probing is a first-class outcome
+/// rather than a failure: <see cref="TryGetContainerAsync"/> returns <c>null</c> when the emulator
+/// cannot be reached and the tests skip. That keeps the suite honest — it either runs against real
+/// Cosmos DB or visibly does not run at all, rather than passing against a substitute.
+/// </remarks>
+internal static class CosmosEmulator
+{
+    /// <summary>
+    /// Well-known Cosmos DB emulator credentials. Published by Microsoft and identical on every
+    /// installation, so this is a fixed test constant rather than a secret.
+    /// </summary>
+    private const string Endpoint = "https://localhost:8081/";
+
+    private const string Key =
+        "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+    private const string DatabaseId = "trellis-conformance";
+
+    private static readonly Lazy<Task<Container?>> Container = new(ProvisionAsync);
+
+    /// <summary>
+    /// Returns the shared idempotency container, or <c>null</c> when no emulator is reachable.
+    /// </summary>
+    public static Task<Container?> TryGetContainerAsync() => Container.Value;
+
+    private static async Task<Container?> ProvisionAsync()
+    {
+        var client = new CosmosClient(Endpoint, Key, new CosmosClientOptions
+        {
+            // The emulator presents a self-signed certificate, and Gateway mode keeps the test to
+            // the single HTTPS port that was probed.
+            ConnectionMode = ConnectionMode.Gateway,
+            ServerCertificateCustomValidationCallback = (_, _, _) => true,
+            RequestTimeout = TimeSpan.FromSeconds(10),
+            MaxRetryAttemptsOnRateLimitedRequests = 0,
+        });
+
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            var database = await client.CreateDatabaseIfNotExistsAsync(
+                DatabaseId, cancellationToken: timeout.Token);
+
+            return await CosmosIdempotencyContainer.CreateIfNotExistsAsync(
+                database.Database, cancellationToken: timeout.Token);
+        }
+        catch (Exception ex) when (ex is CosmosException or HttpRequestException or OperationCanceledException)
+        {
+            // Narrow by design: these are the shapes "no emulator here" takes. Anything else is a
+            // real defect and must surface rather than silently skipping the whole suite.
+            client.Dispose();
+            return null;
+        }
+    }
+}

--- a/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyDecisionTests.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyDecisionTests.cs
@@ -1,0 +1,147 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos.Tests;
+
+using System;
+using Trellis.Asp.Idempotency;
+
+/// <summary>
+/// Exhaustive tests for the store's decision logic and key encoding. These need no emulator, so
+/// the ordering rules stay covered on machines and CI agents where the Cosmos suite skips.
+/// </summary>
+public class CosmosIdempotencyDecisionTests
+{
+    private static readonly IdempotencyOptions Options = new()
+    {
+        Ttl = TimeSpan.FromHours(1),
+        ReservationTimeout = TimeSpan.FromSeconds(30),
+    };
+
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static CosmosIdempotencyDocument Reserved(string fingerprint, DateTimeOffset reservedAt) =>
+        new()
+        {
+            Fingerprint = fingerprint,
+            ReservationId = "res-1",
+            ReservedAtUnixMs = reservedAt.ToUnixTimeMilliseconds(),
+        };
+
+    private static CosmosIdempotencyDocument Completed(string fingerprint, DateTimeOffset completedAt) =>
+        new()
+        {
+            Fingerprint = fingerprint,
+            CompletedAtUnixMs = completedAt.ToUnixTimeMilliseconds(),
+            Snapshot = new CosmosResponseSnapshotDocument { StatusCode = 201, Fingerprint = fingerprint },
+        };
+
+    [Fact]
+    public void Completed_entry_within_ttl_and_matching_fingerprint_replays() =>
+        CosmosIdempotencyDecision.Classify(Completed("fp", Now), "fp", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.Replay);
+
+    [Fact]
+    public void Completed_entry_within_ttl_and_different_fingerprint_is_a_mismatch() =>
+        CosmosIdempotencyDecision.Classify(Completed("fp", Now), "other", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.BodyHashMismatch);
+
+    [Fact]
+    public void Completed_entry_past_ttl_is_absent() =>
+        CosmosIdempotencyDecision.Classify(
+                Completed("fp", Now - Options.Ttl), "fp", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.TreatAsAbsent);
+
+    /// <summary>
+    /// Expiry is checked before fingerprint for completed entries, so a key whose snapshot has
+    /// aged out may legitimately be reused with a different body.
+    /// </summary>
+    [Fact]
+    public void Completed_entry_past_ttl_is_absent_even_for_a_different_fingerprint() =>
+        CosmosIdempotencyDecision.Classify(
+                Completed("fp", Now - Options.Ttl), "other", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.TreatAsAbsent);
+
+    [Fact]
+    public void Live_reservation_with_matching_fingerprint_is_in_flight()
+    {
+        var decision = CosmosIdempotencyDecision.Classify(
+            Reserved("fp", Now - TimeSpan.FromSeconds(5)), "fp", Now, Options);
+
+        decision.Action.Should().Be(IdempotencyDocumentAction.AlreadyInFlight);
+        decision.RetryAfter.Should().Be(TimeSpan.FromSeconds(25));
+    }
+
+    [Fact]
+    public void Live_reservation_with_different_fingerprint_is_a_mismatch() =>
+        CosmosIdempotencyDecision.Classify(
+                Reserved("fp", Now - TimeSpan.FromSeconds(5)), "other", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.BodyHashMismatch);
+
+    [Fact]
+    public void Timed_out_reservation_with_matching_fingerprint_is_taken_over() =>
+        CosmosIdempotencyDecision.Classify(
+                Reserved("fp", Now - Options.ReservationTimeout), "fp", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.TakeOver);
+
+    /// <summary>
+    /// Fingerprint is checked before the timeout for reserved entries, so a different body cannot
+    /// claim a slot by waiting for the reservation to lapse.
+    /// </summary>
+    [Fact]
+    public void Timed_out_reservation_with_different_fingerprint_is_still_a_mismatch() =>
+        CosmosIdempotencyDecision.Classify(
+                Reserved("fp", Now - Options.ReservationTimeout), "other", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.BodyHashMismatch);
+
+    [Fact]
+    public void Reservation_exactly_at_the_timeout_is_taken_over() =>
+        CosmosIdempotencyDecision.Classify(
+                Reserved("fp", Now - Options.ReservationTimeout), "fp", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.TakeOver);
+
+    [Fact]
+    public void Reservation_one_tick_before_the_timeout_is_still_in_flight() =>
+        CosmosIdempotencyDecision.Classify(
+                Reserved("fp", Now - Options.ReservationTimeout + TimeSpan.FromMilliseconds(1)),
+                "fp", Now, Options)
+            .Action.Should().Be(IdempotencyDocumentAction.AlreadyInFlight);
+}
+
+/// <summary>
+/// Cosmos DB rejects item ids containing <c>/</c>, <c>\</c>, <c>?</c>, or <c>#</c>, but
+/// idempotency keys are client-supplied and may contain any of them.
+/// </summary>
+public class CosmosIdempotencyKeyEncodingTests
+{
+    [Theory]
+    [InlineData("simple-key")]
+    [InlineData("with/slash")]
+    [InlineData("with\\backslash")]
+    [InlineData("with?question")]
+    [InlineData("with#hash")]
+    [InlineData("with spaces and trailing ")]
+    [InlineData("unicode-\u00e9\u00e8-\u4e2d\u6587-\U0001f600")]
+    [InlineData("")]
+    public void Encoded_ids_round_trip_and_contain_no_reserved_characters(string key)
+    {
+        var id = CosmosIdempotencyStore.EncodeId(key);
+
+        id.Should().NotContainAny("/", "\\", "?", "#");
+        CosmosIdempotencyStore.DecodeId(id).Should().Be(key);
+    }
+
+    [Fact]
+    public void Distinct_keys_encode_to_distinct_ids() =>
+        CosmosIdempotencyStore.EncodeId("key-a").Should()
+            .NotBe(CosmosIdempotencyStore.EncodeId("key-b"));
+
+    /// <summary>
+    /// Cosmos DB caps item ids at 1023 bytes. Base64 inflates by 4/3, so the longest key
+    /// `IdempotencyOptions.MaxKeyLength` permits must still fit.
+    /// </summary>
+    [Fact]
+    public void The_longest_permitted_key_fits_within_the_cosmos_id_limit()
+    {
+        var longestKey = new string('k', new IdempotencyOptions().MaxKeyLength);
+
+        CosmosIdempotencyStore.EncodeId(longestKey).Length.Should().BeLessThan(1023);
+    }
+}

--- a/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyDecisionTests.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyDecisionTests.cs
@@ -69,6 +69,28 @@ public class CosmosIdempotencyDecisionTests
         decision.RetryAfter.Should().Be(TimeSpan.FromSeconds(25));
     }
 
+    /// <summary>
+    /// A reservation written by a host whose clock runs ahead lands in the future, making the
+    /// elapsed time negative. Left unclamped, <c>ReservationTimeout - elapsed</c> would exceed the
+    /// configured timeout and break the contract rule that <c>RetryAfter</c> falls within
+    /// <c>(0, ReservationTimeout]</c> — telling the client to wait longer than the reservation can
+    /// possibly live. The conformance suite cannot catch this, because it drives a single fake
+    /// clock and so has no skew to produce.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(30)]
+    [InlineData(3600)]
+    public void Reservation_from_a_clock_ahead_of_ours_clamps_retry_after(int skewSeconds)
+    {
+        var decision = CosmosIdempotencyDecision.Classify(
+            Reserved("fp", Now + TimeSpan.FromSeconds(skewSeconds)), "fp", Now, Options);
+
+        decision.Action.Should().Be(IdempotencyDocumentAction.AlreadyInFlight);
+        decision.RetryAfter.Should().BePositive();
+        decision.RetryAfter.Should().BeLessThanOrEqualTo(Options.ReservationTimeout);
+    }
+
     [Fact]
     public void Live_reservation_with_different_fingerprint_is_a_mismatch() =>
         CosmosIdempotencyDecision.Classify(

--- a/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyServiceCollectionExtensionsTests.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyServiceCollectionExtensionsTests.cs
@@ -1,0 +1,180 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos.Tests;
+
+using System;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Trellis.Asp.Idempotency;
+
+/// <summary>
+/// Registration tests for <see cref="CosmosIdempotencyServiceCollectionExtensions"/>.
+/// </summary>
+/// <remarks>
+/// These need no emulator. Constructing a <see cref="CosmosClient"/> and calling
+/// <c>GetContainer</c> are both offline operations — the SDK connects lazily on first use — so the
+/// whole registration path can be exercised without a live service.
+/// </remarks>
+public sealed class CosmosIdempotencyServiceCollectionExtensionsTests
+{
+    private const string Endpoint = "https://localhost:8081/";
+
+    private const string Key =
+        "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+    [Fact]
+    public void Factory_overload_registers_the_Cosmos_store_as_the_idempotency_store()
+    {
+        using var provider = BuildProvider(services =>
+            services.AddCosmosIdempotencyStore(_ => GetContainer()));
+
+        provider.GetRequiredService<IIdempotencyStore>().Should().BeOfType<CosmosIdempotencyStore>();
+    }
+
+    [Fact]
+    public void Store_is_a_singleton_so_one_client_is_shared_across_requests()
+    {
+        using var provider = BuildProvider(services =>
+            services.AddCosmosIdempotencyStore(_ => GetContainer()));
+
+        var first = provider.GetRequiredService<IIdempotencyStore>();
+        var second = provider.GetRequiredService<IIdempotencyStore>();
+
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void Container_factory_is_resolved_from_the_provider()
+    {
+        IServiceProvider? captured = null;
+
+        using var provider = BuildProvider(services =>
+            services.AddCosmosIdempotencyStore(sp =>
+            {
+                captured = sp;
+                return GetContainer();
+            }));
+
+        provider.GetRequiredService<IIdempotencyStore>();
+
+        captured.Should().NotBeNull("the factory must be able to resolve co-registered services");
+    }
+
+    [Fact]
+    public void Registered_TimeProvider_is_used_when_one_is_present()
+    {
+        var time = new FakeTimeProvider();
+
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton<TimeProvider>(time);
+            services.AddCosmosIdempotencyStore(_ => GetContainer());
+        });
+
+        // The store takes TimeProvider as an optional dependency, so resolution must succeed both
+        // with and without one registered; the no-TimeProvider case is covered by the other tests.
+        provider.GetRequiredService<IIdempotencyStore>().Should().BeOfType<CosmosIdempotencyStore>();
+    }
+
+    [Fact]
+    public void Id_overload_addresses_the_container_through_the_registered_client()
+    {
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton(new CosmosClient(Endpoint, Key));
+            services.AddCosmosIdempotencyStore("orders", "idempotency-entries");
+        });
+
+        provider.GetRequiredService<IIdempotencyStore>().Should().BeOfType<CosmosIdempotencyStore>();
+    }
+
+    [Fact]
+    public void Id_overload_defaults_the_container_id()
+    {
+        using var provider = BuildProvider(services =>
+        {
+            services.AddSingleton(new CosmosClient(Endpoint, Key));
+            services.AddCosmosIdempotencyStore("orders");
+        });
+
+        provider.GetRequiredService<IIdempotencyStore>().Should().BeOfType<CosmosIdempotencyStore>();
+    }
+
+    [Fact]
+    public void Id_overload_requires_a_registered_CosmosClient()
+    {
+        using var provider = BuildProvider(services => services.AddCosmosIdempotencyStore("orders"));
+
+        var resolve = () => provider.GetRequiredService<IIdempotencyStore>();
+
+        resolve.Should().Throw<InvalidOperationException>(
+            "the overload resolves CosmosClient from the container, so a missing registration must " +
+            "fail loudly rather than silently producing a store that cannot reach Cosmos DB");
+    }
+
+    [Fact]
+    public void Null_services_are_rejected()
+    {
+        var factoryOverload = () =>
+            ((IServiceCollection)null!).AddCosmosIdempotencyStore(_ => GetContainer());
+        var idOverload = () => ((IServiceCollection)null!).AddCosmosIdempotencyStore("orders");
+
+        factoryOverload.Should().Throw<ArgumentNullException>();
+        idOverload.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Null_container_factory_is_rejected()
+    {
+        var act = () => new ServiceCollection()
+            .AddCosmosIdempotencyStore((Func<IServiceProvider, Container>)null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Missing_database_id_is_rejected(string? databaseId)
+    {
+        var act = () => new ServiceCollection().AddCosmosIdempotencyStore(databaseId!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Missing_container_id_is_rejected(string? containerId)
+    {
+        var act = () => new ServiceCollection().AddCosmosIdempotencyStore("orders", containerId!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Registration_returns_the_collection_for_chaining()
+    {
+        var services = new ServiceCollection();
+
+        services.AddCosmosIdempotencyStore(_ => GetContainer()).Should().BeSameAs(services);
+        services.AddCosmosIdempotencyStore("orders").Should().BeSameAs(services);
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<IdempotencyOptions>();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Addresses a container without contacting Cosmos DB — the SDK returns a handle and connects
+    /// lazily, so nothing here requires a running emulator.
+    /// </summary>
+    private static Container GetContainer() =>
+        new CosmosClient(Endpoint, Key).GetContainer("orders", "idempotency");
+}

--- a/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyStoreConformanceTests.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyStoreConformanceTests.cs
@@ -1,0 +1,55 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos.Tests;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Trellis.Asp.Idempotency;
+using Trellis.Testing.Idempotency;
+
+/// <summary>
+/// Runs the published <see cref="IdempotencyStoreConformance"/> suite against a real Cosmos DB
+/// instance (the emulator).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The suite runs with the default 30-second reservation timeout and one-hour TTL and still
+/// completes in the time of ordinary Cosmos DB round trips, because
+/// <see cref="CosmosIdempotencyStore"/> enforces expiry against an injected
+/// <see cref="TimeProvider"/> rather than trusting the service's background TTL sweep. Advancing a
+/// fake clock is therefore enough to exercise takeover and TTL expiry — which is the same property
+/// that makes the store correct in production, where an item may outlive its <c>ttl</c> and still
+/// be returned by a read.
+/// </para>
+/// <para>
+/// Skips when no emulator is reachable. See <see cref="CosmosEmulator"/>.
+/// </para>
+/// <para>
+/// Excluded from default runs — use <c>dotnet test --filter-trait "Category=Integration"</c>
+/// (requires the Azure Cosmos DB emulator).
+/// </para>
+/// </remarks>
+[Trait("Category", "Integration")]
+public sealed class CosmosIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    private readonly FakeTimeProvider _time = new();
+
+    protected override async ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options)
+    {
+        var container = await CosmosEmulator.TryGetContainerAsync();
+        Assert.SkipWhen(
+            container is null,
+            "No Cosmos DB emulator reachable at https://localhost:8081/, so the Cosmos conformance suite did not run.");
+
+        return new CosmosIdempotencyStore(container!, options, _time);
+    }
+
+    protected override Task AdvanceAsync(TimeSpan duration)
+    {
+        _time.Advance(duration);
+        return Task.CompletedTask;
+    }
+
+    // Each caller is a real network round trip to the emulator, so keep the race small enough to
+    // stay fast while still being a genuine race.
+    protected override int ConcurrentReservationAttempts => 8;
+}

--- a/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyTtlTests.cs
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/CosmosIdempotencyTtlTests.cs
@@ -1,0 +1,101 @@
+﻿namespace Trellis.Asp.Idempotency.Cosmos.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Time.Testing;
+using Trellis.Asp.Idempotency;
+
+/// <summary>
+/// Pins the per-item <c>ttl</c> the store persists in each document state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The conformance suite cannot cover this. It advances a fake clock, but Cosmos DB's sweeper runs
+/// on real time, so no conformance run is long enough for an item to be physically deleted. That
+/// leaves a gap the store must close by construction: if a <em>reserved</em> document carried a
+/// finite <c>ttl</c>, then once the sweeper eventually removed it, a same-key request with a
+/// different body would be granted a fresh reservation instead of the
+/// <see cref="IdempotencyReservationOutcome.BodyHashMismatch"/> that
+/// <see cref="CosmosIdempotencyDecision.Classify"/> returns while the document is still present —
+/// so the store's answer would depend on whether a best-effort background sweep had happened to
+/// run. These tests assert the store never gets into that position.
+/// </para>
+/// <para>
+/// Excluded from default runs — use <c>dotnet test --filter-trait "Category=Integration"</c>
+/// (requires the Azure Cosmos DB emulator).
+/// </para>
+/// </remarks>
+[Trait("Category", "Integration")]
+public sealed class CosmosIdempotencyTtlTests
+{
+    private readonly FakeTimeProvider _time = new();
+
+    [Fact]
+    public async Task Reserved_document_never_expires_so_a_sweep_cannot_change_the_answer()
+    {
+        var (store, container, scope) = await CreateAsync();
+
+        var reserved = await store.TryReserveAsync(scope, "key", "fingerprint", TestContext.Current.CancellationToken);
+        reserved.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+
+        var ttl = await ReadTtlAsync(container, scope);
+        ttl.Should().Be(-1, "a reserved document outlives every timeout in Classify, so Cosmos DB must not delete it");
+    }
+
+    [Fact]
+    public async Task Completed_document_expires_so_storage_is_reclaimed()
+    {
+        var (store, container, scope) = await CreateAsync();
+
+        var reserved = (IdempotencyReservationOutcome.Reserved)await store.TryReserveAsync(
+            scope, "key", "fingerprint", TestContext.Current.CancellationToken);
+
+        await store.CompleteAsync(
+            scope,
+            "key",
+            reserved.ReservationId,
+            new IdempotencyResponseSnapshot(200, new Dictionary<string, string[]>(), [], "fingerprint"),
+            TestContext.Current.CancellationToken);
+
+        var ttl = await ReadTtlAsync(container, scope);
+        ttl.Should().BePositive("a completed document is unreachable once Classify treats it as absent");
+    }
+
+    private async Task<(CosmosIdempotencyStore Store, Container Container, string Scope)> CreateAsync()
+    {
+        var container = await CosmosEmulator.TryGetContainerAsync();
+        Assert.SkipWhen(
+            container is null,
+            "No Cosmos DB emulator reachable at https://localhost:8081/, so the Cosmos TTL tests did not run.");
+
+        var options = new IdempotencyOptions();
+        return (new CosmosIdempotencyStore(container!, options, _time), container!, Guid.NewGuid().ToString("N"));
+    }
+
+    /// <summary>
+    /// Reads <c>ttl</c> straight out of the stored JSON rather than through the store's own model,
+    /// so the assertion is about what Cosmos DB will actually act on.
+    /// </summary>
+    private static async Task<int?> ReadTtlAsync(Container container, string scope)
+    {
+        using var iterator = container.GetItemQueryStreamIterator(
+            new QueryDefinition("SELECT c.ttl FROM c"),
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(scope) });
+
+        using var response = await iterator.ReadNextAsync(TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        using var payload = await JsonDocument.ParseAsync(
+            response.Content, cancellationToken: TestContext.Current.CancellationToken);
+
+        var documents = payload.RootElement.GetProperty("Documents");
+        documents.GetArrayLength().Should().Be(1, "each test uses its own scope, so the partition holds one entry");
+
+        var ttl = documents[0];
+        return ttl.TryGetProperty("ttl", out var value) ? value.GetInt32() : null;
+    }
+}

--- a/Trellis.Asp.Idempotency.Cosmos/tests/Trellis.Asp.Idempotency.Cosmos.Tests.csproj
+++ b/Trellis.Asp.Idempotency.Cosmos/tests/Trellis.Asp.Idempotency.Cosmos.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\src\Trellis.Asp.Idempotency.Cosmos.csproj" />
+    <ProjectReference Include="..\..\Trellis.Testing.Idempotency\src\Trellis.Testing.Idempotency.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+  </ItemGroup>
+</Project>

--- a/Trellis.Asp/tests/Idempotency/InMemoryIdempotencyStoreConformanceTests.cs
+++ b/Trellis.Asp/tests/Idempotency/InMemoryIdempotencyStoreConformanceTests.cs
@@ -1,0 +1,29 @@
+﻿namespace Trellis.Asp.Tests.Idempotency;
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Trellis.Asp.Idempotency;
+using Trellis.Testing.Idempotency;
+
+/// <summary>
+/// Runs the published <see cref="IdempotencyStoreConformance"/> suite against
+/// <see cref="InMemoryIdempotencyStore"/>.
+/// </summary>
+/// <remarks>
+/// This keeps the shipped reference implementation honest against the same contract third-party
+/// stores are held to, so the suite cannot drift away from the store it documents.
+/// </remarks>
+public sealed class InMemoryIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    private readonly FakeTimeProvider _time = new();
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new InMemoryIdempotencyStore(options, _time));
+
+    protected override Task AdvanceAsync(TimeSpan duration)
+    {
+        _time.Advance(duration);
+        return Task.CompletedTask;
+    }
+}

--- a/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
+++ b/Trellis.Asp/tests/Trellis.Asp.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Testing\src\Trellis.Testing.csproj" />
+    <ProjectReference Include="..\..\Trellis.Testing.Idempotency\src\Trellis.Testing.Idempotency.csproj" />
     <ProjectReference Include="..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
     <ProjectReference Include="..\src\Trellis.Asp.csproj" />
     <ProjectReference Include="..\generator\Trellis.AspSourceGenerator.csproj"

--- a/Trellis.Testing.Idempotency/NUGET_README.md
+++ b/Trellis.Testing.Idempotency/NUGET_README.md
@@ -1,0 +1,49 @@
+# Trellis.Testing.Idempotency
+
+[![NuGet Package](https://img.shields.io/nuget/v/Trellis.Testing.Idempotency.svg)](https://www.nuget.org/packages/Trellis.Testing.Idempotency)
+
+Executable conformance suite for Trellis `IIdempotencyStore` implementations.
+
+## Installation
+```bash
+dotnet add package Trellis.Testing.Idempotency
+```
+
+## Quick Example
+```csharp
+using Trellis.Testing.Idempotency;
+
+public sealed class RedisIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    // Redis enforces expiry server-side, so use short real timeouts.
+    protected override TimeSpan ReservationTimeout => TimeSpan.FromSeconds(2);
+    protected override TimeSpan Ttl => TimeSpan.FromSeconds(4);
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new RedisIdempotencyStore(_multiplexer, options));
+}
+```
+
+That one class runs the full contract: reserve, replay, fingerprint mismatch, reservation
+takeover, TTL expiry, abandon semantics, and atomicity under concurrent load.
+
+## Why
+
+`Trellis.Asp` ships only `InMemoryIdempotencyStore`, which is not safe across instances or process
+restarts, so production deployments write their own over Redis, Cosmos DB, or a database. A
+violation of the contract fails **silently** — a non-atomic reserve lets two racing callers both
+execute the handler, and an unconditional `AbandonAsync` destroys a response `CompleteAsync`
+already persisted. Nothing throws. The symptom is a customer charged twice.
+
+## Key Features
+- **One class per store** — implement `CreateStoreAsync` and inherit 17 contract tests
+- **Works with fake or real clocks** — override `AdvanceAsync` for `TimeProvider`-based stores, or
+  shorten `Ttl`/`ReservationTimeout` when a remote server owns expiry
+- **Safe against shared infrastructure** — each test instance gets a unique `Scope`, so suites can
+  run in parallel against one Redis or Cosmos DB instance
+- **Structural snapshot comparison** — `ShouldMatch` avoids the reference-equality trap in
+  `IdempotencyResponseSnapshot` that would fail every serialising store
+
+## Documentation
+See the [API reference](https://github.com/xavierjohn/Trellis/blob/main/docs/docfx_project/api_reference/trellis-api-testing-idempotency.md)
+for the full rule list and the implementation traps the suite catches.

--- a/Trellis.Testing.Idempotency/README.md
+++ b/Trellis.Testing.Idempotency/README.md
@@ -1,0 +1,49 @@
+# Trellis.Testing.Idempotency
+
+[![NuGet Package](https://img.shields.io/nuget/v/Trellis.Testing.Idempotency.svg)](https://www.nuget.org/packages/Trellis.Testing.Idempotency)
+
+Executable conformance suite for Trellis `IIdempotencyStore` implementations.
+
+## Installation
+```bash
+dotnet add package Trellis.Testing.Idempotency
+```
+
+## Quick Example
+```csharp
+using Trellis.Testing.Idempotency;
+
+public sealed class RedisIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    // Redis enforces expiry server-side, so use short real timeouts.
+    protected override TimeSpan ReservationTimeout => TimeSpan.FromSeconds(2);
+    protected override TimeSpan Ttl => TimeSpan.FromSeconds(4);
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new RedisIdempotencyStore(_multiplexer, options));
+}
+```
+
+That one class runs the full contract: reserve, replay, fingerprint mismatch, reservation
+takeover, TTL expiry, abandon semantics, and atomicity under concurrent load.
+
+## Why
+
+`Trellis.Asp` ships only `InMemoryIdempotencyStore`, which is not safe across instances or process
+restarts, so production deployments write their own over Redis, Cosmos DB, or a database. A
+violation of the contract fails **silently** — a non-atomic reserve lets two racing callers both
+execute the handler, and an unconditional `AbandonAsync` destroys a response `CompleteAsync`
+already persisted. Nothing throws. The symptom is a customer charged twice.
+
+## Key Features
+- **One class per store** — implement `CreateStoreAsync` and inherit 17 contract tests
+- **Works with fake or real clocks** — override `AdvanceAsync` for `TimeProvider`-based stores, or
+  shorten `Ttl`/`ReservationTimeout` when a remote server owns expiry
+- **Safe against shared infrastructure** — each test instance gets a unique `Scope`, so suites can
+  run in parallel against one Redis or Cosmos DB instance
+- **Structural snapshot comparison** — `ShouldMatch` avoids the reference-equality trap in
+  `IdempotencyResponseSnapshot` that would fail every serialising store
+
+## Documentation
+See the [API reference](https://github.com/xavierjohn/Trellis/blob/main/docs/docfx_project/api_reference/trellis-api-testing-idempotency.md)
+for the full rule list and the implementation traps the suite catches.

--- a/Trellis.Testing.Idempotency/src/IdempotencyStoreConformance.cs
+++ b/Trellis.Testing.Idempotency/src/IdempotencyStoreConformance.cs
@@ -1,0 +1,521 @@
+﻿namespace Trellis.Testing.Idempotency;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Trellis.Asp.Idempotency;
+using Xunit;
+
+/// <summary>
+/// Executable specification of the <see cref="IIdempotencyStore"/> contract. Inherit this class,
+/// implement <see cref="CreateStoreAsync"/>, and the suite runs against your store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists.</b> <c>IdempotencyMiddleware</c> ships with only
+/// <c>InMemoryIdempotencyStore</c>, which is explicitly not safe across instances or process
+/// restarts, so every production deployment supplies its own store backed by Redis, Cosmos DB,
+/// a relational database, or something bespoke. The rules those implementations must satisfy are
+/// subtle, and getting one wrong fails silently — a replayed request executes twice and the
+/// caller is charged twice, with no exception anywhere. This suite turns each rule into a test.
+/// </para>
+/// <para>
+/// <b>Clocks.</b> Two tests need time to pass: reservation takeover and TTL expiry. A store built
+/// on <see cref="TimeProvider"/> should override <see cref="AdvanceAsync"/> to advance its fake
+/// clock, leaving <see cref="ReservationTimeout"/> and <see cref="Ttl"/> at their defaults. A
+/// store whose expiry is enforced by a remote server (Redis <c>PX</c>, Cosmos DB <c>ttl</c>)
+/// cannot have its clock faked, so it should instead override <see cref="ReservationTimeout"/>
+/// and <see cref="Ttl"/> to values of a few seconds and let <see cref="AdvanceAsync"/> keep its
+/// default real delay.
+/// </para>
+/// <para>
+/// <b>Server-side expiry is not sufficient on its own.</b> Cosmos DB deletes expired items on a
+/// best-effort background sweep, so an item can outlive its <c>ttl</c> and still be returned by a
+/// read. Redis is prompt but may be configured with an eviction policy that removes a live entry
+/// early. A conforming store therefore records its own expiry timestamp and re-checks it on read
+/// rather than trusting the server to have deleted the row. <see cref="Reserve_after_the_ttl_elapses_treats_a_completed_entry_as_absent"/>
+/// catches an implementation that trusts the sweep.
+/// </para>
+/// <para>
+/// <b>Isolation.</b> Every test instance gets a fresh <see cref="Scope"/> containing a GUID, so a
+/// suite may safely run against a shared Redis or Cosmos DB instance, in parallel, without one
+/// test observing another's keys.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public sealed class RedisIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+/// {
+///     // A remote server owns expiry, so use short real timeouts and a real delay.
+///     protected override TimeSpan ReservationTimeout => TimeSpan.FromSeconds(2);
+///     protected override TimeSpan Ttl => TimeSpan.FromSeconds(4);
+///
+///     protected override ValueTask&lt;IIdempotencyStore&gt; CreateStoreAsync(IdempotencyOptions options) =&gt;
+///         new(new RedisIdempotencyStore(ConnectionMultiplexer, options));
+/// }
+/// </code>
+/// </example>
+public abstract class IdempotencyStoreConformance
+{
+    /// <summary>
+    /// Creates the store under test, configured with <paramref name="options"/>. Called once per
+    /// test. The <see cref="IdempotencyOptions.ReservationTimeout"/> and
+    /// <see cref="IdempotencyOptions.Ttl"/> on <paramref name="options"/> are taken from
+    /// <see cref="ReservationTimeout"/> and <see cref="Ttl"/> and must be honoured, or the
+    /// expiry tests will not mean anything.
+    /// </summary>
+    /// <param name="options">Options the store must be configured with.</param>
+    protected abstract ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options);
+
+    /// <summary>
+    /// How long a reservation is held before another request may take it over. Override with a
+    /// value of a few seconds when expiry is enforced by a remote server and
+    /// <see cref="AdvanceAsync"/> therefore has to delay for real.
+    /// </summary>
+    protected virtual TimeSpan ReservationTimeout => TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How long a completed snapshot remains replayable. Override with a value of a few seconds
+    /// when expiry is enforced by a remote server and <see cref="AdvanceAsync"/> therefore has to
+    /// delay for real.
+    /// </summary>
+    protected virtual TimeSpan Ttl => TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Number of callers used by <see cref="Concurrent_reservations_of_one_key_grant_exactly_one_winner"/>.
+    /// Lower it if the store under test is a remote service with limited throughput.
+    /// </summary>
+    protected virtual int ConcurrentReservationAttempts => 32;
+
+    /// <summary>
+    /// Makes <paramref name="duration"/> elapse from the store's point of view. Defaults to a real
+    /// delay, which is correct for a store whose expiry a remote server enforces. Override it to
+    /// advance a <c>FakeTimeProvider</c> when the store reads the clock in-process, so the suite
+    /// runs instantly.
+    /// </summary>
+    /// <param name="duration">How much time must appear to pass.</param>
+    protected virtual Task AdvanceAsync(TimeSpan duration) => Task.Delay(duration);
+
+    /// <summary>
+    /// Scope used by every test on this instance. xUnit constructs one instance per test, so each
+    /// test gets its own scope and cannot collide with another running against the same backing
+    /// store.
+    /// </summary>
+    protected string Scope { get; } = $"trellis-conformance-{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Builds a snapshot with the given fingerprint and a one-byte body, for tests that only need
+    /// to tell two snapshots apart.
+    /// </summary>
+    /// <param name="fingerprint">Fingerprint to record on the snapshot.</param>
+    /// <param name="bodyMarker">Single body byte, used to identify which snapshot was stored.</param>
+    protected static IdempotencyResponseSnapshot SnapshotFor(string fingerprint, byte bodyMarker = 0x7B) =>
+        new(
+            StatusCode: 201,
+            Headers: new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Content-Type"] = ["application/json"],
+            },
+            Body: [bodyMarker],
+            Fingerprint: fingerprint);
+
+    /// <summary>
+    /// Asserts that <paramref name="actual"/> carries the same data as <paramref name="expected"/>.
+    /// </summary>
+    /// <remarks>
+    /// Compared field by field rather than with record equality on purpose.
+    /// <see cref="IdempotencyResponseSnapshot"/> is a record whose <c>Headers</c> and <c>Body</c>
+    /// members compare by <em>reference</em>, so an equality assertion would pass only for a store
+    /// that hands back the very instance it was given. Any store that serialises — which is every
+    /// durable store — returns an equal-but-distinct instance and would fail for no good reason.
+    /// </remarks>
+    /// <param name="actual">Snapshot returned by the store.</param>
+    /// <param name="expected">Snapshot originally handed to <see cref="IIdempotencyStore.CompleteAsync"/>.</param>
+    protected static void ShouldMatch(IdempotencyResponseSnapshot actual, IdempotencyResponseSnapshot expected)
+    {
+        actual.StatusCode.Should().Be(expected.StatusCode);
+        actual.Fingerprint.Should().Be(expected.Fingerprint);
+        actual.Body.Should().Equal(expected.Body);
+
+        // IdempotencyResponseSnapshot documents header names as case-insensitive, so a store that
+        // round-trips them through a dictionary carrying an ordinal comparer, or that normalizes
+        // casing on the way out, is still conforming. Compare through an explicit
+        // OrdinalIgnoreCase view rather than inheriting whichever comparer the store happened to
+        // use, so the suite does not reject a store for something the contract permits.
+        var actualHeaders = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, values) in actual.Headers)
+            actualHeaders[name] = values;
+
+        actualHeaders.Should().HaveCount(expected.Headers.Count);
+        foreach (var (name, values) in expected.Headers)
+        {
+            actualHeaders.Should().ContainKey(name);
+            actualHeaders[name].Should().Equal(values, "header '{0}' must replay verbatim", name);
+        }
+    }
+
+    private async ValueTask<IIdempotencyStore> NewStoreAsync()
+    {
+        var options = new IdempotencyOptions
+        {
+            ReservationTimeout = ReservationTimeout,
+            Ttl = Ttl,
+        };
+
+        return await CreateStoreAsync(options);
+    }
+
+    private async ValueTask<(IIdempotencyStore Store, string ReservationId)> ReserveAsync(
+        string key, string fingerprint)
+    {
+        var store = await NewStoreAsync();
+        var reservationId = await ReserveOnAsync(store, key, fingerprint);
+        return (store, reservationId);
+    }
+
+    private static async ValueTask<string> ReserveOnAsync(
+        IIdempotencyStore store, string scope, string key, string fingerprint)
+    {
+        var outcome = await store.TryReserveAsync(scope, key, fingerprint, CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>(
+            "the suite expected this key to be free");
+        return ((IdempotencyReservationOutcome.Reserved)outcome).ReservationId;
+    }
+
+    private ValueTask<string> ReserveOnAsync(IIdempotencyStore store, string key, string fingerprint) =>
+        ReserveOnAsync(store, Scope, key, fingerprint);
+
+    // ---- Reserving -------------------------------------------------------------------------
+
+    /// <summary>
+    /// A free key must be granted, and the reservation id must be usable as a token, so the store
+    /// can later tell this request apart from one that took the slot over.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_on_a_free_key_returns_Reserved_with_a_non_empty_reservation_id()
+    {
+        var store = await NewStoreAsync();
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+        ((IdempotencyReservationOutcome.Reserved)outcome).ReservationId.Should().NotBeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// While one request holds the slot, a second with the same fingerprint must be told to retry
+    /// rather than being allowed to execute concurrently. The suggested wait must be positive and
+    /// no longer than the configured timeout, since the slot cannot outlive it.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_while_another_request_holds_the_key_returns_AlreadyInFlight()
+    {
+        var (store, _) = await ReserveAsync("key-1", "fp-1");
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.AlreadyInFlight>();
+        var retryAfter = ((IdempotencyReservationOutcome.AlreadyInFlight)outcome).RetryAfter;
+        retryAfter.Should().BePositive();
+        retryAfter.Should().BeLessThanOrEqualTo(ReservationTimeout,
+            "the reservation expires after ReservationTimeout, so waiting longer than that is never required");
+    }
+
+    /// <summary>
+    /// Scope keeps tenants and actors apart. Without this, one client could replay another's
+    /// response — or block it — simply by guessing a key.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_under_a_different_scope_does_not_collide()
+    {
+        var store = await NewStoreAsync();
+        await ReserveOnAsync(store, $"{Scope}-alice", "shared-key", "fp-1");
+
+        var outcome = await store.TryReserveAsync(
+            $"{Scope}-bob", "shared-key", "fp-1", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+    }
+
+    /// <summary>
+    /// The point of the whole mechanism: once a response is recorded, a retry replays it instead
+    /// of running the handler again.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_after_Complete_replays_the_snapshot_for_a_matching_fingerprint()
+    {
+        var (store, reservationId) = await ReserveAsync("key-1", "fp-1");
+        var snapshot = SnapshotFor("fp-1");
+        await store.CompleteAsync(Scope, "key-1", reservationId, snapshot, CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Replay>();
+        ShouldMatch(((IdempotencyReservationOutcome.Replay)outcome).Snapshot, snapshot);
+    }
+
+    /// <summary>
+    /// Reusing a key with a different body is a client bug. Replaying the old response would hide
+    /// it and silently drop the new request, so the store must report the mismatch instead.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_after_Complete_with_a_different_fingerprint_returns_BodyHashMismatch()
+    {
+        var (store, reservationId) = await ReserveAsync("key-1", "fp-original");
+        await store.CompleteAsync(
+            Scope, "key-1", reservationId, SnapshotFor("fp-original"), CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-different", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.BodyHashMismatch>();
+        ((IdempotencyReservationOutcome.BodyHashMismatch)outcome).StoredFingerprint
+            .Should().Be("fp-original");
+    }
+
+    /// <summary>
+    /// The same protection applies before the first request finishes: a different body must not be
+    /// able to queue behind, or take over, an in-flight reservation.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_while_in_flight_with_a_different_fingerprint_returns_BodyHashMismatch()
+    {
+        var (store, _) = await ReserveAsync("key-1", "fp-1");
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-different", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.BodyHashMismatch>();
+        ((IdempotencyReservationOutcome.BodyHashMismatch)outcome).StoredFingerprint.Should().Be("fp-1");
+    }
+
+    // ---- Expiry ----------------------------------------------------------------------------
+
+    /// <summary>
+    /// A crashed or hung handler must not hold a key forever. Once the timeout passes, a retry of
+    /// the same request takes the slot over and receives a new reservation id — the old id is what
+    /// lets the store reject the original request if it ever finishes.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_after_the_reservation_timeout_takes_over_with_a_new_reservation_id()
+    {
+        var (store, first) = await ReserveAsync("key-1", "fp-1");
+
+        await AdvanceAsync(ReservationTimeout + TimeSpan.FromSeconds(1));
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+        ((IdempotencyReservationOutcome.Reserved)outcome).ReservationId.Should().NotBe(first,
+            "a takeover must issue a new token so the displaced request's completion can be rejected");
+    }
+
+    /// <summary>
+    /// Takeover is for retries of the same request. An expired reservation must still refuse a
+    /// different body rather than letting it claim the key.
+    /// </summary>
+    [Fact]
+    public async Task Reserve_after_the_reservation_timeout_with_a_different_fingerprint_returns_BodyHashMismatch()
+    {
+        var (store, _) = await ReserveAsync("key-1", "fp-1");
+
+        await AdvanceAsync(ReservationTimeout + TimeSpan.FromSeconds(1));
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-different", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.BodyHashMismatch>();
+        ((IdempotencyReservationOutcome.BodyHashMismatch)outcome).StoredFingerprint.Should().Be("fp-1");
+    }
+
+    /// <summary>
+    /// Snapshots are retained for <see cref="Ttl"/> and no longer. Afterwards the key behaves as
+    /// if it had never been used.
+    /// </summary>
+    /// <remarks>
+    /// A store that leaves expiry entirely to a server-side sweep fails here, because Cosmos DB
+    /// deletes expired items on a best-effort background pass and can still return one. Record an
+    /// expiry timestamp and re-check it on read.
+    /// </remarks>
+    [Fact]
+    public async Task Reserve_after_the_ttl_elapses_treats_a_completed_entry_as_absent()
+    {
+        var (store, reservationId) = await ReserveAsync("key-1", "fp-1");
+        await store.CompleteAsync(
+            Scope, "key-1", reservationId, SnapshotFor("fp-1"), CancellationToken.None);
+
+        await AdvanceAsync(Ttl + TimeSpan.FromSeconds(1));
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+    }
+
+    // ---- Completing and abandoning ----------------------------------------------------------
+
+    /// <summary>
+    /// The displaced request must not be able to publish its response after losing the slot.
+    /// Otherwise the client replays the output of an execution that the takeover already
+    /// superseded.
+    /// </summary>
+    [Fact]
+    public async Task Complete_with_a_reservation_id_that_lost_the_slot_is_ignored()
+    {
+        var (store, first) = await ReserveAsync("key-1", "fp-1");
+
+        await AdvanceAsync(ReservationTimeout + TimeSpan.FromSeconds(1));
+        var takeover = await ReserveOnAsync(store, "key-1", "fp-1");
+
+        // The displaced request finally finishes and tries to publish its response.
+        await store.CompleteAsync(
+            Scope, "key-1", first, SnapshotFor("fp-1", bodyMarker: 0x01), CancellationToken.None);
+
+        // The request that actually owns the slot completes normally.
+        var winning = SnapshotFor("fp-1", bodyMarker: 0x02);
+        await store.CompleteAsync(Scope, "key-1", takeover, winning, CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Replay>();
+        ShouldMatch(((IdempotencyReservationOutcome.Replay)outcome).Snapshot, winning);
+    }
+
+    /// <summary>
+    /// A handler that fails must release the key immediately so the client can retry, rather than
+    /// making it wait out the reservation timeout.
+    /// </summary>
+    [Fact]
+    public async Task Abandon_releases_the_slot_for_an_immediate_retry()
+    {
+        var (store, reservationId) = await ReserveAsync("key-1", "fp-1");
+
+        await store.AbandonAsync(Scope, "key-1", reservationId, CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+    }
+
+    /// <summary>
+    /// The mirror of the stale-completion rule: a displaced request failing must not release the
+    /// slot out from under the request that took it over, which is still running.
+    /// </summary>
+    [Fact]
+    public async Task Abandon_with_a_reservation_id_that_lost_the_slot_is_ignored()
+    {
+        var (store, first) = await ReserveAsync("key-1", "fp-1");
+
+        await AdvanceAsync(ReservationTimeout + TimeSpan.FromSeconds(1));
+        await ReserveOnAsync(store, "key-1", "fp-1");
+
+        await store.AbandonAsync(Scope, "key-1", first, CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.AlreadyInFlight>(
+            "the takeover reservation is still running and must keep the slot");
+    }
+
+    /// <summary>
+    /// The middleware calls <see cref="IIdempotencyStore.AbandonAsync"/> from the failure paths
+    /// around <see cref="IIdempotencyStore.CompleteAsync"/>. A store that persisted the snapshot
+    /// and then threw on a secondary step would, if abandon deleted unconditionally, destroy a
+    /// response it had already durably recorded — and the retry would execute the handler again.
+    /// </summary>
+    [Fact]
+    public async Task Abandon_after_Complete_must_not_delete_the_persisted_snapshot()
+    {
+        var (store, reservationId) = await ReserveAsync("key-1", "fp-1");
+        var snapshot = SnapshotFor("fp-1");
+        await store.CompleteAsync(Scope, "key-1", reservationId, snapshot, CancellationToken.None);
+
+        await store.AbandonAsync(Scope, "key-1", reservationId, CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "key-1", "fp-1", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Replay>(
+            "AbandonAsync must not delete a snapshot CompleteAsync already persisted");
+        ShouldMatch(((IdempotencyReservationOutcome.Replay)outcome).Snapshot, snapshot);
+    }
+
+    /// <summary>
+    /// Both calls are best-effort cleanup that the middleware may make after the entry has already
+    /// expired, so an unknown key is a no-op rather than an error.
+    /// </summary>
+    [Fact]
+    public async Task Complete_on_a_key_that_was_never_reserved_is_ignored()
+    {
+        var store = await NewStoreAsync();
+
+        await store.CompleteAsync(
+            Scope, "never-reserved", "bogus", SnapshotFor("fp-1"), CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "never-reserved", "fp-1", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>(
+            "a completion for a key that was never reserved must not create an entry");
+    }
+
+    /// <inheritdoc cref="Complete_on_a_key_that_was_never_reserved_is_ignored"/>
+    [Fact]
+    public async Task Abandon_on_a_key_that_was_never_reserved_is_ignored()
+    {
+        var store = await NewStoreAsync();
+
+        await store.AbandonAsync(Scope, "never-reserved", "bogus", CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "never-reserved", "fp-1", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Reserved>();
+    }
+
+    // ---- Concurrency -----------------------------------------------------------------------
+
+    /// <summary>
+    /// The load-bearing guarantee. If reservation is not atomic, two racing callers both believe
+    /// they own the key and the handler runs twice — precisely the double execution the middleware
+    /// exists to prevent. A store must reserve with a single atomic operation such as Redis
+    /// <c>SET NX</c>, a Cosmos DB insert that conflicts on duplicate id, or a unique-index insert.
+    /// </summary>
+    [Fact]
+    public async Task Concurrent_reservations_of_one_key_grant_exactly_one_winner()
+    {
+        var store = await NewStoreAsync();
+        var callers = ConcurrentReservationAttempts;
+        callers.Should().BeGreaterThanOrEqualTo(2, "a race needs at least two callers");
+
+        // Every caller blocks on one gate and is released together. Parallel.ForEachAsync would
+        // instead cap concurrency at Environment.ProcessorCount, so on a single-CPU host or
+        // container the calls would run serially and a read-then-write store would pass this rule
+        // — leaving the suite's most important guarantee silently unenforced.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = Enumerable.Range(0, callers).Select(async _ =>
+        {
+            await gate.Task;
+            return await store.TryReserveAsync(Scope, "race-key", "fp-1", CancellationToken.None);
+        }).ToArray();
+
+        gate.SetResult();
+        var outcomes = await Task.WhenAll(attempts);
+
+        outcomes.OfType<IdempotencyReservationOutcome.Reserved>().Should().ContainSingle(
+            "exactly one caller may hold the slot; every other caller must be told it is in flight");
+        outcomes.OfType<IdempotencyReservationOutcome.AlreadyInFlight>().Should().HaveCount(callers - 1,
+            "nothing has been completed yet, so no caller may observe Replay or BodyHashMismatch");
+    }
+
+    /// <summary>
+    /// Reservations belong to their key. Traffic on unrelated keys must not clear one — a store
+    /// that sweeps expired entries too eagerly would orphan a slow handler and let its response be
+    /// lost.
+    /// </summary>
+    [Fact]
+    public async Task An_in_flight_reservation_survives_traffic_on_other_keys()
+    {
+        var (store, slow) = await ReserveAsync("slow", "fp-slow");
+
+        await ReserveOnAsync(store, "unrelated", "fp-unrelated");
+
+        var snapshot = SnapshotFor("fp-slow");
+        await store.CompleteAsync(Scope, "slow", slow, snapshot, CancellationToken.None);
+
+        var outcome = await store.TryReserveAsync(Scope, "slow", "fp-slow", CancellationToken.None);
+        outcome.Should().BeOfType<IdempotencyReservationOutcome.Replay>(
+            "the slow handler still owned its reservation, so its completion must have been accepted");
+        ShouldMatch(((IdempotencyReservationOutcome.Replay)outcome).Snapshot, snapshot);
+    }
+}

--- a/Trellis.Testing.Idempotency/src/Trellis.Testing.Idempotency.csproj
+++ b/Trellis.Testing.Idempotency/src/Trellis.Testing.Idempotency.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>Trellis.Testing.Idempotency</AssemblyName>
+    <RootNamespace>Trellis.Testing.Idempotency</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!--
+      The suite is only ever loaded by a test host, never AOT-published, and the xUnit and
+      FluentAssertions surface it builds on is not annotated for trimming. Leaving the repo-wide
+      analyzers on would fail the build on warnings that cannot be actioned here.
+    -->
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+
+    <!-- Conformance test names read as sentences; the repo's test projects suppress this too. -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+
+    <PackageId>Trellis.Testing.Idempotency</PackageId>
+    <Description>Executable conformance suite for Trellis IIdempotencyStore implementations - inherit one class to prove a Redis, Cosmos DB, EF Core, or bespoke store satisfies the reserve, replay, takeover, and abandon contract</Description>
+    <PackageTags>trellis;testing;idempotency;conformance;contract-tests;aspnetcore;redis;cosmosdb;http</PackageTags>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+    <TrellisApiRefName>testing-idempotency</TrellisApiRefName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/Trellis.Testing.Idempotency/tests/ConfigurableIdempotencyStore.cs
+++ b/Trellis.Testing.Idempotency/tests/ConfigurableIdempotencyStore.cs
@@ -1,0 +1,231 @@
+﻿namespace Trellis.Testing.Idempotency.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Trellis.Asp.Idempotency;
+
+/// <summary>
+/// Defects that <see cref="ConfigurableIdempotencyStore"/> can be told to exhibit, so the
+/// conformance suite can be proven to catch each one.
+/// </summary>
+[Flags]
+public enum StoreDefects
+{
+    /// <summary>Behave correctly.</summary>
+    None = 0,
+
+    /// <summary>Accept any reservation id on complete and abandon, including a displaced one.</summary>
+    IgnoreReservationId = 1,
+
+    /// <summary>Delete the entry on abandon even after a snapshot has been persisted.</summary>
+    DeleteSnapshotOnAbandon = 1 << 1,
+
+    /// <summary>Key entries by key alone, letting one scope observe another's entries.</summary>
+    IgnoreScope = 1 << 2,
+
+    /// <summary>Check for an existing entry and then write, without holding a lock across both.</summary>
+    NonAtomicReserve = 1 << 3,
+
+    /// <summary>Keep serving a completed snapshot after its TTL has elapsed.</summary>
+    IgnoreTtl = 1 << 4,
+
+    /// <summary>Reissue the displaced reservation's id when taking a slot over.</summary>
+    ReuseReservationIdOnTakeover = 1 << 5,
+
+    /// <summary>
+    /// Lower-case header names on the way out. Not a defect — <c>IdempotencyResponseSnapshot</c>
+    /// documents header names as case-insensitive — so the suite must <em>accept</em> this. Used
+    /// to prove the suite does not over-specify.
+    /// </summary>
+    NormalizeHeaderCasing = 1 << 6,
+}
+
+/// <summary>
+/// A second, independent <see cref="IIdempotencyStore"/> implementation whose behaviour can be
+/// selectively broken. With <see cref="StoreDefects.None"/> it is correct, which proves the
+/// conformance suite is satisfiable by something other than the store it was extracted from.
+/// </summary>
+internal sealed class ConfigurableIdempotencyStore(
+    IdempotencyOptions options, TimeProvider time, StoreDefects defects) : IIdempotencyStore
+{
+    private sealed class Entry
+    {
+        public required string Fingerprint { get; set; }
+        public required string ReservationId { get; set; }
+        public required DateTimeOffset ExpiresAt { get; set; }
+        public IdempotencyResponseSnapshot? Snapshot { get; set; }
+        public bool IsCompleted => Snapshot is not null;
+    }
+
+    private readonly Dictionary<string, Entry> _entries = [];
+    private readonly Lock _gate = new();
+
+    private bool Has(StoreDefects defect) => (defects & defect) != 0;
+
+    private string KeyFor(string scope, string key) =>
+        Has(StoreDefects.IgnoreScope) ? key : $"{scope}\u001f{key}";
+
+    public async ValueTask<IdempotencyReservationOutcome> TryReserveAsync(
+        string scope, string key, string fingerprint, CancellationToken cancellationToken)
+    {
+        if (!Has(StoreDefects.NonAtomicReserve))
+            return Reserve(scope, key, fingerprint);
+
+        var id = KeyFor(scope, key);
+        lock (_gate)
+        {
+            if (_entries.ContainsKey(id))
+                return new IdempotencyReservationOutcome.AlreadyInFlight(options.ReservationTimeout);
+        }
+
+        // The window every racing caller slips through when reserve is not one atomic operation.
+        await Task.Delay(50, cancellationToken).ConfigureAwait(false);
+
+        var reservationId = Guid.NewGuid().ToString("N");
+        lock (_gate)
+        {
+            _entries[id] = new Entry
+            {
+                Fingerprint = fingerprint,
+                ReservationId = reservationId,
+                ExpiresAt = time.GetUtcNow() + options.ReservationTimeout,
+            };
+        }
+
+        return new IdempotencyReservationOutcome.Reserved(reservationId);
+    }
+
+    private IdempotencyReservationOutcome Reserve(string scope, string key, string fingerprint)
+    {
+        var id = KeyFor(scope, key);
+        var now = time.GetUtcNow();
+
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(id, out var entry))
+            {
+                var completedAndExpired = entry.IsCompleted
+                    && now >= entry.ExpiresAt
+                    && !Has(StoreDefects.IgnoreTtl);
+
+                if (completedAndExpired)
+                {
+                    _entries.Remove(id);
+                }
+                else
+                {
+                    if (!string.Equals(entry.Fingerprint, fingerprint, StringComparison.Ordinal))
+                        return new IdempotencyReservationOutcome.BodyHashMismatch(entry.Fingerprint);
+
+                    if (entry.IsCompleted)
+                        return new IdempotencyReservationOutcome.Replay(entry.Snapshot!);
+
+                    if (now < entry.ExpiresAt)
+                        return new IdempotencyReservationOutcome.AlreadyInFlight(entry.ExpiresAt - now);
+
+                    var takeoverId = Has(StoreDefects.ReuseReservationIdOnTakeover)
+                        ? entry.ReservationId
+                        : Guid.NewGuid().ToString("N");
+                    entry.ReservationId = takeoverId;
+                    entry.ExpiresAt = now + options.ReservationTimeout;
+                    return new IdempotencyReservationOutcome.Reserved(takeoverId);
+                }
+            }
+
+            var reservationId = Guid.NewGuid().ToString("N");
+            _entries[id] = new Entry
+            {
+                Fingerprint = fingerprint,
+                ReservationId = reservationId,
+                ExpiresAt = now + options.ReservationTimeout,
+            };
+            return new IdempotencyReservationOutcome.Reserved(reservationId);
+        }
+    }
+
+    public ValueTask CompleteAsync(
+        string scope,
+        string key,
+        string reservationId,
+        IdempotencyResponseSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(KeyFor(scope, key), out var entry)
+                && !entry.IsCompleted
+                && Owns(entry, reservationId))
+            {
+                entry.Snapshot = Has(StoreDefects.NormalizeHeaderCasing)
+                    ? WithLowerCaseHeaderNames(snapshot)
+                    : snapshot;
+                entry.ExpiresAt = time.GetUtcNow() + options.Ttl;
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private static IdempotencyResponseSnapshot WithLowerCaseHeaderNames(
+        IdempotencyResponseSnapshot snapshot)
+    {
+        var headers = new Dictionary<string, string[]>(StringComparer.Ordinal);
+        foreach (var (name, values) in snapshot.Headers)
+            headers[name.ToLowerInvariant()] = values;
+
+        return snapshot with { Headers = headers };
+    }
+
+    public ValueTask AbandonAsync(
+        string scope, string key, string reservationId, CancellationToken cancellationToken)
+    {
+        var id = KeyFor(scope, key);
+        lock (_gate)
+        {
+            if (_entries.TryGetValue(id, out var entry))
+            {
+                var mayRemove = entry.IsCompleted
+                    ? Has(StoreDefects.DeleteSnapshotOnAbandon)
+                    : Owns(entry, reservationId);
+
+                if (mayRemove)
+                    _entries.Remove(id);
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private bool Owns(Entry entry, string reservationId) =>
+        Has(StoreDefects.IgnoreReservationId)
+        || string.Equals(entry.ReservationId, reservationId, StringComparison.Ordinal);
+}
+
+/// <summary>
+/// Binds <see cref="ConfigurableIdempotencyStore"/> to the conformance suite.
+/// </summary>
+/// <remarks>
+/// Deliberately <c>internal</c> and nested-free but non-public so xUnit does not discover it as a
+/// test class — the meta-tests invoke individual rules on it by hand and assert that broken stores
+/// make them fail.
+/// </remarks>
+internal sealed class DefectiveStoreSuite(StoreDefects defects) : IdempotencyStoreConformance
+{
+    private readonly FakeTimeProvider _time = new();
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new ConfigurableIdempotencyStore(options, _time, defects));
+
+    protected override Task AdvanceAsync(TimeSpan duration)
+    {
+        _time.Advance(duration);
+        return Task.CompletedTask;
+    }
+
+    // Task.Delay in the non-atomic reserve path is real time, so keep the racing caller count
+    // modest while still making a non-atomic store fail every run.
+    protected override int ConcurrentReservationAttempts => 8;
+}

--- a/Trellis.Testing.Idempotency/tests/IdempotencyStoreConformanceMetaTests.cs
+++ b/Trellis.Testing.Idempotency/tests/IdempotencyStoreConformanceMetaTests.cs
@@ -1,0 +1,119 @@
+﻿namespace Trellis.Testing.Idempotency.Tests;
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit.Sdk;
+
+/// <summary>
+/// Proves the conformance suite is worth inheriting.
+/// </summary>
+/// <remarks>
+/// A suite of tests that passes for every store is worse than no suite at all, because it grants
+/// false confidence. Each test here runs one rule against a store built to violate exactly that
+/// rule and asserts the rule fails. <see cref="A_correct_store_passes_every_rule"/> closes the
+/// loop from the other side, running the whole suite against a correct implementation that is not
+/// the one the rules were extracted from.
+/// </remarks>
+public class IdempotencyStoreConformanceMetaTests
+{
+    private static async Task ShouldFail(
+        StoreDefects defects, Func<IdempotencyStoreConformance, Task> rule)
+    {
+        var act = async () => await rule(new DefectiveStoreSuite(defects));
+
+        await act.Should().ThrowAsync<XunitException>(
+            "the conformance suite must reject a store with this defect");
+    }
+
+    [Fact]
+    public async Task Suite_rejects_a_store_that_accepts_a_displaced_reservation_id_on_complete() =>
+        await ShouldFail(
+            StoreDefects.IgnoreReservationId,
+            suite => suite.Complete_with_a_reservation_id_that_lost_the_slot_is_ignored());
+
+    [Fact]
+    public async Task Suite_rejects_a_store_that_accepts_a_displaced_reservation_id_on_abandon() =>
+        await ShouldFail(
+            StoreDefects.IgnoreReservationId,
+            suite => suite.Abandon_with_a_reservation_id_that_lost_the_slot_is_ignored());
+
+    [Fact]
+    public async Task Suite_rejects_a_store_whose_abandon_deletes_a_persisted_snapshot() =>
+        await ShouldFail(
+            StoreDefects.DeleteSnapshotOnAbandon,
+            suite => suite.Abandon_after_Complete_must_not_delete_the_persisted_snapshot());
+
+    [Fact]
+    public async Task Suite_rejects_a_store_that_ignores_scope() =>
+        await ShouldFail(
+            StoreDefects.IgnoreScope,
+            suite => suite.Reserve_under_a_different_scope_does_not_collide());
+
+    [Fact]
+    public async Task Suite_rejects_a_store_whose_reserve_is_not_atomic() =>
+        await ShouldFail(
+            StoreDefects.NonAtomicReserve,
+            suite => suite.Concurrent_reservations_of_one_key_grant_exactly_one_winner());
+
+    [Fact]
+    public async Task Suite_rejects_a_store_that_serves_a_snapshot_past_its_ttl() =>
+        await ShouldFail(
+            StoreDefects.IgnoreTtl,
+            suite => suite.Reserve_after_the_ttl_elapses_treats_a_completed_entry_as_absent());
+
+    [Fact]
+    public async Task Suite_rejects_a_store_that_reuses_the_reservation_id_on_takeover() =>
+        await ShouldFail(
+            StoreDefects.ReuseReservationIdOnTakeover,
+            suite => suite.Reserve_after_the_reservation_timeout_takes_over_with_a_new_reservation_id());
+
+    /// <summary>
+    /// The mirror of the rejection tests: the suite must not reject a store for behaviour the
+    /// contract explicitly permits. `IdempotencyResponseSnapshot` documents header names as
+    /// case-insensitive, so a store that normalizes their casing is conforming.
+    /// </summary>
+    [Fact]
+    public async Task Suite_accepts_a_store_that_normalizes_header_name_casing()
+    {
+        var suite = new DefectiveStoreSuite(StoreDefects.NormalizeHeaderCasing);
+
+        await suite.Reserve_after_Complete_replays_the_snapshot_for_a_matching_fingerprint();
+    }
+
+    /// <summary>
+    /// Runs every rule in the suite against a correct store, mirroring how xUnit runs them: a
+    /// fresh suite instance, and therefore a fresh store, per rule.
+    /// </summary>
+    /// <remarks>
+    /// Discovered reflectively rather than listed, so a rule added to the suite is covered here
+    /// automatically instead of silently escaping this check.
+    /// </remarks>
+    [Fact]
+    public async Task A_correct_store_passes_every_rule()
+    {
+        var rules = Rules();
+        rules.Should().HaveCountGreaterThanOrEqualTo(17,
+            "the suite is not expected to shrink; update this floor deliberately if a rule is removed");
+
+        foreach (var rule in rules)
+        {
+            var suite = new DefectiveStoreSuite(StoreDefects.None);
+            await (Task)rule.Invoke(suite, [])!;
+        }
+    }
+
+    /// <summary>
+    /// Guards the shape the meta-tests depend on: rules must be public so a store author can
+    /// invoke one in isolation while diagnosing a failure.
+    /// </summary>
+    [Fact]
+    public void Every_rule_is_public_and_returns_a_Task() =>
+        Rules().Should().OnlyContain(m => m.IsPublic && m.ReturnType == typeof(Task));
+
+    private static MethodInfo[] Rules() =>
+        [.. typeof(IdempotencyStoreConformance)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => m.GetCustomAttribute<FactAttribute>() is not null)];
+}

--- a/Trellis.Testing.Idempotency/tests/Trellis.Testing.Idempotency.Tests.csproj
+++ b/Trellis.Testing.Idempotency/tests/Trellis.Testing.Idempotency.Tests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\src\Trellis.Testing.Idempotency.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+  </ItemGroup>
+</Project>

--- a/Trellis.slnx
+++ b/Trellis.slnx
@@ -79,6 +79,10 @@
     <Project Path="Trellis.Asp.ApiVersioning/src/Trellis.Asp.ApiVersioning.csproj" />
     <Project Path="Trellis.Asp.ApiVersioning/tests/Trellis.Asp.ApiVersioning.Tests.csproj" />
   </Folder>
+  <Folder Name="/Trellis.Asp.Idempotency.Cosmos/">
+    <Project Path="Trellis.Asp.Idempotency.Cosmos/src/Trellis.Asp.Idempotency.Cosmos.csproj" />
+    <Project Path="Trellis.Asp.Idempotency.Cosmos/tests/Trellis.Asp.Idempotency.Cosmos.Tests.csproj" />
+  </Folder>
   <Folder Name="/Trellis.Authorization/">
     <Project Path="Trellis.Authorization/src/Trellis.Authorization.csproj" />
     <Project Path="Trellis.Authorization/tests/Trellis.Authorization.Tests.csproj" />
@@ -158,6 +162,10 @@
   <Folder Name="/Trellis.Testing.AspNetCore/">
     <Project Path="Trellis.Testing.AspNetCore/src/Trellis.Testing.AspNetCore.csproj" />
     <Project Path="Trellis.Testing.AspNetCore/tests/Trellis.Testing.AspNetCore.Tests.csproj" />
+  </Folder>
+  <Folder Name="/Trellis.Testing.Idempotency/">
+    <Project Path="Trellis.Testing.Idempotency/src/Trellis.Testing.Idempotency.csproj" />
+    <Project Path="Trellis.Testing.Idempotency/tests/Trellis.Testing.Idempotency.Tests.csproj" />
   </Folder>
   <Folder Name="/Trellis.Testing.Worker/">
     <Project Path="Trellis.Testing.Worker/src/Trellis.Testing.Worker.csproj" />

--- a/Trellis.slnx
+++ b/Trellis.slnx
@@ -1,6 +1,5 @@
 ﻿<Solution>
   <Folder Name="/.github/">
-    <File Path=".github/codecov.yml" />
     <File Path=".github/copilot-instructions.md" />
     <File Path=".github/dependabot.yml" />
   </Folder>

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,14 @@ coverage:
 # Exclude non-framework code from coverage reporting.
 # Examples/ and samples/ are demonstration apps, not library code shipped to consumers.
 # Test projects and generated files should never count toward framework coverage.
+#
+# The two Cosmos DB files below are the only source files in the framework that cannot be executed
+# without a live service. They are covered — the full IIdempotencyStore conformance suite runs
+# against a real Cosmos DB emulator — but those tests are marked [Trait("Category", "Integration")]
+# and excluded from CI, matching the SQL Server-backed tests, so the coverage run cannot see them.
+# The exemption is deliberately per-file rather than per-package: the decision ordering, document
+# model, and service registration in the same package are all reachable offline and remain gated.
+# Revisit if the Cosmos DB emulator is ever run as a CI service container.
 ignore:
   - "Examples/"
   - "samples/"
@@ -21,6 +29,8 @@ ignore:
   - "**/*.designer.cs"
   - "**/obj/"
   - "**/bin/"
+  - "Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyStore.cs"
+  - "Trellis.Asp.Idempotency.Cosmos/src/CosmosIdempotencyContainer.cs"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md
@@ -1,0 +1,189 @@
+# Trellis.Asp.Idempotency.Cosmos API Reference
+
+Cosmos DB-backed `IIdempotencyStore` for the `Trellis.Asp` idempotency middleware.
+
+- **Package:** `Trellis.Asp.Idempotency.Cosmos`
+- **Namespace:** `Trellis.Asp.Idempotency.Cosmos`
+- **Depends on:** `Trellis.Asp`, `Microsoft.Azure.Cosmos`, `Newtonsoft.Json`
+
+## Why Cosmos DB
+
+`InMemoryIdempotencyStore` is documented as unsafe across instances and process restarts, so any
+multi-replica service needs a shared store. Cosmos DB fits the `IIdempotencyStore` contract
+unusually well:
+
+| Contract requirement | Cosmos DB primitive |
+| --- | --- |
+| Atomic reserve | `CreateItem` returns `409 Conflict` on a duplicate id within a partition, decided on the primary replica |
+| Conditional complete / abandon | Native ETag with `IfMatchEtag`, no scripting required |
+| Expiry | Per-item `ttl` reclaims storage without a sweeper process |
+| No silent eviction | Unlike a Redis cache under `allkeys-lru`, Cosmos DB never drops a live entry under memory pressure |
+| Diagnosis | Entries are queryable in Data Explorer |
+
+## Quick start
+
+```csharp
+// Startup: provision the container once. It must be partitioned on /scope with TTL enabled.
+var database = (await cosmosClient.CreateDatabaseIfNotExistsAsync("billing")).Database;
+await CosmosIdempotencyContainer.CreateIfNotExistsAsync(database);
+
+// Composition root.
+builder.Services.AddSingleton(cosmosClient);
+builder.Services.AddTrellisIdempotency(o => o.MaxResponseBodyBytes = 64 * 1024);
+builder.Services.AddCosmosIdempotencyStore("billing");
+
+// Pipeline: after UseRouting and UseAuthentication, so scope resolves to the authenticated actor.
+app.UseTrellisIdempotency();
+```
+
+## `CosmosIdempotencyStore`
+
+`public sealed class CosmosIdempotencyStore : IIdempotencyStore`
+
+| Member | Notes |
+| --- | --- |
+| `CosmosIdempotencyStore(Container container, IdempotencyOptions options, TimeProvider? timeProvider = null)` | `container` must use partition key path `/scope` with TTL enabled. `timeProvider` defaults to `TimeProvider.System`. |
+
+### How it stays correct
+
+**Reserve is one atomic operation.** A reservation is claimed with `CreateItem`, keyed by
+`id = Base64Url(key)` within partition `scope`. Cosmos DB resolves duplicates on the partition's
+primary replica, so exactly one concurrent caller wins. The store *never* grants a reservation on
+the strength of a read.
+
+**Every other mutation is ETag-conditional.** Taking over a timed-out reservation, recording a
+response, and releasing a slot are all `IfMatchEtag` replaces or deletes. A caller whose view is
+stale gets `412` and retries, so it cannot clobber newer state.
+
+**Session consistency is safe.** On a Session-consistency account, the read that follows a `409`
+may hit a replica that has not yet seen another instance's write, returning a stale item or a
+transient `404`. Neither can cause a double execution, because reservations are granted only by an
+atomic create or an ETag-conditional replace. A stale read simply produces `412`/`404` on the
+follow-up write and the operation retries. The worst observable effect is a spurious
+`AlreadyInFlight`, which the caller retries. **Strong consistency is not required.**
+
+**Expiry is enforced in-process, not by Cosmos DB.** Cosmos DB deletes expired items on a
+best-effort background sweep, so an item can outlive its `ttl` and still be returned by a read. The
+store re-checks `reservedAt` / `completedAt` on every read and treats a TTL-expired snapshot as
+absent. Per-item `ttl` is a storage-reclamation backstop only, and deletion is therefore only ever
+allowed to fall on a document the store's own rules have already made unreachable:
+
+| Document state | `ttl` | Why |
+|---|---|---|
+| Reserved | `-1` (never expires) | A reserved entry stays answerable indefinitely, because a request reusing the key with a different body must keep being rejected. A finite `ttl` would make that answer depend on whether a background sweep had happened to run. |
+| Completed | `Ttl + 60s` | Unreachable once the store treats it as absent, so deleting it cannot change an answer. |
+
+Reservations are removed by `AbandonAsync` or superseded on completion, so the only documents that
+accumulate are those whose process was killed between reserving and responding.
+
+**Reservation timeout depends on host clocks.** Takeover compares the reading instance's clock
+against a `reservedAt` written by another instance, so the effective timeout is the configured
+`ReservationTimeout` shifted by the clock skew between the two hosts. This is not a new failure
+mode — the timeout is a liveness bound that already permits taking over a handler that is merely
+slow rather than dead — but it moves the boundary. Set `ReservationTimeout` comfortably above the
+slowest expected handler *plus* the skew tolerated across the fleet, and keep hosts NTP-synchronised.
+`InMemoryIdempotencyStore` reads one clock and is not exposed to this.
+
+**Abandon never deletes a completed entry.** The middleware calls `AbandonAsync` from the failure
+paths around `CompleteAsync`, so an unconditional delete would destroy a response that was already
+durably recorded and let the retry re-run the handler.
+
+### Stored document
+
+```json
+{
+  "id": "aWRlbXBvdGVuY3kta2V5",
+  "scope": "actor:user-1",
+  "key": "idempotency-key",
+  "fingerprint": "sha256:...",
+  "reservationId": "3f2a...",
+  "reservedAt": 1767268800000,
+  "completedAt": 1767268801000,
+  "snapshot": { "statusCode": 201, "headers": { }, "body": "eyJ9", "fingerprint": "sha256:..." },
+  "ttl": 86460
+}
+```
+
+The example shows a completed entry; while reserved, `reservationId` is set, `completedAt` and
+`snapshot` are absent, and `ttl` is `-1`.
+
+Item ids are Base64Url-encoded because idempotency keys are client-supplied and may contain
+`/`, `\`, `?`, or `#`, none of which Cosmos DB permits in an id. Encoding rather than hashing keeps
+the mapping collision-free and reversible. The longest key `IdempotencyOptions.MaxKeyLength`
+permits (200) encodes well inside the 1023-byte id limit.
+
+## `CosmosIdempotencyContainer`
+
+| Member | Notes |
+| --- | --- |
+| `const string PartitionKeyPath` | `"/scope"` |
+| `static Task<Container> CreateIfNotExistsAsync(Database database, string containerId = "idempotency", int? throughput = null, CancellationToken ct = default)` | Creates the container with `DefaultTimeToLive = -1`, which enables TTL while expiring nothing by default, leaving each item's own `ttl` in control. |
+
+> Per-item `ttl` is **ignored** unless the container enables TTL. A container provisioned without
+> `DefaultTimeToLive` accumulates idempotency entries forever.
+
+## Registration
+
+`public static class CosmosIdempotencyServiceCollectionExtensions`
+
+| Signature | Notes |
+| --- | --- |
+| `AddCosmosIdempotencyStore(this IServiceCollection services, Func<IServiceProvider, Container> containerFactory)` | Use when the container is provisioned at startup or shared with other components. |
+| `AddCosmosIdempotencyStore(this IServiceCollection services, string databaseId, string containerId = "idempotency")` | Resolves `CosmosClient` from the container. Addresses the container; does not create it. |
+
+> **No `TrellisServiceBuilder.UseXxx()` slot**, by design. These are store registrations, in the
+> same category as `AddInMemoryIdempotencyStore()`: they do not participate in pipeline ordering,
+> so a builder slot would add surface without removing a decision.
+
+## Operational notes
+
+**Partition design.** Partitioning by scope keeps every operation for one key inside a single
+logical partition, which is what makes the create-or-conditionally-replace protocol atomic. Because
+scope derives from the actor or tenant, keys spread evenly in multi-tenant hosts. A host that
+mounts `UseTrellisIdempotency()` *before* authentication resolves every request to the shared
+`anonymous` scope, concentrating all traffic on one partition and capping it at that partition's
+throughput.
+
+**Request-unit cost.** RU charge scales with item size, so an entry costs roughly what its captured
+response body costs to write. With `MaxResponseBodyBytes` at its 1 MiB default, one completion can
+exceed 100 RU. Lower the cap, or keep large payloads out of the snapshot.
+
+**Newtonsoft.Json.** The Cosmos DB SDK v3 uses it internally but omits it from its package
+dependencies so consumers pin the version, and its build target fails without an explicit
+reference. This package therefore has a transitive `Newtonsoft.Json` dependency.
+
+**Stream APIs.** The store uses `CreateItemStreamAsync` / `ReadItemStreamAsync` /
+`ReplaceItemStreamAsync` / `DeleteItemStreamAsync` rather than the typed overloads, because a `409`
+is a *normal* outcome on the replay path — every retry produces one. The typed overloads raise
+`CosmosException` for it, which would put exception throwing on the hot path.
+
+## Verification
+
+The store is covered by the `Trellis.Testing.Idempotency` conformance suite running against a real
+Cosmos DB emulator — all 17 contract rules, not a substitute. Because expiry is enforced against an
+injected `TimeProvider`, the reservation-takeover and TTL rules run against real Cosmos DB with a
+fake clock and complete in the time of ordinary round trips.
+
+The suite skips, visibly, when no emulator is reachable. The decision-ordering rules and key
+encoding are additionally covered by tests that need no emulator.
+
+Tests that require the emulator are marked `[Trait("Category", "Integration")]`, matching the
+repository convention for SQL Server-backed tests, so CI excludes them via
+`--filter-not-trait "Category=Integration"`. To run them:
+
+```powershell
+# Requires the Azure Cosmos DB emulator on https://localhost:8081/
+dotnet test Trellis.Asp.Idempotency.Cosmos/tests/Trellis.Asp.Idempotency.Cosmos.Tests.csproj `
+  --filter-trait "Category=Integration"
+```
+
+| Run | Tests |
+|---|---|
+| Default / CI | 20 — decision ordering, key encoding, registration; no emulator needed |
+| `Category=Integration` | 19 — the 17 conformance rules plus the two `ttl` tests, against real Cosmos DB |
+
+## See also
+
+- [`trellis-api-asp.md`](trellis-api-asp.md#iidempotencystore) — the middleware and the contract.
+- [`trellis-api-testing-idempotency.md`](trellis-api-testing-idempotency.md#quick-start) — the
+  conformance suite, for authoring a different store.

--- a/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md
@@ -179,8 +179,13 @@ dotnet test Trellis.Asp.Idempotency.Cosmos/tests/Trellis.Asp.Idempotency.Cosmos.
 
 | Run | Tests |
 |---|---|
-| Default / CI | 20 — decision ordering, key encoding, registration; no emulator needed |
+| Default / CI | 36 — decision ordering, document model, key encoding, service registration; no emulator needed |
 | `Category=Integration` | 19 — the 17 conformance rules plus the two `ttl` tests, against real Cosmos DB |
+
+Because CI cannot see the integration run, `CosmosIdempotencyStore.cs` and
+`CosmosIdempotencyContainer.cs` are exempted in `codecov.yml`. The exemption is per-file, not
+per-package: everything reachable without a live service — decision ordering, the document model,
+and service registration — stays gated by the coverage target.
 
 ## See also
 

--- a/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp-idempotency-cosmos.md
@@ -84,6 +84,10 @@ slow rather than dead — but it moves the boundary. Set `ReservationTimeout` co
 slowest expected handler *plus* the skew tolerated across the fleet, and keep hosts NTP-synchronised.
 `InMemoryIdempotencyStore` reads one clock and is not exposed to this.
 
+A skewed clock can also make a reservation appear to have been made in the *future*, which would
+otherwise produce a `Retry-After` longer than the reservation can possibly live. The value is
+clamped into `(0, ReservationTimeout]`, so a client is never told to wait longer than the timeout.
+
 **Abandon never deletes a completed entry.** The middleware calls `AbandonAsync` from the failure
 paths around `CompleteAsync`, so an unconditional delete would destroy a response that was already
 durably recorded and let the retry re-run the handler.

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -490,6 +490,13 @@ public interface IIdempotencyStore
 | `ValueTask CompleteAsync(string scope, string key, string reservationId, IdempotencyResponseSnapshot snapshot, CancellationToken ct)` | `ValueTask` | Records the response snapshot under the reservation. Conditional on the reservation token (CAS) so a slow original handler whose reservation has been atomically taken over by a same-key retry cannot finalise the entry under the now-invalid token. |
 | `ValueTask AbandonAsync(string scope, string key, string reservationId, CancellationToken ct)` | `ValueTask` | Releases a reservation without a snapshot so the next retry can re-reserve. Called on any failure path (exception, response-too-large, `SendFileAsync`, abort, **5xx response status**, **response trailers**). |
 
+> **Writing your own store?** Inherit `IdempotencyStoreConformance` from the
+> `Trellis.Testing.Idempotency` package to run the full contract — atomic reserve, replay,
+> fingerprint mismatch, reservation takeover, TTL expiry, and abandon-after-complete — against your
+> implementation. Every rule here fails *silently* when violated, so the suite is the practical way
+> to know a Redis, Cosmos DB, or EF Core store is correct. See
+> [`trellis-api-testing-idempotency.md`](trellis-api-testing-idempotency.md#quick-start).
+
 ### `InMemoryIdempotencyStore`
 
 **Declaration**
@@ -498,7 +505,7 @@ public interface IIdempotencyStore
 public sealed class InMemoryIdempotencyStore : IIdempotencyStore
 ```
 
-Single-process `ConcurrentDictionary`-backed store. Register with `services.AddInMemoryIdempotencyStore()` for dev / single-instance hosts and tests. **Not safe across multiple instances or process restarts** — production hosts that retry across replicas need an EF-backed store that implements the same CAS contract.
+Single-process `ConcurrentDictionary`-backed store. Register with `services.AddInMemoryIdempotencyStore()` for dev / single-instance hosts and tests. **Not safe across multiple instances or process restarts** — production hosts that retry across replicas need a durable store implementing the same CAS contract. `Trellis.Asp.Idempotency.Cosmos` ships one; see [`trellis-api-asp-idempotency-cosmos.md`](trellis-api-asp-idempotency-cosmos.md#quick-start).
 
 ### `IIdempotencyScopeResolver`
 

--- a/docs/docfx_project/api_reference/trellis-api-testing-idempotency.md
+++ b/docs/docfx_project/api_reference/trellis-api-testing-idempotency.md
@@ -1,0 +1,183 @@
+# Trellis.Testing.Idempotency API Reference
+
+Executable conformance suite for `IIdempotencyStore` implementations.
+
+- **Package:** `Trellis.Testing.Idempotency`
+- **Namespace:** `Trellis.Testing.Idempotency`
+- **Depends on:** `Trellis.Asp` (for the contract types), `xunit.v3`, `FluentAssertions`
+
+## Why this package exists
+
+`Trellis.Asp` ships exactly one `IIdempotencyStore`: `InMemoryIdempotencyStore`, which its own
+documentation describes as *"not safe across multiple instances or process restarts"*. Every
+production deployment therefore writes its own store over Redis, Cosmos DB, a relational database,
+or something bespoke.
+
+The contract those stores must satisfy is subtle, and a violation fails **silently**. A store that
+reserves non-atomically lets two racing callers both execute the handler; a store whose
+`AbandonAsync` deletes unconditionally destroys a response that `CompleteAsync` already persisted.
+Neither throws. The symptom is a customer charged twice, weeks later.
+
+This package turns each rule into a test you inherit.
+
+## Quick start
+
+Add a single test class per store:
+
+```csharp
+namespace Contoso.Billing.Tests;
+
+using Trellis.Asp.Idempotency;
+using Trellis.Testing.Idempotency;
+
+public sealed class RedisIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    // Expiry is enforced by the Redis server, whose clock cannot be faked, so use short real
+    // timeouts and let AdvanceAsync keep its default real delay.
+    protected override TimeSpan ReservationTimeout => TimeSpan.FromSeconds(2);
+    protected override TimeSpan Ttl => TimeSpan.FromSeconds(4);
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new RedisIdempotencyStore(_multiplexer, options));
+}
+```
+
+For a store that reads the clock in-process through `TimeProvider`, override `AdvanceAsync`
+instead and keep the default timeouts, so the suite runs instantly:
+
+```csharp
+public sealed class InMemoryIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    private readonly FakeTimeProvider _time = new();
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new InMemoryIdempotencyStore(options, _time));
+
+    protected override Task AdvanceAsync(TimeSpan duration)
+    {
+        _time.Advance(duration);
+        return Task.CompletedTask;
+    }
+}
+```
+
+## `IdempotencyStoreConformance`
+
+`public abstract class IdempotencyStoreConformance`
+
+### Required member
+
+| Member | Notes |
+| --- | --- |
+| `protected abstract ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options)` | Called once per test. Must honour `options.Ttl` and `options.ReservationTimeout`, or the expiry tests are vacuous. |
+
+### Optional overrides
+
+| Member | Default | Override when |
+| --- | --- | --- |
+| `protected virtual TimeSpan ReservationTimeout` | 30 s | Expiry is server-enforced — drop to a few seconds. |
+| `protected virtual TimeSpan Ttl` | 1 h | Expiry is server-enforced — drop to a few seconds. |
+| `protected virtual Task AdvanceAsync(TimeSpan duration)` | `Task.Delay(duration)` | The store reads an injectable clock — advance the fake clock and return `Task.CompletedTask`. |
+| `protected virtual int ConcurrentReservationAttempts` | 32 | The store is a remote service with limited throughput. |
+
+### Helpers available to derived classes
+
+| Member | Notes |
+| --- | --- |
+| `protected string Scope { get; }` | Unique per test instance (xUnit constructs one per `[Fact]`), so a suite is safe against a **shared** Redis or Cosmos DB instance, in parallel. |
+| `protected static IdempotencyResponseSnapshot SnapshotFor(string fingerprint, byte bodyMarker = 0x7B)` | Builds a minimal distinguishable snapshot. |
+| `protected static void ShouldMatch(IdempotencyResponseSnapshot actual, IdempotencyResponseSnapshot expected)` | Field-by-field comparison. See the warning below. |
+
+> **Do not assert snapshot equality with `Should().Be(...)`.** `IdempotencyResponseSnapshot` is a
+> record whose `Headers` and `Body` members compare by **reference**. Record equality therefore
+> passes only for a store that returns the very instance it was handed — that is, only for an
+> in-memory store. Every durable store serialises and returns an equal-but-distinct instance. Use
+> `ShouldMatch`, which compares field by field and matches header names case-insensitively, as the
+> snapshot contract specifies.
+
+## The rules pinned by the suite
+
+### Reserving
+
+| Test | Rule |
+| --- | --- |
+| `Reserve_on_a_free_key_returns_Reserved_with_a_non_empty_reservation_id` | A free key is granted with a usable token. |
+| `Reserve_while_another_request_holds_the_key_returns_AlreadyInFlight` | Concurrent duplicate is told to retry; `RetryAfter` is positive and `<= ReservationTimeout`. |
+| `Reserve_under_a_different_scope_does_not_collide` | Scope isolates tenants and actors. |
+| `Reserve_after_Complete_replays_the_snapshot_for_a_matching_fingerprint` | The core replay guarantee. |
+| `Reserve_after_Complete_with_a_different_fingerprint_returns_BodyHashMismatch` | Key reuse with a new body is surfaced, not silently swallowed. `StoredFingerprint` carries the original. |
+| `Reserve_while_in_flight_with_a_different_fingerprint_returns_BodyHashMismatch` | Same protection before the first request finishes. |
+
+### Expiry
+
+| Test | Rule |
+| --- | --- |
+| `Reserve_after_the_reservation_timeout_takes_over_with_a_new_reservation_id` | A crashed handler cannot hold a key forever; takeover issues a **new** id. |
+| `Reserve_after_the_reservation_timeout_with_a_different_fingerprint_returns_BodyHashMismatch` | Takeover is for retries of the *same* request only. |
+| `Reserve_after_the_ttl_elapses_treats_a_completed_entry_as_absent` | Snapshots are retained for `Ttl` and no longer. |
+
+### Completing and abandoning
+
+| Test | Rule |
+| --- | --- |
+| `Complete_with_a_reservation_id_that_lost_the_slot_is_ignored` | A displaced request cannot publish its response over the winner's. |
+| `Abandon_releases_the_slot_for_an_immediate_retry` | A failed handler frees the key at once. |
+| `Abandon_with_a_reservation_id_that_lost_the_slot_is_ignored` | A displaced request cannot free the winner's slot. |
+| `Abandon_after_Complete_must_not_delete_the_persisted_snapshot` | The subtle one — see below. |
+| `Complete_on_a_key_that_was_never_reserved_is_ignored` | Best-effort cleanup, no throw, no entry created. |
+| `Abandon_on_a_key_that_was_never_reserved_is_ignored` | Best-effort cleanup, no throw. |
+
+### Concurrency
+
+| Test | Rule |
+| --- | --- |
+| `Concurrent_reservations_of_one_key_grant_exactly_one_winner` | Reservation must be a **single atomic operation**. The load-bearing guarantee. Callers are released together from a shared gate rather than through `Parallel.ForEachAsync`, so the race is exercised even on a single-CPU host. |
+| `An_in_flight_reservation_survives_traffic_on_other_keys` | Unrelated traffic must not orphan a slow handler's reservation. |
+
+## Implementation traps the suite catches
+
+### Non-atomic reserve
+
+A read-then-write reserve (`GetAsync` then `SetAsync`) passes every single-threaded test and fails
+under load, executing the handler twice. Reserve with one atomic primitive:
+
+| Backing store | Atomic reserve |
+| --- | --- |
+| Redis | `SET key value NX PX <reservationTimeout>` (or a Lua script when takeover logic is needed) |
+| Cosmos DB | `CreateItemAsync` — a duplicate id in the same partition returns HTTP 409 |
+| Relational | `INSERT` against a unique index on `(scope, key)` — catch the duplicate-key violation |
+
+`IDistributedCache` **cannot** back a conforming store: it has no atomic set-if-not-exists, so
+`TryReserveAsync` is not implementable on it. Use `StackExchange.Redis` directly.
+
+### Trusting server-side expiry
+
+Cosmos DB deletes expired items on a best-effort background sweep, so an item can outlive its
+`ttl` and still be returned by a read. Record your own expiry timestamp on the item and re-check it
+when reading, rather than assuming a returned item is live.
+
+### Eviction
+
+A Redis instance configured with `allkeys-lru` can evict a live reservation under memory pressure,
+silently permitting a double execution. Use `noeviction` for the idempotency database, and consider
+asserting the policy at startup with `CONFIG GET maxmemory-policy`.
+
+### Unconditional abandon
+
+`IdempotencyMiddleware` calls `AbandonAsync` from the failure paths around `CompleteAsync`. If
+`CompleteAsync` persisted the snapshot and then threw on a later step, an `AbandonAsync` that
+deletes unconditionally destroys a durably recorded response, and the retry re-executes the
+handler. Delete only when the entry is still in the reserved state.
+
+### Snapshot size and cost
+
+`IdempotencyOptions.MaxResponseBodyBytes` defaults to 1 MiB. On Cosmos DB, request-unit cost scales
+with item size, so a 1 MiB snapshot costs upwards of 100 RU to write. Lower the cap, or store large
+bodies in blob storage and keep a reference in the snapshot.
+
+## See also
+
+- `docs/docfx_project/api_reference/trellis-api-asp.md` — the idempotency middleware and the
+  `IIdempotencyStore` contract itself.
+- `docs/docfx_project/api_reference/trellis-api-testing-aspnetcore.md` — ASP.NET Core integration
+  test helpers.

--- a/docs/docfx_project/articles/integration-aspnet.md
+++ b/docs/docfx_project/articles/integration-aspnet.md
@@ -1,8 +1,8 @@
 ﻿---
 title: ASP.NET Core Integration
 package: Trellis.Asp
-topics: [asp, minimal-api, controllers, http-result, problem-details, etag, prefer, pagination]
-related_api_reference: [trellis-api-asp.md, trellis-api-core.md]
+topics: [asp, minimal-api, controllers, http-result, problem-details, etag, prefer, pagination, idempotency]
+related_api_reference: [trellis-api-asp.md, trellis-api-core.md, trellis-api-asp-idempotency-cosmos.md]
 last_verified: 2026-05-01
 audience: [developer]
 ---
@@ -25,6 +25,8 @@ audience: [developer]
 | Emit `201 Created` with a `Location` header | `opts.CreatedAtRoute(name, values)` (AOT-safe) / `Created(...)` / `CreatedAtAction(...)` | [Created responses](#created-responses) |
 | Return paginated JSON + RFC 8288 `Link` header | `Result<Page<T>>.ToHttpResponse(nextUrlBuilder, body)` | [Pagination](#pagination) |
 | Make `POST` / `PATCH` retry-safe with the IETF `Idempotency-Key` header | `AddTrellisIdempotency` + `AddInMemoryIdempotencyStore` + `UseTrellisIdempotency`; mark endpoints `[Idempotent]` | [Idempotency-Key middleware](#idempotency-key-middleware) |
+| Make idempotency survive restarts and span replicas | `AddCosmosIdempotencyStore(...)` (`Trellis.Asp.Idempotency.Cosmos`) | [Choosing a store](#idempotency-key-middleware) |
+| Verify a custom `IIdempotencyStore` against the contract | Derive from `IdempotencyStoreConformance` (`Trellis.Testing.Idempotency`) | [Choosing a store](#idempotency-key-middleware) |
 | Validate scalar value objects (route, query, JSON body) | `AddScalarValueValidation` + `UseScalarValueValidation` + `WithScalarValueValidation` | [Scalar value validation](#scalar-value-validation) |
 | Bind value objects in route segments | `AddTrellisRouteConstraint<T>("Name")` then `"/x/{id:Name}"` | [Route constraints](#route-constraints) |
 | Hydrate the current `Actor` from JWT claims | `AddClaimsActorProvider` / `AddEntraActorProvider` / `AddDevelopmentActorProvider` / `AddNestedJsonPathClaimsActorProvider` | [Actor providers](#actor-providers) |
@@ -508,7 +510,7 @@ using Trellis.Asp.Idempotency;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddTrellis(t => t.UseAsp());
 builder.Services.AddTrellisIdempotency();        // options: AddTrellisIdempotency(o => { o.Ttl = TimeSpan.FromHours(1); })
-builder.Services.AddInMemoryIdempotencyStore();  // production hosts supply their own IIdempotencyStore
+builder.Services.AddInMemoryIdempotencyStore();  // dev / single instance; see below for production stores
 
 var app = builder.Build();
 app.UseTrellisIdempotency();                     // before MapControllers / endpoint mapping
@@ -537,12 +539,25 @@ For MVC controllers add `[Idempotent]` to the action method instead of `.WithMet
 | Response capture | `Set-Cookie`, `Date`, `Server`, and hop-by-hop headers (`Connection`, `Keep-Alive`, `Transfer-Encoding`, `Upgrade`, `Proxy-Authenticate`, `Proxy-Authorization`, `TE`, `Trailer`) are stripped from the snapshot. Cookies stay out by default so a replay does not re-issue rotated session tokens; opt back in via `IncludeSetCookieInSnapshot = true`. |
 | Failure paths | 5xx responses, response trailers, `SendFileAsync`, oversized request / response bodies (>1 MiB by default), and unhandled exceptions abandon the reservation so the next retry re-executes. |
 
-**`IIdempotencyStore`** is the persistence seam. `AddInMemoryIdempotencyStore()` is fine for single-instance dev hosts and tests; it sweeps completed-and-expired snapshots opportunistically so memory stays bounded by `Ttl`. Production hosts that retry across multiple replicas must supply their own implementation backed by shared storage (EF Core, Redis, Cosmos DB, …) honouring the same CAS contract.
+**`IIdempotencyStore`** is the persistence seam.
+
+| Store | Package | Use when |
+|---|---|---|
+| `AddInMemoryIdempotencyStore()` | `Trellis.Asp` | Single-instance dev hosts and tests. Sweeps completed-and-expired snapshots opportunistically so memory stays bounded by `Ttl`. **Not safe across instances or process restarts.** |
+| `AddCosmosIdempotencyStore(...)` | `Trellis.Asp.Idempotency.Cosmos` | Production hosts that retry across replicas. Reservations are atomic (`CreateItem` → `409`), completion and abandonment are ETag-conditional, and per-item TTL reclaims storage. |
+| Your own | — | Any other backing store. Derive a test class from `IdempotencyStoreConformance` in `Trellis.Testing.Idempotency` to check it against all 17 contract rules. |
+
+Choosing a store is a one-line decision alongside `AddTrellisIdempotency()`; it does not participate in pipeline ordering, so there is no `TrellisServiceBuilder.UseXxx()` slot for it.
+
+> [!NOTE]
+> Not every cache can back a conforming store. The contract needs an **atomic** set-if-not-exists, which `IDistributedCache` does not expose. A Redis-backed store must use `SET NX` (or a script) directly, and must not run under an eviction policy such as `allkeys-lru` — evicting a live reservation silently allows a double charge.
 
 > [!IMPORTANT]
 > `UseTrellisIdempotency()` must run **after `UseRouting()`** so the middleware can see the endpoint's `[Idempotent]` metadata and buffer the request body before the handler consumes it, and **after `UseAuthentication()` / `UseAuthorization()`** so the default `DefaultIdempotencyScopeResolver` partitions the store by the authenticated `Actor`. Mounting before authentication causes every authenticated request to fall back to the shared `anonymous` scope, which lets different users collide on the same key. In a Minimal API host where `UseRouting` is not called explicitly, the runtime inserts routing implicitly; placing `UseTrellisIdempotency()` after `UseAuthentication()` / `UseAuthorization()` and immediately before `MapControllers()` / `MapGet(...)` is equivalent.
 
 Full surface (options, store, scope resolver, attribute, parser, fingerprint helpers): [`trellis-api-asp.md`](../api_reference/trellis-api-asp.md#namespace-trellisaspidempotency).
+Cosmos DB store: [`trellis-api-asp-idempotency-cosmos.md`](../api_reference/trellis-api-asp-idempotency-cosmos.md#quick-start).
+Conformance suite for a custom store: [`trellis-api-testing-idempotency.md`](../api_reference/trellis-api-testing-idempotency.md#quick-start).
 
 ## Scalar value validation
 

--- a/docs/docfx_project/articles/integration-testing.md
+++ b/docs/docfx_project/articles/integration-testing.md
@@ -1,8 +1,8 @@
 ﻿---
 title: Integration Testing
 package: Trellis.Testing
-topics: [testing, assertions, result, maybe, fakerepository, webfactory, actor-headers]
-related_api_reference: [trellis-api-testing-reference.md, trellis-api-testing-aspnetcore.md, trellis-api-testing-worker.md, trellis-api-core.md]
+topics: [testing, assertions, result, maybe, fakerepository, webfactory, actor-headers, idempotency-conformance]
+related_api_reference: [trellis-api-testing-reference.md, trellis-api-testing-aspnetcore.md, trellis-api-testing-worker.md, trellis-api-testing-idempotency.md, trellis-api-core.md]
 last_verified: 2026-05-01
 audience: [developer]
 ---
@@ -28,6 +28,7 @@ audience: [developer]
 | Replay a `.http` file against the test host | `HttpFileParser.ParseFile` + `HttpFileRunner.RunAsync` + `HttpFileAssertions.AssertExpectationsMet` | [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#http-file-replay-helpers) |
 | Acquire a real Entra token in gated E2E tests | `MsalTestTokenProvider` + `factory.CreateClientWithEntraTokenAsync(...)` | [`trellis-api-testing-aspnetcore.md`](../api_reference/trellis-api-testing-aspnetcore.md#msal--entra-e2e-token-helpers) |
 | Test a `BackgroundService` with deterministic time + event capture | `WorkerHarness<TWorker>.CreateAsync(...)` + `Time.Advance(...)` + `WaitForEventAsync<TEvent>(...)` | [Background workers](#background-workers) |
+| Verify a custom `IIdempotencyStore` against the contract | Derive from `IdempotencyStoreConformance` (`Trellis.Testing.Idempotency`) | [Idempotency store conformance](#idempotency-store-conformance) |
 
 ## Use this guide when
 
@@ -56,8 +57,9 @@ audience: [developer]
 | `MsalTestTokenProvider` (+ `MsalTestOptions`, `TestUserCredentials`) | `Trellis.Testing.AspNetCore` | MSAL ROPC token acquisition for gated E2E tests against a dedicated test tenant. |
 | `HttpFileParser` / `HttpFileRunner` / `HttpFileAssertions` | `Trellis.Testing.AspNetCore.Http` | Parse, run, and assert `.http` files against a `WebApplicationFactory` client. |
 | `WorkerHarness<TWorker>` (+ `WorkerHarnessOptions`, `IWorkerTickSignal`, `WorkerHarnessTimeoutException`) | `Trellis.Testing.Worker` | Integration-test harness for `BackgroundService` workers: `FakeTimeProvider`, `TestActorProvider`, domain-event capture, race-proof `WaitForEventAsync` / `WaitForTickAsync`. |
+| `IdempotencyStoreConformance` | `Trellis.Testing.Idempotency` | Inheritable suite of 17 `[Fact]` rules pinning the `IIdempotencyStore` contract for any implementation. |
 
-Full signatures: [trellis-api-testing-reference.md](../api_reference/trellis-api-testing-reference.md), [trellis-api-testing-aspnetcore.md](../api_reference/trellis-api-testing-aspnetcore.md), [trellis-api-testing-worker.md](../api_reference/trellis-api-testing-worker.md).
+Full signatures: [trellis-api-testing-reference.md](../api_reference/trellis-api-testing-reference.md), [trellis-api-testing-aspnetcore.md](../api_reference/trellis-api-testing-aspnetcore.md), [trellis-api-testing-worker.md](../api_reference/trellis-api-testing-worker.md), [trellis-api-testing-idempotency.md](../api_reference/trellis-api-testing-idempotency.md#quick-start).
 
 ## Installation
 
@@ -65,9 +67,40 @@ Full signatures: [trellis-api-testing-reference.md](../api_reference/trellis-api
 dotnet add package Trellis.Testing
 dotnet add package Trellis.Testing.AspNetCore
 dotnet add package Trellis.Testing.Worker
+dotnet add package Trellis.Testing.Idempotency   # only when implementing IIdempotencyStore
 ```
 
 `Trellis.Testing.AspNetCore` and `Trellis.Testing.Worker` already reference `Trellis.Testing` transitively. Install `Trellis.Testing.AspNetCore` when the project owns ASP.NET Core integration tests, and `Trellis.Testing.Worker` when it has integration tests for `BackgroundService` workers.
+
+`Trellis.Testing.Idempotency` is separate from the others because it references xUnit directly — the conformance rules *are* `[Fact]` methods you inherit. The other testing packages stay runner-agnostic, so this one is installed only by projects that implement an `IIdempotencyStore`.
+
+## Idempotency store conformance
+
+`IIdempotencyStore` (see [ASP.NET Core integration](integration-aspnet.md#idempotency-key-middleware)) has a small surface but a subtle contract: reservations must be atomic under concurrency, fingerprint mismatches must be rejected, timed-out reservations must be takeable, and an abandon after a completion must **not** delete the recorded response. A store that gets any of these wrong fails in production as a double charge or a lost receipt — exactly the failures idempotency exists to prevent.
+
+Rather than re-derive those rules, derive from `IdempotencyStoreConformance` and inherit all 17 as tests:
+
+```csharp
+using Trellis.Testing.Idempotency;
+
+public sealed class RedisIdempotencyStoreConformanceTests : IdempotencyStoreConformance
+{
+    private readonly FakeTimeProvider _time = new();
+
+    protected override ValueTask<IIdempotencyStore> CreateStoreAsync(IdempotencyOptions options) =>
+        new(new RedisIdempotencyStore(Connection, options, _time));
+
+    // Enforce expiry against an injected clock and the suite runs in milliseconds
+    // instead of waiting out the real reservation timeout and TTL.
+    protected override Task AdvanceAsync(TimeSpan duration)
+    {
+        _time.Advance(duration);
+        return Task.CompletedTask;
+    }
+}
+```
+
+Each rule runs in its own instance against a per-instance `Scope`, so the suite is safe against a *shared* remote store. `Trellis.Asp.Idempotency.Cosmos` is verified this way against a real Cosmos DB emulator.
 
 ## Quick start
 

--- a/docs/docfx_project/docfx.json
+++ b/docs/docfx_project/docfx.json
@@ -15,6 +15,8 @@
             "Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj",
             "Trellis.Testing/src/Trellis.Testing.csproj",
             "Trellis.Testing.AspNetCore/src/Trellis.Testing.AspNetCore.csproj",
+            "Trellis.Asp.Idempotency.Cosmos/src/Trellis.Asp.Idempotency.Cosmos.csproj",
+            "Trellis.Testing.Idempotency/src/Trellis.Testing.Idempotency.csproj",
             "Trellis.Testing.Worker/src/Trellis.Testing.Worker.csproj",
             "Trellis.StateMachine/src/Trellis.StateMachine.csproj",
             "Trellis.Authorization/src/Trellis.Authorization.csproj",


### PR DESCRIPTION
## Why

Trellis shipped only `InMemoryIdempotencyStore`, which is documented as unsafe across instances and process restarts. Every multi-replica deployment therefore had to write its own `IIdempotencyStore` against a contract that was only implicitly specified.

Several backing stores are each legitimately correct for different deployments — SQL, Redis, Cosmos DB — so rather than pick a winner, this PR makes the contract **verifiable** first, then ships one reference implementation.

## `Trellis.Testing.Idempotency`

An inheritable 17-rule conformance suite covering reservation, replay, fingerprint mismatch, takeover, TTL expiry, completion, abandonment, and concurrency. Implementors derive from `IdempotencyStoreConformance`, override `CreateStoreAsync`, and inherit the whole contract.

Meta-tests run the suite against a deliberately defective store, so it is **provably non-vacuous** rather than merely green. Two traps that would have silently weakened it:

- `IdempotencyResponseSnapshot` compares `Headers` and `Body` **by reference**. A naive equality assertion would pass only for a store returning the identical instance and fail every serialising one. Assertions compare field by field and match header names case-insensitively, as the contract requires.
- `Parallel.ForEachAsync` caps concurrency at `ProcessorCount`, which made the single-winner rule **vacuous on a one-CPU CI container** — verified reproducible with `DOTNET_PROCESSOR_COUNT=1`. The race now uses an explicit starting gate.

## `Trellis.Asp.Idempotency.Cosmos`

The first durable store. Cosmos DB fits the contract unusually well: `CreateItem` returns `409` on a duplicate id within a partition, decided on the primary replica — exactly the atomic reserve required; ETags give conditional completion and abandonment without scripting; and per-item `ttl` reclaims storage with no sweeper process. Unlike a Redis cache under `allkeys-lru`, it never silently evicts a live reservation.

Two properties make it correct rather than merely working:

- **Session consistency is sufficient.** A reservation is granted only by an atomic create or an ETag-conditional replace, never on the strength of a read. A stale read produces `412`/`404` on the follow-up write and retries. Worst observable effect is a spurious `AlreadyInFlight`. Strong consistency is not required.
- **Expiry is enforced in-process.** Cosmos DB's TTL sweep is best-effort and can still return an expired item, so the store re-checks its own timestamps.

A reserved document is written with `ttl = -1`. `Classify` keeps a reserved entry answerable indefinitely so a same-key request carrying a different body keeps being rejected; a finite `ttl` would have let the sweeper delete it, making the store's answer depend on whether a background sweep had happened to run. Only completed documents expire, and only once the store already treats them as absent.

The store uses the Cosmos **stream** APIs rather than the typed overloads, because a `409` is the normal outcome of every replay and the typed overloads raise `CosmosException` for it — exception throwing on the hot path.

`AddCosmosIdempotencyStore(...)` deliberately has **no** `TrellisServiceBuilder.UseXxx()` slot, matching `AddInMemoryIdempotencyStore()`; it is added to the documented "no slot" list.

## Verification

All 17 conformance rules pass against a **real Cosmos DB emulator**, plus tests that read `ttl` straight out of the stored JSON rather than through the store's own model.

| Run | Tests |
|---|---|
| Default / CI (`--filter-not-trait "Category=Integration"`) | 20 — decision ordering, key encoding, registration; no emulator needed |
| Opt-in (`--filter-trait "Category=Integration"`) | 19 — the 17 conformance rules plus two `ttl` tests, against real Cosmos DB |

Emulator-backed tests are marked `[Trait("Category", "Integration")]`, matching the existing SQL Server-backed tests, so CI excludes them rather than burning the connect timeout and skipping.

Full solution: `dotnet build -c Release` **0 warnings**; CI-equivalent test run **7444 passed, 0 failed**.

## Notes

- Adds a transitive `Newtonsoft.Json` dependency. The Cosmos SDK v3 needs it at runtime but does not declare it, and its build target fails without an explicit reference.
- `Trellis.Testing.Idempotency` is the first Trellis package to reference xunit (`xunit.v3.extensibility.core` — a packable library cannot reference `xunit.v3`, which requires `OutputType=Exe`). This is why it is a separate package rather than folded into the existing testing packages, which reference only the runner-agnostic FluentAssertions. Precedent: `Microsoft.EntityFrameworkCore.Specification.Tests`.
- Verified against the local emulator, which is single-region. The Session-consistency argument for multi-region replication is reasoned about rather than empirically tested.
- CI will pack two new packages for the first time — worth a glance at the alpha-publish run.
