### PR TITLE
Carry the outbox message identity onto the publish seam (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,23 @@ Groundwork that makes a message-broker adapter possible to write correctly. Both
 already ship — a transactional outbox that stages events durably, and an inbox that deduplicates them — but the
 publish seam between them could not express what a transport needs.
 
-**The outbox row id now reaches the publisher.** `IIntegrationEventPublisher` gains
-`PublishAsync(OutboundIntegrationMessage, CancellationToken)`, and `OutboxRelay` calls it with the row's own
-`OutboxMessage.Id`. This is a correctness fix, not a convenience: relay delivery is at-least-once, so the same
-row can be published more than once, while `IntegrationEnvelope.MessageId` is specified as "the producer's outbox
-message id carried verbatim by the transport". The previous signature passed only the event, so an adapter had no
-choice but to mint a fresh id per attempt — putting a *different* `MessageId` on each copy, missing the consumer's
-`(ConsumerId, MessageId)` dedup, and running handlers twice. The inbox would have looked correct while guaranteeing
-nothing.
+**BREAKING: `IIntegrationEventPublisher.PublishAsync` now takes an `OutboundIntegrationMessage`.** The
+bare-event overload `PublishAsync(IIntegrationEvent, CancellationToken)` is **removed**; the interface has a
+single method carrying both the event and the outbox row's `MessageId`. Custom publishers change their
+signature to accept the message and read `message.Event`; in-process implementations can ignore the id.
 
-The new overload is a **default interface method** that forwards to the existing event-only overload, so every
-current implementation keeps compiling and behaving identically; only broker adapters override it.
+This is a correctness fix, not a convenience. Relay delivery is at-least-once, so the same row can be published
+more than once, while `IntegrationEnvelope.MessageId` is specified as "the producer's outbox message id carried
+verbatim by the transport". The previous signature passed only the event, so an adapter had no choice but to
+mint a fresh id per attempt — putting a *different* `MessageId` on each copy, missing the consumer's
+`(ConsumerId, MessageId)` dedup, and running handlers twice. The inbox would have looked correct while
+guaranteeing nothing.
+
+The bare-event overload was **removed rather than kept alongside** the new one. Keeping both (via a default
+interface method) would have preserved source and binary compatibility, but it also meant an adapter that
+simply did not implement the message overload would compile, run, and silently degrade the inbox — the failure
+would surface as duplicate side effects in production, not as a build error. A single method makes publishing
+without the identity unrepresentable.
 
 **`IntegrationEventNameAttribute` + `IntegrationEventNameMap` give events a wire identity.** The outbox stores
 `Type.AssemblyQualifiedName`, which is correct for in-process relaying and unusable across services: the consumer's
@@ -31,10 +37,11 @@ assemblies differ, and the string embeds an assembly version, so it can stop res
 A logical name (`[IntegrationEventName("orders.order-placed.v1")]`) is owned by the contract instead, and the map
 resolves it in both directions. The outbox's own storage format is unchanged — this is a wire concern only.
 
-The map validates at construction (blank names, non-concrete types, one name claiming two types, one type claiming
-two names) because each is an unrecoverable contract bug that should surface at startup. Lookups return `Maybe<T>`
-instead, because an *unknown* name is a normal operational condition: a producer may emit contracts this consumer
-does not subscribe to, and the transport should dead-letter or ignore them by policy rather than crash.
+The map validates at construction (blank names, non-concrete types, unbound generic parameters, one name claiming
+two types, one type claiming two names) because each is an unrecoverable contract bug that should surface at
+startup. Lookups return `Maybe<T>` instead, because an *unknown* name is a normal operational condition: a producer
+may emit contracts this consumer does not subscribe to, and the transport should dead-letter or ignore them by
+policy rather than crash.
 
 Neither duplicate-collapsing claim is overstated in the docs: carrying the id collapses redeliveries of a single
 outbox row, but a retried domain row re-runs its translator and stages a genuinely new row with its own id. That

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — cross-service messaging contracts on the outbox publish seam
+
+Groundwork that makes a message-broker adapter possible to write correctly. Both ends of reliable messaging
+already ship — a transactional outbox that stages events durably, and an inbox that deduplicates them — but the
+publish seam between them could not express what a transport needs.
+
+**The outbox row id now reaches the publisher.** `IIntegrationEventPublisher` gains
+`PublishAsync(OutboundIntegrationMessage, CancellationToken)`, and `OutboxRelay` calls it with the row's own
+`OutboxMessage.Id`. This is a correctness fix, not a convenience: relay delivery is at-least-once, so the same
+row can be published more than once, while `IntegrationEnvelope.MessageId` is specified as "the producer's outbox
+message id carried verbatim by the transport". The previous signature passed only the event, so an adapter had no
+choice but to mint a fresh id per attempt — putting a *different* `MessageId` on each copy, missing the consumer's
+`(ConsumerId, MessageId)` dedup, and running handlers twice. The inbox would have looked correct while guaranteeing
+nothing.
+
+The new overload is a **default interface method** that forwards to the existing event-only overload, so every
+current implementation keeps compiling and behaving identically; only broker adapters override it.
+
+**`IntegrationEventNameAttribute` + `IntegrationEventNameMap` give events a wire identity.** The outbox stores
+`Type.AssemblyQualifiedName`, which is correct for in-process relaying and unusable across services: the consumer's
+assemblies differ, and the string embeds an assembly version, so it can stop resolving after a routine version bump.
+A logical name (`[IntegrationEventName("orders.order-placed.v1")]`) is owned by the contract instead, and the map
+resolves it in both directions. The outbox's own storage format is unchanged — this is a wire concern only.
+
+The map validates at construction (blank names, non-concrete types, one name claiming two types, one type claiming
+two names) because each is an unrecoverable contract bug that should surface at startup. Lookups return `Maybe<T>`
+instead, because an *unknown* name is a normal operational condition: a producer may emit contracts this consumer
+does not subscribe to, and the transport should dead-letter or ignore them by policy rather than crash.
+
+Neither duplicate-collapsing claim is overstated in the docs: carrying the id collapses redeliveries of a single
+outbox row, but a retried domain row re-runs its translator and stages a genuinely new row with its own id. That
+second case still needs business-identity deduplication, and
+[`trellis-api-efcore-outbox.md`](docs/docfx_project/api_reference/trellis-api-efcore-outbox.md) now tabulates the
+difference.
+
 ### Added — `Trellis.Asp.Idempotency.Cosmos`, a production-grade idempotency store
 
 The first durable `IIdempotencyStore` Trellis ships. `InMemoryIdempotencyStore` is documented as unsafe across

--- a/Trellis.Core/src/DomainDrivenDesign/IntegrationEventNameAttribute.cs
+++ b/Trellis.Core/src/DomainDrivenDesign/IntegrationEventNameAttribute.cs
@@ -1,0 +1,36 @@
+namespace Trellis;
+
+/// <summary>
+/// Declares the stable, on-the-wire name of an <see cref="IIntegrationEvent"/> so producers and consumers
+/// in <i>different</i> services can agree on the type a message carries.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a logical name is required across services.</b> In-process relaying identifies an event by its
+/// <see cref="System.Type.AssemblyQualifiedName"/>, which is fine while producer and consumer are the same
+/// process. On a message broker it is unusable: the consumer's assemblies differ from the producer's, and
+/// the string embeds an assembly version, so it can stop resolving after a routine version bump. A logical
+/// name is owned by the contract rather than by the CLR layout, so each side maps it to whatever local type
+/// it likes.
+/// </para>
+/// <para>
+/// <b>Choose a versioned name.</b> The name is a published contract: once a message carrying it exists on a
+/// queue or in another team's code, changing it is a breaking change. Include a version segment
+/// (<c>orders.order-placed.v1</c>) so an incompatible payload change can ship as a new name consumed
+/// side-by-side, rather than as a silent break.
+/// </para>
+/// <para>Names are compared with the ordinal comparer — casing is significant.</para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [IntegrationEventName("orders.order-placed.v1")]
+/// public sealed record OrderPlaced(Guid OrderId, DateTimeOffset OccurredAt) : IIntegrationEvent;
+/// </code>
+/// </example>
+/// <param name="name">The stable wire name, for example <c>orders.order-placed.v1</c>.</param>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class IntegrationEventNameAttribute(string name) : Attribute
+{
+    /// <summary>The stable wire name identifying this event's contract.</summary>
+    public string Name { get; } = name;
+}

--- a/Trellis.EntityFrameworkCore.Outbox/src/OutboxRelay.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/src/OutboxRelay.cs
@@ -148,7 +148,7 @@ internal sealed class OutboxRelay<TContext> : BackgroundService
                 if (message.Kind == OutboxMessageKind.Integration)
                 {
                     var integrationEvent = Deserialize<IIntegrationEvent>(message);
-                    await PublishIntegrationAsync(integrationEvent, cancellationToken).ConfigureAwait(false);
+                    await PublishIntegrationAsync(message.Id, integrationEvent, cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -285,12 +285,17 @@ internal sealed class OutboxRelay<TContext> : BackgroundService
         return collector?.DrainPending() ?? [];
     }
 
-    private async Task PublishIntegrationAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken)
+    // The row's own id travels with the event so a broker adapter can stamp it on the wire. Delivery is
+    // at-least-once, so the same row can be published more than once; carrying a per-attempt id instead
+    // would make each copy look like a distinct message and defeat the consumer's inbox dedup.
+    private async Task PublishIntegrationAsync(
+        Guid messageId, IIntegrationEvent integrationEvent, CancellationToken cancellationToken)
     {
         var publishScope = _scopeFactory.CreateAsyncScope();
         await using var publishScopeLifetime = publishScope.ConfigureAwait(false);
         var publisher = publishScope.ServiceProvider.GetRequiredService<IIntegrationEventPublisher>();
-        await publisher.PublishAsync(integrationEvent, cancellationToken).ConfigureAwait(false);
+        await publisher.PublishAsync(new OutboundIntegrationMessage(messageId, integrationEvent), cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static OutboxMessage CreateIntegrationRow(IIntegrationEvent integrationEvent)

--- a/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
@@ -14,6 +14,115 @@ using Microsoft.Extensions.Time.Testing;
 public sealed class OutboxTests
 {
     [Fact]
+    public async Task Relay_hands_the_outbox_row_id_to_the_integration_publisher()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        var recorder = new RecordingIntegrationEventPublisher();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(recorder);
+        services.AddDbContext<OutboxTestDbContext>(o => o
+            .UseSqlite(connection)
+            .AddTrellisInterceptors()
+            .AddTrellisOutboxInterceptor());
+        services.AddDomainEventDispatch();
+        services.AddDomainEventHandler<ThingCreated, ThingCreatedTranslator>();
+        services.AddIntegrationEventDispatch();
+        // A broker adapter stands in for the default in-process publisher: it is the transport's view.
+        services.AddScoped<IIntegrationEventPublisher>(sp => sp.GetRequiredService<RecordingIntegrationEventPublisher>());
+        services.AddTrellisOutbox<OutboxTestDbContext>();
+
+        await using var provider = services.BuildServiceProvider();
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            await context.Database.EnsureCreatedAsync(ct);
+            context.Things.Add(Thing.Create(ThingId.NewUniqueV7(), "carry-my-id", DateTimeOffset.UnixEpoch));
+            await context.SaveChangesAsync(ct);
+        }
+
+        var relay = provider.GetServices<IHostedService>()
+            .OfType<OutboxRelay<OutboxTestDbContext>>()
+            .Single();
+
+        await relay.DrainAsync(ct); // stages the integration row
+        await relay.DrainAsync(ct); // publishes it
+
+        Guid stagedRowId;
+        await using (var verify = provider.CreateAsyncScope())
+        {
+            var context = verify.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            var integration = await context.Set<OutboxMessage>().AsNoTracking()
+                .SingleAsync(r => r.Kind == OutboxMessageKind.Integration, ct);
+            stagedRowId = integration.Id;
+        }
+
+        // The id the consumer will dedupe on must be the outbox row's own id, not one minted per publish
+        // attempt — otherwise the relay's at-least-once redelivery produces two distinct MessageIds and
+        // the consumer's (ConsumerId, MessageId) dedup misses.
+        recorder.Published.Should().ContainSingle()
+            .Which.MessageId.Should().Be(stagedRowId);
+    }
+
+    [Fact]
+    public async Task Relay_republishes_a_retried_row_under_the_same_message_id()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync(ct);
+
+        // Fails the first publish so the row stays pending and is drained again, mimicking the crash
+        // between publish and the relay's bookkeeping save that makes delivery at-least-once.
+        var recorder = new RecordingIntegrationEventPublisher { FailFirstPublish = true };
+        var time = new FakeTimeProvider(DateTimeOffset.UnixEpoch);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(recorder);
+        services.AddSingleton<TimeProvider>(time);
+        services.AddDbContext<OutboxTestDbContext>(o => o
+            .UseSqlite(connection)
+            .AddTrellisInterceptors()
+            .AddTrellisOutboxInterceptor());
+        services.AddDomainEventDispatch();
+        services.AddDomainEventHandler<ThingCreated, ThingCreatedTranslator>();
+        services.AddIntegrationEventDispatch();
+        services.AddScoped<IIntegrationEventPublisher>(sp => sp.GetRequiredService<RecordingIntegrationEventPublisher>());
+        services.AddTrellisOutbox<OutboxTestDbContext>(o =>
+        {
+            o.RetryBackoff = TimeSpan.FromSeconds(30);
+            o.RetryBackoffJitter = 0;
+        });
+
+        await using var provider = services.BuildServiceProvider();
+
+        await using (var scope = provider.CreateAsyncScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<OutboxTestDbContext>();
+            await context.Database.EnsureCreatedAsync(ct);
+            context.Things.Add(Thing.Create(ThingId.NewUniqueV7(), "retry-me", DateTimeOffset.UnixEpoch));
+            await context.SaveChangesAsync(ct);
+        }
+
+        var relay = provider.GetServices<IHostedService>()
+            .OfType<OutboxRelay<OutboxTestDbContext>>()
+            .Single();
+
+        await relay.DrainAsync(ct); // stages the integration row
+        await relay.DrainAsync(ct); // first publish attempt throws
+        time.Advance(TimeSpan.FromSeconds(31));
+        await relay.DrainAsync(ct); // retry
+
+        recorder.Published.Should().HaveCount(2);
+        recorder.Published[0].MessageId.Should().Be(
+            recorder.Published[1].MessageId,
+            "a redelivered row must look like the same message to the consumer's inbox");
+    }
+
+    [Fact]
     public async Task SaveChanges_captures_events_to_outbox_in_same_transaction_and_clears_aggregate()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -845,6 +954,32 @@ internal sealed class IntegrationCapturingHandler(List<ThingCreatedIntegrationEv
     public ValueTask HandleAsync(ThingCreatedIntegrationEvent integrationEvent, CancellationToken cancellationToken)
     {
         captured.Add(integrationEvent);
+        return ValueTask.CompletedTask;
+    }
+}
+
+// Stands in for a broker adapter: it overrides the message-carrying overload, which is the only one that
+// exposes the wire identity a transport needs.
+internal sealed class RecordingIntegrationEventPublisher : IIntegrationEventPublisher
+{
+    private bool _failed;
+
+    public List<OutboundIntegrationMessage> Published { get; } = [];
+
+    public bool FailFirstPublish { get; init; }
+
+    public ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException("The relay must call the OutboundIntegrationMessage overload.");
+
+    public ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)
+    {
+        Published.Add(message);
+        if (FailFirstPublish && !_failed)
+        {
+            _failed = true;
+            throw new InvalidOperationException("transport unavailable");
+        }
+
         return ValueTask.CompletedTask;
     }
 }

--- a/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
+++ b/Trellis.EntityFrameworkCore.Outbox/tests/OutboxTests.cs
@@ -958,8 +958,7 @@ internal sealed class IntegrationCapturingHandler(List<ThingCreatedIntegrationEv
     }
 }
 
-// Stands in for a broker adapter: it overrides the message-carrying overload, which is the only one that
-// exposes the wire identity a transport needs.
+// Stands in for a broker adapter: the publish contract hands it the wire identity it must stamp.
 internal sealed class RecordingIntegrationEventPublisher : IIntegrationEventPublisher
 {
     private bool _failed;
@@ -967,9 +966,6 @@ internal sealed class RecordingIntegrationEventPublisher : IIntegrationEventPubl
     public List<OutboundIntegrationMessage> Published { get; } = [];
 
     public bool FailFirstPublish { get; init; }
-
-    public ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken) =>
-        throw new InvalidOperationException("The relay must call the OutboundIntegrationMessage overload.");
 
     public ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)
     {

--- a/Trellis.Mediator/src/IIntegrationEventPublisher.cs
+++ b/Trellis.Mediator/src/IIntegrationEventPublisher.cs
@@ -28,4 +28,23 @@ public interface IIntegrationEventPublisher
     /// <param name="cancellationToken">A token to observe while waiting on the consumers.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when all consumers have run (or thrown).</returns>
     ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes an integration event together with the stable message identity a transport must carry
+    /// onto the wire. This is the overload the outbox relay calls.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation discards <see cref="OutboundIntegrationMessage.MessageId"/> and forwards
+    /// to <see cref="PublishAsync(IIntegrationEvent, CancellationToken)"/>, which is correct for in-process
+    /// fan-out: handlers run in the producer's own process, so there is no wire and nothing to deduplicate.
+    /// A broker adapter overrides this to map the id onto its transport (for example
+    /// <c>ServiceBusMessage.MessageId</c>) so consumer-side <c>(ConsumerId, MessageId)</c> deduplication
+    /// survives the relay's at-least-once redelivery. Existing implementations keep compiling and running
+    /// unchanged.
+    /// </remarks>
+    /// <param name="message">The message to publish, carrying the event and its stable id.</param>
+    /// <param name="cancellationToken">A token to observe while waiting on the consumers.</param>
+    /// <returns>A <see cref="ValueTask"/> that completes when all consumers have run (or thrown).</returns>
+    ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken) =>
+        PublishAsync(message.Event, cancellationToken);
 }

--- a/Trellis.Mediator/src/IIntegrationEventPublisher.cs
+++ b/Trellis.Mediator/src/IIntegrationEventPublisher.cs
@@ -1,8 +1,9 @@
 ﻿namespace Trellis.Mediator;
 
 /// <summary>
-/// Publishes a single <see cref="IIntegrationEvent"/> to its consumers. The transactional outbox relay
-/// resolves this contract to deliver integration events durably after the producing transaction commits.
+/// Publishes a single <see cref="IIntegrationEvent"/>, together with the stable message identity a
+/// transport must carry onto the wire, to its consumers. The transactional outbox relay resolves this
+/// contract to deliver integration events durably after the producing transaction commits.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -11,6 +12,15 @@
 /// To deliver to other services, replace this registration with a message-broker adapter (for example
 /// Azure Service Bus or Kafka); the producing side - aggregates, translators, and the outbox - does not
 /// change. This is the seam that keeps the outbox transport-agnostic.
+/// </para>
+/// <para>
+/// <b>The message identity is part of the contract, not an optional extra.</b> The single method takes an
+/// <see cref="OutboundIntegrationMessage"/> rather than a bare event so a transport cannot publish without
+/// the id: relay delivery is at-least-once, and stamping
+/// <see cref="OutboundIntegrationMessage.MessageId"/> verbatim onto the wire is what lets consumer-side
+/// <c>(ConsumerId, MessageId)</c> deduplication recognize a redelivery. An adapter that minted its own id
+/// per attempt would make every redelivery look like a new message and silently defeat the inbox.
+/// In-process implementations may simply ignore the id - there is no wire and nothing to deduplicate.
 /// </para>
 /// <para>
 /// Implementations are expected to be best-effort: non-cancellation handler exceptions are logged and
@@ -22,29 +32,13 @@
 public interface IIntegrationEventPublisher
 {
     /// <summary>
-    /// Publishes the specified integration event to all matching consumers.
+    /// Publishes the specified message to all matching consumers.
     /// </summary>
-    /// <param name="integrationEvent">The event to publish. Resolution uses <c>integrationEvent.GetType()</c>.</param>
+    /// <param name="message">
+    /// The message to publish, carrying the event and its stable id. Handler resolution uses
+    /// <c>message.Event.GetType()</c>.
+    /// </param>
     /// <param name="cancellationToken">A token to observe while waiting on the consumers.</param>
     /// <returns>A <see cref="ValueTask"/> that completes when all consumers have run (or thrown).</returns>
-    ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Publishes an integration event together with the stable message identity a transport must carry
-    /// onto the wire. This is the overload the outbox relay calls.
-    /// </summary>
-    /// <remarks>
-    /// The default implementation discards <see cref="OutboundIntegrationMessage.MessageId"/> and forwards
-    /// to <see cref="PublishAsync(IIntegrationEvent, CancellationToken)"/>, which is correct for in-process
-    /// fan-out: handlers run in the producer's own process, so there is no wire and nothing to deduplicate.
-    /// A broker adapter overrides this to map the id onto its transport (for example
-    /// <c>ServiceBusMessage.MessageId</c>) so consumer-side <c>(ConsumerId, MessageId)</c> deduplication
-    /// survives the relay's at-least-once redelivery. Existing implementations keep compiling and running
-    /// unchanged.
-    /// </remarks>
-    /// <param name="message">The message to publish, carrying the event and its stable id.</param>
-    /// <param name="cancellationToken">A token to observe while waiting on the consumers.</param>
-    /// <returns>A <see cref="ValueTask"/> that completes when all consumers have run (or thrown).</returns>
-    ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken) =>
-        PublishAsync(message.Event, cancellationToken);
+    ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken);
 }

--- a/Trellis.Mediator/src/IntegrationEventNameMap.cs
+++ b/Trellis.Mediator/src/IntegrationEventNameMap.cs
@@ -1,0 +1,139 @@
+﻿namespace Trellis.Mediator;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+/// <summary>
+/// A bidirectional map between an integration event's stable wire name (see
+/// <see cref="IntegrationEventNameAttribute"/>) and its local CLR type — the contract a broker transport
+/// serializes through so producer and consumer never exchange assembly-qualified type names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The map is immutable and validated at construction: an unusable contract surfaces when the application
+/// starts rather than when a message arrives at three in the morning. Every rejection is a contract bug
+/// that cannot be recovered from at runtime — two events claiming one name would make the wire ambiguous,
+/// and a name resolving to a type that is not an <see cref="IIntegrationEvent"/> could never be dispatched.
+/// </para>
+/// <para>
+/// Lookups return <see cref="Maybe{T}"/> rather than throwing, because an <i>unknown</i> name is a normal
+/// operational condition: a producer may legitimately emit events this consumer does not subscribe to, and
+/// the transport should dead-letter or ignore them by policy rather than crash.
+/// </para>
+/// </remarks>
+public sealed class IntegrationEventNameMap
+{
+    private readonly Dictionary<string, Type> _byName;
+    private readonly Dictionary<Type, string> _byType;
+
+    /// <summary>
+    /// Creates a map from explicit name/type pairs. This overload is trimming- and NativeAOT-safe; prefer it
+    /// over <see cref="FromAssemblies"/> when publishing a trimmed application.
+    /// </summary>
+    /// <param name="contracts">The wire name to CLR type pairs to register.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="contracts"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">
+    /// A name is empty, a type does not implement <see cref="IIntegrationEvent"/>, is not concrete, or has
+    /// unbound generic parameters, or a name or type appears more than once.
+    /// </exception>
+    public IntegrationEventNameMap(IEnumerable<KeyValuePair<string, Type>> contracts)
+    {
+        ArgumentNullException.ThrowIfNull(contracts);
+
+        _byName = new Dictionary<string, Type>(StringComparer.Ordinal);
+        _byType = [];
+
+        foreach (var (name, type) in contracts)
+        {
+            ArgumentNullException.ThrowIfNull(type, nameof(contracts));
+            ArgumentException.ThrowIfNullOrWhiteSpace(name, nameof(contracts));
+
+            if (!typeof(IIntegrationEvent).IsAssignableFrom(type))
+                throw new ArgumentException(
+                    $"Type '{type}' is mapped to integration event name '{name}' but does not implement {nameof(IIntegrationEvent)}.",
+                    nameof(contracts));
+
+            if (type is { IsAbstract: true } or { IsInterface: true })
+                throw new ArgumentException(
+                    $"Type '{type}' is mapped to integration event name '{name}' but is not a concrete type, so an " +
+                    "incoming message could never be materialized as it.",
+                    nameof(contracts));
+
+            // An open generic passes the concrete-type check but is just as unusable: it would be keyed under
+            // its type definition, so NameFor(GenericEvent<int>) misses, and TypeFor would hand a transport a
+            // type it cannot instantiate. A wire contract has to name one closed type.
+            if (type.ContainsGenericParameters)
+                throw new ArgumentException(
+                    $"Type '{type}' is mapped to integration event name '{name}' but has unbound generic " +
+                    "parameters. Name a closed constructed type so the wire contract identifies exactly one shape.",
+                    nameof(contracts));
+
+            if (_byName.TryGetValue(name, out var existingType))
+                throw new ArgumentException(
+                    $"Integration event name '{name}' is declared by both '{existingType}' and '{type}'. A wire name " +
+                    "must identify exactly one type or an incoming message would be ambiguous.",
+                    nameof(contracts));
+
+            if (_byType.TryGetValue(type, out var existingName))
+                throw new ArgumentException(
+                    $"Type '{type}' is mapped to both integration event names '{existingName}' and '{name}'. A type " +
+                    "must publish under exactly one name or consumers could not agree on its contract.",
+                    nameof(contracts));
+
+            _byName.Add(name, type);
+            _byType.Add(type, name);
+        }
+    }
+
+    /// <summary>An empty map: every lookup returns <see cref="Maybe{T}.None"/>.</summary>
+    public static IntegrationEventNameMap Empty { get; } = new([]);
+
+    /// <summary>The wire names registered in this map.</summary>
+    public IReadOnlyCollection<string> Names => _byName.Keys;
+
+    /// <summary>
+    /// Builds a map by scanning <paramref name="assemblies"/> for concrete <see cref="IIntegrationEvent"/>
+    /// types carrying <see cref="IntegrationEventNameAttribute"/>. Types without the attribute are skipped,
+    /// so a contract assembly can hold events that are deliberately in-process only.
+    /// </summary>
+    /// <param name="assemblies">The assemblies holding the integration event contracts.</param>
+    /// <returns>The validated map.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="assemblies"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Two scanned types declare the same wire name.</exception>
+    [RequiresUnreferencedCode(
+        "Scans assemblies for IIntegrationEvent types annotated with IntegrationEventNameAttribute; the types " +
+        "may be trimmed. Use the IEnumerable<KeyValuePair<string, Type>> constructor in trimmed applications.")]
+    public static IntegrationEventNameMap FromAssemblies(params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        var contracts =
+            from assembly in assemblies
+            from type in assembly.GetTypes()
+            where type is { IsAbstract: false, IsInterface: false } && typeof(IIntegrationEvent).IsAssignableFrom(type)
+            let attribute = type.GetCustomAttribute<IntegrationEventNameAttribute>(inherit: false)
+            where attribute is not null
+            select new KeyValuePair<string, Type>(attribute.Name, type);
+
+        return new IntegrationEventNameMap(contracts);
+    }
+
+    /// <summary>Returns the wire name registered for <paramref name="type"/>, if any.</summary>
+    /// <param name="type">The local CLR event type.</param>
+    /// <returns>The wire name, or <see cref="Maybe{T}.None"/> when the type has no registered contract.</returns>
+    public Maybe<string> NameFor(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return _byType.TryGetValue(type, out var name) ? Maybe<string>.From(name) : Maybe<string>.None;
+    }
+
+    /// <summary>Returns the CLR type registered for <paramref name="name"/>, if any.</summary>
+    /// <param name="name">The wire name read from the message.</param>
+    /// <returns>The CLR type, or <see cref="Maybe{T}.None"/> when this application knows no such contract.</returns>
+    public Maybe<Type> TypeFor(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return _byName.TryGetValue(name, out var type) ? Maybe<Type>.From(type) : Maybe<Type>.None;
+    }
+
+}

--- a/Trellis.Mediator/src/MediatorIntegrationEventPublisher.cs
+++ b/Trellis.Mediator/src/MediatorIntegrationEventPublisher.cs
@@ -42,10 +42,13 @@ internal sealed partial class MediatorIntegrationEventPublisher : IIntegrationEv
     [UnconditionalSuppressMessage(
         "AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling",
         Justification = "Reflection over IIntegrationEventHandler<TEvent> for the runtime event type. The handler types are reached via DI-based registration (AddIntegrationEventHandler<TEvent, THandler>) which preserves them through trimming; consumers needing strict NativeAOT guarantees can supply a custom IIntegrationEventPublisher implementation.")]
-    public async ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken)
+    public async ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(integrationEvent);
+        ArgumentNullException.ThrowIfNull(message);
 
+        // The id identifies the message on a wire. This publisher is the in-process path - there is no wire
+        // and nothing to deduplicate - so only the event matters here.
+        var integrationEvent = message.Event;
         var eventType = integrationEvent.GetType();
         var invoker = s_invokerCache.GetOrAdd(eventType, CreateInvoker);
 

--- a/Trellis.Mediator/src/OutboundIntegrationMessage.cs
+++ b/Trellis.Mediator/src/OutboundIntegrationMessage.cs
@@ -1,0 +1,35 @@
+namespace Trellis.Mediator;
+
+/// <summary>
+/// The publish-side counterpart of <see cref="IntegrationEnvelope"/>: the integration event to publish
+/// together with the stable <see cref="MessageId"/> a transport must carry verbatim onto the wire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the id travels with the event.</b> Consumer-side deduplication keys on
+/// <c>(ConsumerId, MessageId)</c>, and <see cref="IntegrationEnvelope.MessageId"/> is specified as the
+/// producer's outbox message id carried verbatim by the transport. Outbox relay delivery is
+/// at-least-once, so the same row can be published more than once — a crash between publishing and the
+/// relay's bookkeeping save re-delivers it. A transport that minted a fresh id per publish attempt would
+/// put a <i>different</i> <c>MessageId</c> on each copy, the consumer's dedup would miss, and handlers
+/// would run twice. Passing the row's own id makes redeliveries indistinguishable to the consumer, which
+/// is exactly what the inbox needs.
+/// </para>
+/// <para>
+/// This collapses redeliveries of a <i>single</i> outbox row. It does not collapse the other duplicate the
+/// outbox can produce: a retried domain row re-runs its translator and stages a genuinely new integration
+/// row with its own id. Consumers still dedupe that on business identity.
+/// </para>
+/// <para>
+/// Lineage members present on <see cref="IntegrationEnvelope"/> (<c>MessageSource</c>, <c>CausationId</c>,
+/// <c>CorrelationId</c>) are deliberately absent here: nothing in the current relay can populate them
+/// without new persisted outbox columns, and an always-null member on a publish contract is worse than no
+/// member at all. They can be added once the outbox records them.
+/// </para>
+/// </remarks>
+/// <param name="MessageId">
+/// The stable, unique message identity — the producer's outbox row id (a UUIDv7). Every redelivery of the
+/// same row carries this same value.
+/// </param>
+/// <param name="Event">The integration event to publish.</param>
+public sealed record OutboundIntegrationMessage(Guid MessageId, IIntegrationEvent Event);

--- a/Trellis.Mediator/src/OutboundIntegrationMessage.cs
+++ b/Trellis.Mediator/src/OutboundIntegrationMessage.cs
@@ -29,7 +29,38 @@ namespace Trellis.Mediator;
 /// </remarks>
 /// <param name="MessageId">
 /// The stable, unique message identity — the producer's outbox row id (a UUIDv7). Every redelivery of the
-/// same row carries this same value.
+/// same row carries this same value. Must not be <see cref="Guid.Empty"/>: an empty id is not a missing
+/// value a transport can work around, because every message stamped with it collapses to the same
+/// <c>(ConsumerId, MessageId)</c> inbox key and the consumer would discard all but the first as duplicates.
 /// </param>
 /// <param name="Event">The integration event to publish.</param>
-public sealed record OutboundIntegrationMessage(Guid MessageId, IIntegrationEvent Event);
+public sealed record OutboundIntegrationMessage(Guid MessageId, IIntegrationEvent Event)
+{
+    private readonly Guid _messageId = MessageId != Guid.Empty
+        ? MessageId
+        : throw new ArgumentException("Message identity must not be empty.", nameof(MessageId));
+
+    private readonly IIntegrationEvent _event = Event ?? throw new ArgumentNullException(nameof(Event));
+
+    /// <summary>
+    /// Gets the stable, unique message identity — the producer's outbox row id (a UUIDv7).
+    /// </summary>
+    /// <exception cref="ArgumentException">The value is <see cref="Guid.Empty"/>.</exception>
+    public Guid MessageId
+    {
+        get => _messageId;
+        init => _messageId = value != Guid.Empty
+            ? value
+            : throw new ArgumentException("Message identity must not be empty.", nameof(value));
+    }
+
+    /// <summary>
+    /// Gets the integration event to publish.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">The value is <see langword="null"/>.</exception>
+    public IIntegrationEvent Event
+    {
+        get => _event;
+        init => _event = value ?? throw new ArgumentNullException(nameof(value));
+    }
+}

--- a/Trellis.Mediator/tests/IntegrationEventNameMapTests.cs
+++ b/Trellis.Mediator/tests/IntegrationEventNameMapTests.cs
@@ -1,0 +1,118 @@
+namespace Trellis.Mediator.Tests;
+
+using System.Reflection;
+
+#pragma warning disable CA1707 // readable xUnit test names
+
+/// <summary>
+/// Tests for <see cref="IntegrationEventNameMap"/> — the producer/consumer wire-name contract that lets a
+/// broker transport identify an event without exchanging assembly-qualified type names.
+/// </summary>
+public sealed class IntegrationEventNameMapTests
+{
+    [Fact]
+    public void FromAssemblies_MapsAnnotatedEventsInBothDirections()
+    {
+        var map = IntegrationEventNameMap.FromAssemblies(Assembly.GetExecutingAssembly());
+
+        map.TypeFor("trellis.tests.named-event.v1").TryGetValue(out var type).Should().BeTrue();
+        type.Should().Be<NamedIntegrationEvent>();
+
+        map.NameFor(typeof(NamedIntegrationEvent)).TryGetValue(out var name).Should().BeTrue();
+        name.Should().Be("trellis.tests.named-event.v1");
+    }
+
+    [Fact]
+    public void FromAssemblies_SkipsEventsWithoutTheAttribute()
+    {
+        var map = IntegrationEventNameMap.FromAssemblies(Assembly.GetExecutingAssembly());
+
+        // An unannotated event is in-process only by choice, not an error.
+        map.NameFor(typeof(UnnamedIntegrationEvent)).HasValue.Should().BeFalse();
+    }
+
+    // A producer may emit contracts this consumer does not subscribe to; that is policy, not a crash.
+    [Fact]
+    public void TypeFor_UnknownName_ReturnsNone() =>
+        IntegrationEventNameMap.Empty.TypeFor("orders.never-heard-of-it.v1").HasValue.Should().BeFalse();
+
+    [Fact]
+    public void TypeFor_IsCaseSensitive()
+    {
+        var map = new IntegrationEventNameMap([new("orders.order-placed.v1", typeof(NamedIntegrationEvent))]);
+
+        map.TypeFor("Orders.Order-Placed.V1").HasValue.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_DuplicateName_Throws()
+    {
+        var act = () => new IntegrationEventNameMap(
+        [
+            new("orders.order-placed.v1", typeof(NamedIntegrationEvent)),
+            new("orders.order-placed.v1", typeof(UnnamedIntegrationEvent)),
+        ]);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*must identify exactly one type*");
+    }
+
+    [Fact]
+    public void Constructor_SameTypeUnderTwoNames_Throws()
+    {
+        var act = () => new IntegrationEventNameMap(
+        [
+            new("orders.order-placed.v1", typeof(NamedIntegrationEvent)),
+            new("orders.order-placed.v2", typeof(NamedIntegrationEvent)),
+        ]);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*exactly one name*");
+    }
+
+    [Fact]
+    public void Constructor_TypeThatIsNotAnIntegrationEvent_Throws()
+    {
+        var act = () => new IntegrationEventNameMap([new("orders.order-placed.v1", typeof(string))]);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*does not implement IIntegrationEvent*");
+    }
+
+    [Fact]
+    public void Constructor_AbstractType_Throws()
+    {
+        var act = () => new IntegrationEventNameMap([new("orders.order-placed.v1", typeof(AbstractIntegrationEvent))]);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not a concrete type*");
+    }
+
+    [Fact]
+    public void Constructor_OpenGenericType_Throws()
+    {
+        // It is concrete, but it would be keyed under its type definition: NameFor(GenericIntegrationEvent<int>)
+        // would miss, and TypeFor would return a type no deserializer can materialize. FromAssemblies routes
+        // through this same constructor, so an annotated open generic is rejected there too.
+        var act = () => new IntegrationEventNameMap(
+            [new("orders.order-placed.v1", typeof(GenericIntegrationEvent<>))]);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*unbound generic parameters*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_BlankName_Throws(string name)
+    {
+        var act = () => new IntegrationEventNameMap([new(name, typeof(NamedIntegrationEvent))]);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}
+
+[IntegrationEventName("trellis.tests.named-event.v1")]
+internal sealed record NamedIntegrationEvent(DateTimeOffset OccurredAt) : IIntegrationEvent;
+
+internal sealed record UnnamedIntegrationEvent(DateTimeOffset OccurredAt) : IIntegrationEvent;
+
+internal abstract record AbstractIntegrationEvent(DateTimeOffset OccurredAt) : IIntegrationEvent;
+
+// Deliberately unannotated: scanning must skip it, so the suite's FromAssemblies tests stay unaffected.
+internal sealed record GenericIntegrationEvent<T>(T Payload, DateTimeOffset OccurredAt) : IIntegrationEvent;

--- a/Trellis.Mediator/tests/MediatorIntegrationEventPublisherTests.cs
+++ b/Trellis.Mediator/tests/MediatorIntegrationEventPublisherTests.cs
@@ -32,7 +32,7 @@ public class MediatorIntegrationEventPublisherTests
     }
 
     [Fact]
-    public async Task PublishAsync_OutboundMessageOverload_FansOutToInProcessHandlers()
+    public async Task PublishAsync_FansOutToInProcessHandlersIgnoringTheMessageId()
     {
         var services = new ServiceCollection();
         AddNullLogging(services);
@@ -44,24 +44,10 @@ public class MediatorIntegrationEventPublisherTests
             provider, NullLogger<MediatorIntegrationEventPublisher>.Instance);
 
         var evt = new TestIntegrationEvent("payload", DateTimeOffset.UtcNow);
-        await ((IIntegrationEventPublisher)publisher).PublishAsync(
+        await publisher.PublishAsync(
             new OutboundIntegrationMessage(Guid.CreateVersion7(), evt), CancellationToken.None);
 
         handler.Received.Should().ContainSingle().Which.Should().BeSameAs(evt);
-    }
-
-    [Fact]
-    public async Task PublishAsync_OutboundMessageOverload_FallsBackForImplementationsThatOnlyOverrideTheEventOverload()
-    {
-        // The default interface method is what keeps pre-existing publishers - which cannot know about
-        // OutboundIntegrationMessage - working after the relay switched to the message-carrying overload.
-        var legacy = new EventOnlyPublisher();
-        var evt = new TestIntegrationEvent("payload", DateTimeOffset.UtcNow);
-
-        await ((IIntegrationEventPublisher)legacy).PublishAsync(
-            new OutboundIntegrationMessage(Guid.CreateVersion7(), evt), CancellationToken.None);
-
-        legacy.Received.Should().ContainSingle().Which.Should().BeSameAs(evt);
     }
 
     [Fact]
@@ -101,7 +87,7 @@ public class MediatorIntegrationEventPublisherTests
     }
 
     [Fact]
-    public async Task PublishAsync_NullEvent_Throws()
+    public async Task PublishAsync_NullMessage_Throws()
     {
         var services = new ServiceCollection();
         AddNullLogging(services);
@@ -290,17 +276,6 @@ public class MediatorIntegrationEventPublisherTests
         }
     }
 
-    private sealed class EventOnlyPublisher : IIntegrationEventPublisher
-    {
-        public List<IIntegrationEvent> Received { get; } = [];
-
-        public ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken)
-        {
-            Received.Add(integrationEvent);
-            return ValueTask.CompletedTask;
-        }
-    }
-
     private sealed class CaptureLogger : ILogger<MediatorIntegrationEventPublisher>
     {
         public List<(LogLevel Level, string Message)> Records { get; } = [];
@@ -316,4 +291,14 @@ public class MediatorIntegrationEventPublisherTests
             Func<TState, Exception?, string> formatter)
             => Records.Add((logLevel, formatter(state, exception)));
     }
+}
+
+// These tests exercise fan-out behaviour - handler resolution, exception swallowing, cancellation - for
+// which the wire identity is irrelevant. The helper supplies a throwaway id so each test reads as the
+// behaviour it is actually pinning.
+internal static class IntegrationPublisherTestExtensions
+{
+    public static ValueTask PublishAsync(
+        this IIntegrationEventPublisher publisher, IIntegrationEvent integrationEvent, CancellationToken cancellationToken) =>
+        publisher.PublishAsync(new OutboundIntegrationMessage(Guid.CreateVersion7(), integrationEvent), cancellationToken);
 }

--- a/Trellis.Mediator/tests/MediatorIntegrationEventPublisherTests.cs
+++ b/Trellis.Mediator/tests/MediatorIntegrationEventPublisherTests.cs
@@ -32,6 +32,39 @@ public class MediatorIntegrationEventPublisherTests
     }
 
     [Fact]
+    public async Task PublishAsync_OutboundMessageOverload_FansOutToInProcessHandlers()
+    {
+        var services = new ServiceCollection();
+        AddNullLogging(services);
+        var handler = new RecordingHandler();
+        services.AddSingleton<IIntegrationEventHandler<TestIntegrationEvent>>(handler);
+
+        var provider = services.BuildServiceProvider();
+        var publisher = new MediatorIntegrationEventPublisher(
+            provider, NullLogger<MediatorIntegrationEventPublisher>.Instance);
+
+        var evt = new TestIntegrationEvent("payload", DateTimeOffset.UtcNow);
+        await ((IIntegrationEventPublisher)publisher).PublishAsync(
+            new OutboundIntegrationMessage(Guid.CreateVersion7(), evt), CancellationToken.None);
+
+        handler.Received.Should().ContainSingle().Which.Should().BeSameAs(evt);
+    }
+
+    [Fact]
+    public async Task PublishAsync_OutboundMessageOverload_FallsBackForImplementationsThatOnlyOverrideTheEventOverload()
+    {
+        // The default interface method is what keeps pre-existing publishers - which cannot know about
+        // OutboundIntegrationMessage - working after the relay switched to the message-carrying overload.
+        var legacy = new EventOnlyPublisher();
+        var evt = new TestIntegrationEvent("payload", DateTimeOffset.UtcNow);
+
+        await ((IIntegrationEventPublisher)legacy).PublishAsync(
+            new OutboundIntegrationMessage(Guid.CreateVersion7(), evt), CancellationToken.None);
+
+        legacy.Received.Should().ContainSingle().Which.Should().BeSameAs(evt);
+    }
+
+    [Fact]
     public async Task PublishAsync_NoHandlersRegistered_IsNoOp()
     {
         var services = new ServiceCollection();
@@ -253,6 +286,17 @@ public class MediatorIntegrationEventPublisherTests
         public ValueTask HandleAsync(TestIntegrationEvent integrationEvent, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class EventOnlyPublisher : IIntegrationEventPublisher
+    {
+        public List<IIntegrationEvent> Received { get; } = [];
+
+        public ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken)
+        {
+            Received.Add(integrationEvent);
             return ValueTask.CompletedTask;
         }
     }

--- a/Trellis.Mediator/tests/OutboundIntegrationMessageTests.cs
+++ b/Trellis.Mediator/tests/OutboundIntegrationMessageTests.cs
@@ -1,0 +1,54 @@
+﻿namespace Trellis.Mediator.Tests;
+
+public class OutboundIntegrationMessageTests
+{
+    [Fact]
+    public void Ctor_NullEvent_Throws()
+    {
+        var act = () => new OutboundIntegrationMessage(Guid.CreateVersion7(), null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("Event");
+    }
+
+    [Fact]
+    public void Ctor_EmptyMessageId_Throws()
+    {
+        var act = () => new OutboundIntegrationMessage(Guid.Empty, new SampleIntegrationEvent(DateTimeOffset.UnixEpoch));
+
+        act.Should().Throw<ArgumentException>().WithParameterName("MessageId");
+    }
+
+    [Fact]
+    public void With_NullEvent_Throws()
+    {
+        var message = new OutboundIntegrationMessage(Guid.CreateVersion7(), new SampleIntegrationEvent(DateTimeOffset.UnixEpoch));
+
+        var act = () => message with { Event = null! };
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void With_EmptyMessageId_Throws()
+    {
+        var message = new OutboundIntegrationMessage(Guid.CreateVersion7(), new SampleIntegrationEvent(DateTimeOffset.UnixEpoch));
+
+        var act = () => message with { MessageId = Guid.Empty };
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Ctor_ValidArguments_ExposesBoth()
+    {
+        var id = Guid.CreateVersion7();
+        var integrationEvent = new SampleIntegrationEvent(DateTimeOffset.UnixEpoch);
+
+        var message = new OutboundIntegrationMessage(id, integrationEvent);
+
+        message.MessageId.Should().Be(id);
+        message.Event.Should().BeSameAs(integrationEvent);
+    }
+
+    private sealed record SampleIntegrationEvent(DateTimeOffset OccurredAt) : IIntegrationEvent;
+}

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Core
 namespaces: [Trellis]
-types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IETagStampable, IReconstitutionStampable, IEntity, "Entity<TId>", IDomainEvent, IIntegrationEvent, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredDateTimeOffset<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, PositiveAttribute, NonNegativeAttribute, NegativeAttribute, NonPositiveAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResourceCollectionNameAttribute, ResultDebugSettings]
+types: [Result, "Result<T>", IResult, "IResult<TValue>", "IFailureFactory<TSelf>", IPersistOnFailure, "Maybe<T>", Maybe, MaybeInvariant, Error, ITransportFault, RetryAdvice, RetryClassification, ErrorRetryExtensions, Unit, "Page<T>", Page, Cursor, PageSize, CursorCodec, PageBuilder, "EquatableArray<T>", EquatableArray, ResourceRef, InputPointer, FieldViolation, RuleViolation, IAggregate, "Aggregate<TId>", IETagStampable, IReconstitutionStampable, IEntity, "Entity<TId>", IDomainEvent, IIntegrationEvent, IntegrationEventNameAttribute, ITrackedAggregateSource, ValueObject, "ScalarValueObject<TSelf,T>", "IScalarValue<TSelf,TPrimitive>", "IFormattableScalarValue<TSelf,TPrimitive>", "RequiredString<TSelf>", "RequiredInt<TSelf>", "RequiredLong<TSelf>", "RequiredDecimal<TSelf>", "RequiredBool<TSelf>", "RequiredGuid<TSelf>", "RequiredDateTime<TSelf>", "RequiredDateTimeOffset<TSelf>", "RequiredEnum<TSelf>", "RequiredEnumJsonConverter<T>", "ParsableJsonConverter<T>", ResultRequiresExplicitHttpMappingConverter, PrimitiveValueObjectTrace, "Specification<T>", TrellisJsonValidationException, RangeAttribute, StringLengthAttribute, NotDefaultAttribute, TrimAttribute, PositiveAttribute, NonNegativeAttribute, NegativeAttribute, NonPositiveAttribute, RailwayTrackAttribute, TrackBehavior, EnumValueAttribute, ResourceCollectionNameAttribute, ResultDebugSettings]
 version: v3
 last_verified: 2026-06-03
 audience: [llm]
@@ -59,6 +59,7 @@ Use this table before searching the long type catalog.
 | Page list responses | `new Page<T>(items, next, previous, requestedLimit, appliedLimit)` (or `Page.Empty<T>(...)` when there are no items), `Cursor` | [`Pagination`](#pagination) |
 | Model aggregates/entities/events | `Aggregate<TId>`, `Entity<TId>`, `IDomainEvent` | [`Domain-Driven Design`](#domain-driven-design) |
 | Define a stable published integration contract | `IIntegrationEvent` | [`IIntegrationEvent`](#iintegrationevent) |
+| Name an integration contract for the wire (cross-service) | `[IntegrationEventName]` | [`IntegrationEventNameAttribute`](#integrationeventnameattribute) |
 | Move reusable query predicates out of repositories | `Specification<T>` | [`Specification<T>`](#specificationt) |
 | Define custom required value objects | `partial class X : RequiredString<X>` / `RequiredGuid<X>` / other `Required*` bases | [`Primitive value object base classes`](#primitive-value-object-base-classes) |
 | Extract a success value or throw at a trust boundary (DTO → entity rehydration, JSON deserialization) | `result.GetValueOrThrow($"context message")` / `GetValueOrThrowAsync(...)` | [`GetValueOrThrowExtensions`](#extension-class-catalog-full-signatures) (entry in the extension catalog), [cookbook Recipe 30](trellis-api-cookbook.md#recipe-30--rehydrating-entities-from-persistence-fail-loud-vs-result-track) |
@@ -1689,6 +1690,30 @@ Integration events are typically translated from domain events: a domain-event h
 | Name | Type | Description |
 | --- | --- | --- |
 | `OccurredAt` | `DateTimeOffset` | Timestamp (with explicit UTC offset) for when the business fact this integration event describes occurred. Use this as the single event timestamp. |
+
+### `IntegrationEventNameAttribute`
+
+```csharp
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class IntegrationEventNameAttribute(string name) : Attribute
+```
+
+Declares the stable, on-the-wire name of an `IIntegrationEvent` so producers and consumers in **different** services can agree on the type a message carries.
+
+```csharp
+[IntegrationEventName("orders.order-placed.v1")]
+public sealed record OrderPlaced(Guid OrderId, DateTimeOffset OccurredAt) : IIntegrationEvent;
+```
+
+In-process relaying identifies an event by `Type.AssemblyQualifiedName`, which is fine while producer and consumer share a process. On a message broker it is unusable: the consumer's assemblies differ from the producer's, and the string embeds an assembly version, so it can stop resolving after a routine version bump. A logical name is owned by the contract rather than by the CLR layout, so each side maps it to whatever local type it likes.
+
+**Choose a versioned name.** Once a message carrying the name exists on a queue or in another team's code, changing it is a breaking change. Include a version segment so an incompatible payload change can ship as a new name consumed side-by-side rather than as a silent break.
+
+Broker transports resolve the name through [`IntegrationEventNameMap`](trellis-api-mediator.md#integrationeventnamemap). Names compare with the **ordinal** comparer — casing is significant.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `Name` | `string` | The stable wire name identifying this event's contract. |
 
 ### `ITrackedAggregateSource`
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore-outbox.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore-outbox.md
@@ -63,11 +63,22 @@ The flow:
 
 1. A **translator** — an ordinary `IDomainEventHandler<TDomainEvent>` — injects `IIntegrationEventCollector` and `Add(...)`s integration events while the relay re-dispatches the domain event.
 2. After publishing a `Domain` row, the relay drains the per-message scope's collector and stages each produced integration event as a new `OutboxMessageKind.Integration` row — in the **same** `SaveChanges` that marks the domain row processed, so an integration event is enrolled only once its source domain event is durably dispatched.
-3. A later drain publishes each `Integration` row through `IIntegrationEventPublisher` (default in-process fan-out to `IIntegrationEventHandler<T>`; replace the registration with a message-broker adapter to deliver to other services).
+3. A later drain publishes each `Integration` row through `IIntegrationEventPublisher` — specifically the `PublishAsync(OutboundIntegrationMessage, CancellationToken)` overload, carrying that row's own `OutboxMessage.Id` (default in-process fan-out to `IIntegrationEventHandler<T>`; replace the registration with a message-broker adapter to deliver to other services).
 
 Register the consumer side with `services.AddIntegrationEventDispatch(...)` / `AddIntegrationEventHandler<TEvent, THandler>()`, or the `TrellisServiceBuilder.UseIntegrationEvents(...)` slot. The collector is optional: outboxes that capture only domain events never register it and are unaffected.
 
 Delivery is at-least-once and a retried domain event re-runs its translator, so a consumer may observe the same integration event more than once (with a different `OutboxMessage.Id` each time) — **dedupe on business identity, not the message id.**
+
+### Two different duplicates — only one is the message id's job
+
+These are easy to conflate, and they need different defences:
+
+| Duplicate | Cause | `OutboxMessage.Id` | Defence |
+| --- | --- | --- | --- |
+| **Redelivery of one `Integration` row** | The relay crashed between publishing and its bookkeeping `SaveChanges`, or the batch outlived its lease | **Same** on every attempt | The consumer's inbox, keyed `(ConsumerId, MessageId)` — provided the transport carried `OutboundIntegrationMessage.MessageId` verbatim |
+| **A re-run translator staging a fresh row** | A `Domain` row was retried, so the translator produced the integration event again | **Different** each time | Business identity — the inbox cannot help, because these genuinely are two messages |
+
+The relay hands `OutboundIntegrationMessage.MessageId` to the publisher precisely so a broker adapter can stamp it on the wire (for example `ServiceBusMessage.MessageId`) and collapse the first row of the table. An adapter that minted its own id per publish attempt would turn every redelivery into a distinct message and silently defeat the consumer's inbox. It does **not** collapse the second row, which is why the "dedupe on business identity" guidance above still stands.
 
 ## Wiring: three required calls
 

--- a/docs/docfx_project/api_reference/trellis-api-efcore-outbox.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore-outbox.md
@@ -63,7 +63,7 @@ The flow:
 
 1. A **translator** — an ordinary `IDomainEventHandler<TDomainEvent>` — injects `IIntegrationEventCollector` and `Add(...)`s integration events while the relay re-dispatches the domain event.
 2. After publishing a `Domain` row, the relay drains the per-message scope's collector and stages each produced integration event as a new `OutboxMessageKind.Integration` row — in the **same** `SaveChanges` that marks the domain row processed, so an integration event is enrolled only once its source domain event is durably dispatched.
-3. A later drain publishes each `Integration` row through `IIntegrationEventPublisher` — specifically the `PublishAsync(OutboundIntegrationMessage, CancellationToken)` overload, carrying that row's own `OutboxMessage.Id` (default in-process fan-out to `IIntegrationEventHandler<T>`; replace the registration with a message-broker adapter to deliver to other services).
+3. A later drain publishes each `Integration` row through `IIntegrationEventPublisher` — its sole method `PublishAsync(OutboundIntegrationMessage, CancellationToken)`, carrying that row's own `OutboxMessage.Id` (default in-process fan-out to `IIntegrationEventHandler<T>`; replace the registration with a message-broker adapter to deliver to other services).
 
 Register the consumer side with `services.AddIntegrationEventDispatch(...)` / `AddIntegrationEventHandler<TEvent, THandler>()`, or the `TrellisServiceBuilder.UseIntegrationEvents(...)` slot. The collector is optional: outboxes that capture only domain events never register it and are unaffected.
 

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -558,10 +558,9 @@ Implementations are expected to be best-effort: non-cancellation handler excepti
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken)` | `ValueTask` | Publishes the specified integration event to all matching consumers. Resolution uses `integrationEvent.GetType()`. Default implementation (`MediatorIntegrationEventPublisher`) is `internal` and registered by `AddIntegrationEventDispatch()`. |
-| `ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)` | `ValueTask` | Publishes an event together with the stable message identity a transport must stamp on the wire. **This is the overload the outbox relay calls.** A default interface method forwards to the event-only overload, so existing implementations keep compiling and behaving identically; broker adapters override it. |
+| `ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)` | `ValueTask` | Publishes an event together with the stable message identity a transport must stamp on the wire. Handler resolution uses `message.Event.GetType()`. Default implementation (`MediatorIntegrationEventPublisher`) is `internal` and registered by `AddIntegrationEventDispatch()`; it ignores the id, since in-process fan-out has no wire and nothing to deduplicate. |
 
-> **Broker adapters must override the `OutboundIntegrationMessage` overload.** Outbox delivery is at-least-once, so the same row can be published more than once. `OutboundIntegrationMessage.MessageId` is the row's own id, and carrying it verbatim onto the wire is what makes redeliveries look like one message to the consumer's `(ConsumerId, MessageId)` inbox dedup. An adapter that minted its own id per publish attempt would silently defeat the inbox.
+> **The message identity is part of the contract, not an optional extra.** This is the interface's only method, so a transport cannot publish without the id. Outbox delivery is at-least-once, so the same row can be published more than once; carrying `OutboundIntegrationMessage.MessageId` verbatim onto the wire is what makes redeliveries look like one message to the consumer's `(ConsumerId, MessageId)` inbox dedup. An adapter that minted its own id per publish attempt would silently defeat the inbox — making that unrepresentable is why the bare-event overload was removed rather than kept alongside.
 
 ### OutboundIntegrationMessage
 **Declaration**
@@ -573,6 +572,8 @@ public sealed record OutboundIntegrationMessage(Guid MessageId, IIntegrationEven
 The publish-side counterpart of [`IntegrationEnvelope`](trellis-api-efcore-inbox.md#integrationenvelope): the event to publish plus the stable `MessageId` (the producer's outbox row id, a UUIDv7) a transport must carry verbatim.
 
 The lineage members that `IntegrationEnvelope` carries (`MessageSource`, `CausationId`, `CorrelationId`) are deliberately absent: nothing in the current relay can populate them without new persisted outbox columns, and an always-null member on a publish contract is worse than no member at all.
+
+Both members are validated on construction — and on `with` copies, since the invariants live on the properties. `Event` must not be `null` (`ArgumentNullException`), and `MessageId` must not be `Guid.Empty` (`ArgumentException`). An empty id is rejected rather than tolerated because it is not a missing value the transport can work around: every message stamped with it collapses to the same `(ConsumerId, MessageId)` inbox key, so the *second* message from that producer would be discarded as a duplicate of the first. Failing at construction turns that into an immediate, local error instead of silent consumer-side message loss.
 
 ### IntegrationEventNameMap
 **Declaration**

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Mediator
 namespaces: [Trellis.Mediator]
-types: [ICommand<T>, IQuery<T>, "IRequestHandler<,>", "IPipelineBehavior<,>", "AuthorizationBehavior<TMessage,TResponse>", "ExceptionBehavior<TMessage,TResponse>", IValidate, "LoggingBehavior<TMessage,TResponse>", "ResourceAuthorizationViaBehavior<TMessage,TLeaf,TOwner,TResponse>", ResolvedAuthorizationPath, ResolvedAuthorizationHop, HopLoadResult, "ResolvedAuthorizationPathHolder<TMessage,TLeaf,TOwner,TResponse>", ResourceAuthorizationPathResolver, "ResourceAuthorizationBehavior<TMessage,TResource,TResponse>", ServiceCollectionExtensions, "TracingBehavior<TMessage,TResponse>", TrellisMediatorTelemetryOptions, IMessageValidator<TMessage>, IDomainEventHandler<TEvent>, IDomainEventPublisher, IIntegrationEventHandler<TEvent>, IIntegrationEventPublisher, IIntegrationEventCollector, DomainEventHandlerCascadedException, CascadeOffender, "DomainEventDispatchBehavior<,>", DomainEventDispatchServiceCollectionExtensions, DomainEventPublisherExtensions, IntegrationEventDispatchServiceCollectionExtensions, "TrackedAggregateDomainEventDispatchBehavior<,>", TrackedAggregateDomainEventDispatchServiceCollectionExtensions]
+types: [ICommand<T>, IQuery<T>, "IRequestHandler<,>", "IPipelineBehavior<,>", "AuthorizationBehavior<TMessage,TResponse>", "ExceptionBehavior<TMessage,TResponse>", IValidate, "LoggingBehavior<TMessage,TResponse>", "ResourceAuthorizationViaBehavior<TMessage,TLeaf,TOwner,TResponse>", ResolvedAuthorizationPath, ResolvedAuthorizationHop, HopLoadResult, "ResolvedAuthorizationPathHolder<TMessage,TLeaf,TOwner,TResponse>", ResourceAuthorizationPathResolver, "ResourceAuthorizationBehavior<TMessage,TResource,TResponse>", ServiceCollectionExtensions, "TracingBehavior<TMessage,TResponse>", TrellisMediatorTelemetryOptions, IMessageValidator<TMessage>, IDomainEventHandler<TEvent>, IDomainEventPublisher, IIntegrationEventHandler<TEvent>, IIntegrationEventPublisher, OutboundIntegrationMessage, IntegrationEventNameMap, IIntegrationEventCollector, DomainEventHandlerCascadedException, CascadeOffender, "DomainEventDispatchBehavior<,>", DomainEventDispatchServiceCollectionExtensions, DomainEventPublisherExtensions, IntegrationEventDispatchServiceCollectionExtensions, "TrackedAggregateDomainEventDispatchBehavior<,>", TrackedAggregateDomainEventDispatchServiceCollectionExtensions]
 version: v3
 last_verified: 2026-06-03
 audience: [llm]
@@ -559,6 +559,44 @@ Implementations are expected to be best-effort: non-cancellation handler excepti
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `ValueTask PublishAsync(IIntegrationEvent integrationEvent, CancellationToken cancellationToken)` | `ValueTask` | Publishes the specified integration event to all matching consumers. Resolution uses `integrationEvent.GetType()`. Default implementation (`MediatorIntegrationEventPublisher`) is `internal` and registered by `AddIntegrationEventDispatch()`. |
+| `ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)` | `ValueTask` | Publishes an event together with the stable message identity a transport must stamp on the wire. **This is the overload the outbox relay calls.** A default interface method forwards to the event-only overload, so existing implementations keep compiling and behaving identically; broker adapters override it. |
+
+> **Broker adapters must override the `OutboundIntegrationMessage` overload.** Outbox delivery is at-least-once, so the same row can be published more than once. `OutboundIntegrationMessage.MessageId` is the row's own id, and carrying it verbatim onto the wire is what makes redeliveries look like one message to the consumer's `(ConsumerId, MessageId)` inbox dedup. An adapter that minted its own id per publish attempt would silently defeat the inbox.
+
+### OutboundIntegrationMessage
+**Declaration**
+
+```csharp
+public sealed record OutboundIntegrationMessage(Guid MessageId, IIntegrationEvent Event)
+```
+
+The publish-side counterpart of [`IntegrationEnvelope`](trellis-api-efcore-inbox.md#integrationenvelope): the event to publish plus the stable `MessageId` (the producer's outbox row id, a UUIDv7) a transport must carry verbatim.
+
+The lineage members that `IntegrationEnvelope` carries (`MessageSource`, `CausationId`, `CorrelationId`) are deliberately absent: nothing in the current relay can populate them without new persisted outbox columns, and an always-null member on a publish contract is worse than no member at all.
+
+### IntegrationEventNameMap
+**Declaration**
+
+```csharp
+public sealed class IntegrationEventNameMap
+```
+
+An immutable, validated two-way map between an integration event's stable wire name (declared with [`IntegrationEventNameAttribute`](trellis-api-core.md#integrationeventnameattribute)) and its local CLR type.
+
+Cross-service messaging cannot identify an event by `Type.AssemblyQualifiedName` — which is what the outbox stores for its own in-process relaying. The consumer's assemblies differ from the producer's, and the string embeds an assembly version, so it can stop resolving after a routine version bump. A logical name is owned by the contract instead of by the CLR layout, so each side maps it to whatever local type it likes. Broker transports serialize through this map.
+
+**Members**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `IntegrationEventNameMap(IEnumerable<KeyValuePair<string, Type>> contracts)` | — | Builds a map from explicit pairs. Trimming- and NativeAOT-safe; prefer it in trimmed apps. |
+| `static IntegrationEventNameMap FromAssemblies(params Assembly[] assemblies)` | `IntegrationEventNameMap` | Scans for concrete `IIntegrationEvent` types carrying the attribute. Types without it are skipped, so a contract assembly may hold deliberately in-process-only events. Annotated `[RequiresUnreferencedCode]`. |
+| `static IntegrationEventNameMap Empty` | `IntegrationEventNameMap` | A map in which every lookup returns `None`. |
+| `Maybe<string> NameFor(Type type)` | `Maybe<string>` | The wire name for a local type, or `None`. |
+| `Maybe<Type> TypeFor(string name)` | `Maybe<Type>` | The local type for a wire name, or `None`. |
+| `IReadOnlyCollection<string> Names` | `IReadOnlyCollection<string>` | The registered wire names. |
+
+Construction throws `ArgumentException` when a name is blank, a type is not a concrete `IIntegrationEvent`, a type has unbound generic parameters, two types claim one name, or one type claims two names — each is an unrecoverable contract bug, so it surfaces at startup. Lookups return `Maybe<T>` instead, because an **unknown name is a normal operational condition**: a producer may emit contracts this consumer does not subscribe to, and the transport should dead-letter or ignore them by policy. Names compare with the **ordinal** comparer, so casing is significant.
 
 ### IIntegrationEventCollector
 **Declaration**
@@ -820,6 +858,8 @@ public interface IIntegrationEventHandler<in TEvent> where TEvent : IIntegration
 public interface IIntegrationEventPublisher
 public interface IIntegrationEventCollector
 ```
+
+Supporting types: `OutboundIntegrationMessage` (publish-side envelope carrying the wire identity) and `IntegrationEventNameMap` (wire name ↔ CLR type contract for broker transports).
 
 ## Behavioral notes
 

--- a/docs/docfx_project/articles/integration-inbox.md
+++ b/docs/docfx_project/articles/integration-inbox.md
@@ -143,6 +143,8 @@ A useful rule of thumb: **do transactional work in the inbox handler; push non-t
 
 Dedup is only as good as the id. The `MessageId` must be **stable across redeliveries** — the same logical message must carry the same id every time it is delivered. The natural choice is the producer's outbox id: `OutboxMessage.Id` is a UUIDv7 minted once when the event is captured, and a well-behaved transport carries it verbatim in the message metadata. Read it back in your adapter and use it as the envelope `MessageId`.
 
+On the produce side that id is handed to the publisher as `OutboundIntegrationMessage.MessageId`, so a sending adapter has it available without reaching back into the outbox — see [Writing a broker adapter](integration-outbox.md#writing-a-broker-adapter).
+
 Do **not** use a per-delivery id the transport mints fresh on each attempt (some brokers assign a new sequence number per delivery) — every redelivery would look new and defeat the inbox. The envelope's other fields — `MessageSource`, `CausationId`, `CorrelationId` — are lineage and observability only; they are recorded for audit but never affect dedup.
 
 ## One message, many consumers

--- a/docs/docfx_project/articles/integration-outbox.md
+++ b/docs/docfx_project/articles/integration-outbox.md
@@ -170,7 +170,7 @@ The default `IIntegrationEventPublisher` fans out to in-process `IIntegrationEve
 
 Two things separate an adapter that works from one that quietly loses the inbox's guarantee.
 
-**Override the message-carrying overload.** The relay calls `PublishAsync(OutboundIntegrationMessage, CancellationToken)`, whose `MessageId` is the outbox row's own id. Stamp it on the wire (`ServiceBusMessage.MessageId`, a Kafka header, and so on) so the consumer's `(ConsumerId, MessageId)` inbox dedup can collapse redeliveries of that row. Minting a fresh id per publish attempt makes every redelivery look like a new message and defeats the inbox. The overload is a default interface method that forwards to the event-only one, so an adapter that forgets to override it compiles and appears to work — this is the failure worth reviewing for.
+**Publish through the message, not the event.** `IIntegrationEventPublisher` has exactly one method, `PublishAsync(OutboundIntegrationMessage, CancellationToken)`, whose `MessageId` is the outbox row's own id. Stamp it on the wire (`ServiceBusMessage.MessageId`, a Kafka header, and so on) so the consumer's `(ConsumerId, MessageId)` inbox dedup can collapse redeliveries of that row. Minting a fresh id per publish attempt makes every redelivery look like a new message and defeats the inbox. The bare-event overload was deliberately removed so an adapter cannot publish without the id by accident.
 
 **Identify the event by a logical name, not by its CLR type.** The outbox stores `Type.AssemblyQualifiedName`, which is correct for its own in-process relaying and unusable across services: the consumer's assemblies differ, and the string embeds an assembly version. Annotate contracts and resolve them through `IntegrationEventNameMap`:
 

--- a/docs/docfx_project/articles/integration-outbox.md
+++ b/docs/docfx_project/articles/integration-outbox.md
@@ -166,6 +166,28 @@ builder.Services.AddTrellis(trellis => trellis
 
 The default `IIntegrationEventPublisher` fans out to in-process `IIntegrationEventHandler<T>` registrations — ideal for a modular monolith and for tests. To deliver to other services, replace that one registration with a message-broker adapter; aggregates, translators, and the outbox are unchanged. Delivery is at-least-once and a retried domain event re-runs its translator, so a consumer may see the same integration event more than once (with a different `OutboxMessage.Id` each time) — **dedupe on business identity, not on the message id.**
 
+### Writing a broker adapter
+
+Two things separate an adapter that works from one that quietly loses the inbox's guarantee.
+
+**Override the message-carrying overload.** The relay calls `PublishAsync(OutboundIntegrationMessage, CancellationToken)`, whose `MessageId` is the outbox row's own id. Stamp it on the wire (`ServiceBusMessage.MessageId`, a Kafka header, and so on) so the consumer's `(ConsumerId, MessageId)` inbox dedup can collapse redeliveries of that row. Minting a fresh id per publish attempt makes every redelivery look like a new message and defeats the inbox. The overload is a default interface method that forwards to the event-only one, so an adapter that forgets to override it compiles and appears to work — this is the failure worth reviewing for.
+
+**Identify the event by a logical name, not by its CLR type.** The outbox stores `Type.AssemblyQualifiedName`, which is correct for its own in-process relaying and unusable across services: the consumer's assemblies differ, and the string embeds an assembly version. Annotate contracts and resolve them through `IntegrationEventNameMap`:
+
+```csharp
+[IntegrationEventName("orders.order-placed.v1")]
+public sealed record OrderPlacedIntegrationEvent(Guid OrderId, DateTimeOffset OccurredAt) : IIntegrationEvent;
+
+// Producer and consumer each build the map over their own contract assembly.
+var names = IntegrationEventNameMap.FromAssemblies(typeof(OrderPlacedIntegrationEvent).Assembly);
+```
+
+Include a version segment in the name. Once a message carrying it sits on a queue or in another team's code, changing the name is a breaking change; a new version can be consumed side-by-side instead.
+
+On the receiving end, build an `IntegrationEnvelope` from the wire id and the resolved type and hand it to `IInboxDispatcher`. Acknowledge the broker message on **both** `Processed` and `SkippedDuplicate` — the dispatcher contract says both mean the message is durably accounted for.
+
+Bear in mind what the message id can and cannot do: it collapses redeliveries of a *single* outbox row, but a retried domain row re-runs its translator and stages a genuinely new row with its own id. That second duplicate still needs business-identity deduplication.
+
 ## Persist-on-failure (`FailAfterCommit`) events
 
 `TransactionalCommandBehavior` commits a `Result.FailAfterCommit` outcome (persist-on-failure), but `DomainEventDispatchBehavior` does **not** dispatch domain events for any failed result — by design those events are discarded, not a durable buffer.


### PR DESCRIPTION
## Why

Trellis ships both ends of reliable messaging — a transactional outbox that stages integration events durably, and an inbox that deduplicates them on `(ConsumerId, MessageId)` — but no broker transport. Sketching an Azure Service Bus adapter surfaced two problems that could not be fixed inside the adapter, because both live in framework contracts.

## Blocker 1 — the outbox row id never reached the publisher

`OutboxMessage.Id` is documented as *"stable message identity (UUIDv7) for consumer-side idempotency / de-duplication"*, and `IntegrationEnvelope.MessageId` as *"the producer's outbox message id carried verbatim by the transport"*. But `IIntegrationEventPublisher.PublishAsync` received only the event — the id was not in the signature.

Relay delivery is at-least-once: `OutboxRelay`'s own remarks note that *"a crash between dispatch and the relay's save re-delivers the message"*. So an adapter had no choice but to mint a fresh id per publish attempt. Every redelivery of one row would land on the wire with a **different** `MessageId`, the consumer's inbox dedup would miss, and handlers would run twice. The inbox would look correct while guaranteeing nothing.

**Fix.** New `OutboundIntegrationMessage(Guid MessageId, IIntegrationEvent Event)`, and `IIntegrationEventPublisher` now takes it.

### This is a breaking change, deliberately

The bare-event overload `PublishAsync(IIntegrationEvent, CancellationToken)` is **removed**. It was initially kept alongside the new one via a default interface method, which preserved source and binary compatibility — but that is precisely the wrong trade here. An adapter that simply did not implement the message overload would compile, run, and appear to work while silently degrading the consumer's inbox. That failure surfaces as duplicate side effects in production, not as a build error. A single method makes publishing without the identity unrepresentable.

**Migration:** custom `IIntegrationEventPublisher` implementations change their signature to accept `OutboundIntegrationMessage` and read `message.Event`. In-process implementations can ignore `message.MessageId` — there is no wire and nothing to deduplicate. Trellis's own `MediatorIntegrationEventPublisher` does exactly that.

`OutboundIntegrationMessage` validates both members, on construction and on `with` copies (validation lives on the accessors, since initializers do not run for `with`). `Event` must not be null — the unvalidated record would otherwise have turned the publisher's `ArgumentNullException` into a `NullReferenceException`. `MessageId` must not be `Guid.Empty`, because an empty id is not a missing value a transport can route around: every message stamped with it collapses to the same inbox dedup key, so the consumer would discard all but the first as a duplicate.

### What this does *not* fix

The outbox can produce two different kinds of duplicate, and only one is addressed here:

| Duplicate | `OutboxMessage.Id` | Defence |
|---|---|---|
| Redelivery of a single `Integration` row | **Same** | Inbox `(ConsumerId, MessageId)` |
| A retried domain row re-runs its translator, staging a new row | **Different** | Business identity |

The docs now tabulate this so the guarantee is not overstated.

## Blocker 2 — the event type identifier is not usable across services

The outbox stores `Type.AssemblyQualifiedName` and rehydrates via `Type.GetType`. That is correct for in-process relaying and unusable across a wire: the consumer's assemblies differ from the producer's, and the string embeds an assembly version, so it can stop resolving after a routine version bump.

**Fix.** `[IntegrationEventName("orders.order-placed.v1")]` (in `Trellis.Core`, so contract assemblies need no mediator reference) plus `IntegrationEventNameMap`, an immutable validated two-way name ↔ type map.

Scope was kept narrow on purpose: **the outbox's storage format is unchanged.** The row is producer-internal and its current identifier works there. Only the wire needs a portable name.

The map validates at construction — blank names, non-concrete types, unbound generic parameters, one name claiming two types, one type claiming two names — because each is an unrecoverable contract bug that should stop startup. Lookups return `Maybe<T>` instead, because an *unknown* name is normal traffic: a producer may emit contracts this consumer does not subscribe to, and the transport should dead-letter or ignore by policy rather than crash.

`FromAssemblies` is marked `[RequiresUnreferencedCode]`; the explicit `IEnumerable<KeyValuePair<string, Type>>` constructor is the trim-safe path.

## Tests

TDD throughout — every behaviour below was confirmed red first.

- Two `OutboxRelay` tests assert the published id equals the `Integration` row's own id, read back from the database, and that the same id survives a redelivery after a crash between dispatch and the relay's save.
- `OutboundIntegrationMessageTests` covers null event, empty id, and both `with`-copy paths.
- `IntegrationEventNameMapTests` — 11 tests over resolution in both directions plus every construction-time rejection.
- Open-generic rejection is tested through the constructor rather than by adding an annotated open generic to the test assembly, which would have broken the `FromAssemblies(Assembly.GetExecutingAssembly())` tests.

Full solution: **0 warnings, 7467 passed, 0 failed, 15 skipped** (skips are LocalDB/Cosmos-gated). Docs linter clean.

## Docs

`trellis-api-core.md`, `trellis-api-mediator.md`, `trellis-api-efcore-outbox.md`, `articles/integration-outbox.md` (new **Writing a broker adapter** section), `articles/integration-inbox.md`, and a `CHANGELOG.md` entry marked BREAKING.

## Follow-up (not in this PR)

1. `Trellis.Messaging.AzureServiceBus` — the adapter these contracts exist to make writable.
2. A transport conformance kit, in the shape of the idempotency kit from #695: nothing today proves an adapter actually carries the id onto the wire, which is the whole point of this change.
3. Outbox lineage columns (`MessageSource`, `CausationId`, `CorrelationId`). Those members are deliberately absent from `OutboundIntegrationMessage` — nothing can populate them today, and an always-null member on a publish contract is worse than no member.