### PR TITLE
Add Trellis.Messaging.AzureServiceBus, the wire between the outbox and the inbox

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,6 +45,7 @@ For any non-trivial Trellis work, load these **before** writing the first line o
 | FluentValidation integration | `docs/docfx_project/api_reference/trellis-api-fluentvalidation.md` |
 | HttpClient extensions | `docs/docfx_project/api_reference/trellis-api-http.md` |
 | HTTP transport abstractions (`WriteOutcome`, `HttpError`, ETag/precondition value types) | `docs/docfx_project/api_reference/trellis-api-http-abstractions.md` |
+| Azure Service Bus transport for integration events | `docs/docfx_project/api_reference/trellis-api-messaging-azureservicebus.md` |
 | Mediator pipeline behaviors | `docs/docfx_project/api_reference/trellis-api-mediator.md` |
 | FluentValidation in the Mediator pipeline | `docs/docfx_project/api_reference/trellis-api-mediator-fluentvalidation.md` |
 | State machine integration | `docs/docfx_project/api_reference/trellis-api-statemachine.md` |
@@ -74,7 +75,7 @@ If you cannot answer any of these, stop and load the missing reference before co
 When adding a new `services.AddTrellisXxx()` or `services.AddXxxDispatch()` style extension, first decide whether it needs a builder slot at all:
 
 - **Composition-root features** — anything an application author turns on (pipeline behaviors, dispatchers, actor providers, outbox/inbox) — **must** get a `TrellisServiceBuilder.UseXxx(...)` slot.
-- **Leaf, store, and adapter-author extension points** get **no** slot. These are called by another `AddXxx` that *is* surfaced, or by an adapter author wiring a non-shipped provider. Existing examples: `AddInMemoryIdempotencyStore`, `AddCosmosIdempotencyStore`, `AddTrellisRouteConstraint`/`AddTrellisRouteConstraints`, and `AddTransactionalCommandBehavior` (provider-neutral; invoked by `AddTrellisUnitOfWork<TContext>()`, which is surfaced as `UseEntityFrameworkUnitOfWork<TContext>()`).
+- **Leaf, store, and adapter-author extension points** get **no** slot. These are called by another `AddXxx` that *is* surfaced, or by an adapter author wiring a non-shipped provider. Existing examples: `AddInMemoryIdempotencyStore`, `AddTrellisRouteConstraint`/`AddTrellisRouteConstraints`, `AddTransactionalCommandBehavior` (provider-neutral; invoked by `AddTrellisUnitOfWork<TContext>()`, which is surfaced as `UseEntityFrameworkUnitOfWork<TContext>()`), and the **vendor-SDK provider packages**: `AddCosmosIdempotencyStore` (`Trellis.Asp.Idempotency.Cosmos`) and `AddAzureServiceBusIntegrationEventPublisher` / `AddAzureServiceBusIntegrationEventConsumer` (`Trellis.Messaging.AzureServiceBus`). Surfacing a vendor package would force every `Trellis.ServiceDefaults` consumer to take a transitive dependency on a cloud SDK in order to use features unrelated to that vendor; `Trellis.ServiceDefaults` deliberately references no vendor SDK.
 
 If the new helper falls in the first category, the work is **not complete** until:
 
@@ -136,6 +137,7 @@ Tests are organized by source area:
 | FluentValidation (standalone) | `Trellis.FluentValidation/src/` | `Trellis.FluentValidation/tests/` |
 | FluentValidation (Mediator) | `Trellis.Mediator.FluentValidation/src/` | `Trellis.Mediator.FluentValidation/tests/` |
 | HTTP abstractions | `Trellis.Http.Abstractions/src/` | `Trellis.Http.Abstractions/tests/` |
+| Azure Service Bus transport | `Trellis.Messaging.AzureServiceBus/src/` | `Trellis.Messaging.AzureServiceBus/tests/` |
 | Persistence abstractions | `Trellis.Persistence.Abstractions/src/` | — |
 | API versioning | `Trellis.Asp.ApiVersioning/src/` | `Trellis.Asp.ApiVersioning/tests/` |
 | Service defaults / composition root | `Trellis.ServiceDefaults/src/` | `Trellis.ServiceDefaults/tests/` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `Trellis.Messaging.AzureServiceBus`, the wire between the outbox and the inbox
+
+Trellis shipped both ends of reliable cross-service messaging — a transactional outbox that stages integration
+events with the business change, and an inbox that deduplicates them on `(ConsumerId, MessageId)` — and no
+transport in between. This package is that transport.
+
+Its central obligation is a single value. Outbox relay delivery is at-least-once, so one row can be published
+more than once; the consumer's inbox only collapses those copies if they arrive under the same message id.
+The publisher therefore stamps the producer's outbox row id onto `ServiceBusMessage.MessageId` verbatim. A
+transport that minted its own id per attempt would leave the inbox in place, looking correct, deduplicating
+nothing.
+
+The wire format prefers standard Service Bus members over custom application properties: `MessageId` for the
+dedup key and `Subject` for the event's stable wire name (from `[IntegrationEventName]`). Both are indexed by
+the broker, visible in the portal and Service Bus Explorer, and usable in subscription filters, so messages
+stay diagnosable and routable by tools that know nothing about Trellis. The default topology is one topic per
+contract; `TopicNameResolver` collapses or prefixes that when a deployment needs something else.
+
+Settlement follows from what the inbox reports, so `AutoCompleteMessages` is off. `Processed` and
+`SkippedDuplicate` both **complete** the message — both mean it is durably accounted for, and abandoning a
+duplicate would redeliver it forever because every attempt reaches the same conclusion. A handler exception
+**abandons**, since the dispatcher rolled back and nothing was applied. A message that is unusable in itself —
+no parseable id, no `Subject`, an unknown contract, a malformed body — is **dead-lettered immediately** with a
+reason code, because retrying the same bytes cannot produce a different outcome; abandoning would only burn
+the delivery count and dead-letter anyway, with no diagnosis attached.
+
+`AddAzureServiceBusIntegrationEventPublisher` **replaces** any existing `IIntegrationEventPublisher` rather
+than appending to it. In-process fan-out and broker publication are alternatives, not layers: registering both
+would deliver each event locally *and* over the wire, so a service subscribed to its own topic would handle
+everything twice. Replacing also makes the call order-independent.
+
+Neither registration gets a `TrellisServiceBuilder.UseXxx()` slot, matching `Trellis.Asp.Idempotency.Cosmos`.
+A builder slot is a compile-time reference, and surfacing one here would make every `Trellis.ServiceDefaults`
+consumer carry the Azure SDK in order to use features unrelated to Azure.
+
+The integration tests run against the real Azure Service Bus emulator, with a repo-owned compose file and
+`Config.json` (the emulator declares entities at startup and cannot create them at runtime, so the entity list
+is part of the fixture). Duplicate detection is deliberately **off** on the test topic: if the broker collapsed
+duplicate ids, the suite would pass even if the transport invented a fresh id per publish. The tests skip
+visibly when no emulator is reachable rather than passing against a substitute.
+
 ### Added — cross-service messaging contracts on the outbox publish seam
 
 Groundwork that makes a message-broker adapter possible to write correctly. Both ends of reliable messaging

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <!-- Runtime -->
   <ItemGroup>
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />

--- a/Trellis.Messaging.AzureServiceBus/NUGET_README.md
+++ b/Trellis.Messaging.AzureServiceBus/NUGET_README.md
@@ -1,0 +1,27 @@
+# Trellis.Messaging.AzureServiceBus
+
+Azure Service Bus transport for [Trellis](https://github.com/xavierjohn/Trellis) integration events — the wire between a producer's transactional outbox and a consumer's deduplicating inbox.
+
+The transport's central obligation is to carry the producer's outbox row id verbatim as the Service Bus `MessageId`. Outbox relay delivery is at-least-once, so the same row can be published more than once; carrying its id is what lets the consumer's `(ConsumerId, MessageId)` inbox dedup collapse those copies into one effective processing.
+
+## Producing
+
+```csharp
+services.AddAzureServiceBusIntegrationEventPublisher(
+    IntegrationEventNameMap.FromAssemblies(typeof(OrderPlaced).Assembly),
+    options => options.MessageSource = "orders-service");
+```
+
+Replaces the in-process publisher. One topic per contract by default, named after the event's `[IntegrationEventName]`.
+
+## Consuming
+
+```csharp
+services.AddAzureServiceBusIntegrationEventConsumer(
+    IntegrationEventNameMap.FromAssemblies(typeof(OrderPlaced).Assembly),
+    options => options.Subscribe("orders.order-placed.v1", "billing"));
+```
+
+Requires `AddTrellisInbox<TContext>()`. Messages are completed on both `Processed` and `SkippedDuplicate`, abandoned when a handler throws, and dead-lettered with a reason code when the message itself is unusable.
+
+See the [package documentation](https://github.com/xavierjohn/Trellis) for the full wire format and settlement rules.

--- a/Trellis.Messaging.AzureServiceBus/README.md
+++ b/Trellis.Messaging.AzureServiceBus/README.md
@@ -1,0 +1,66 @@
+# Trellis.Messaging.AzureServiceBus
+
+Azure Service Bus transport for Trellis integration events — the wire between a producer's transactional outbox and a consumer's deduplicating inbox.
+
+## What it is for
+
+Trellis already ships both ends of reliable messaging: the outbox stages integration events in the same transaction as the business change, and the inbox makes consumption idempotent by recording `(ConsumerId, MessageId)`. This package is the piece in between.
+
+Its central obligation is one line of code: the producer's outbox row id becomes the Service Bus `MessageId`, carried verbatim.
+
+Outbox relay delivery is at-least-once — a crash between publishing and the relay's bookkeeping save republishes the row. If the transport minted its own id per attempt, each copy would reach the consumer under a different `MessageId`, the inbox dedup would miss, and handlers would run twice. Because `IIntegrationEventPublisher` takes an `OutboundIntegrationMessage`, which carries the id, publishing without it is not expressible.
+
+## Wire format
+
+| Service Bus member | Carries |
+|---|---|
+| `MessageId` | The producer's outbox row id (UUIDv7). The consumer's dedup key. |
+| `Subject` | The event's stable wire name, from `[IntegrationEventName("orders.order-placed.v1")]`. |
+| `Body` | The event serialized as UTF-8 JSON. |
+| `ContentType` | `application/json`. |
+| `trellis-message-source` | Optional producing service or bounded context; observability only. |
+
+Standard Service Bus members are used wherever one exists, so a message stays diagnosable in the portal and Service Bus Explorer, and routable by subscription filters, without those tools knowing anything about Trellis.
+
+The default layout is **one topic per contract**, named after the wire name. Subscribers declare interest by subscribing to the topics they want rather than filtering a firehose. Override `TopicNameResolver` to prefix an environment segment or to collapse contracts onto a shared topic — if you collapse them, filter subscriptions on `sys.Label`, which always carries the wire name.
+
+## Producing
+
+```csharp
+services.AddAzureServiceBusIntegrationEventPublisher(
+    IntegrationEventNameMap.FromAssemblies(typeof(OrderPlaced).Assembly),
+    options => options.MessageSource = "orders-service");
+```
+
+This **replaces** the in-process publisher rather than adding to it. The two are alternatives, not layers: registering both would deliver each event locally *and* over the wire, so a service subscribed to its own topic would handle everything twice.
+
+Register a `ServiceBusClient` in the container; the publisher does not own its lifetime.
+
+## Consuming
+
+```csharp
+services.AddAzureServiceBusIntegrationEventConsumer(
+    IntegrationEventNameMap.FromAssemblies(typeof(OrderPlaced).Assembly),
+    options => options.Subscribe("orders.order-placed.v1", "billing"));
+```
+
+Requires an `IInboxDispatcher` (`AddTrellisInbox<TContext>()`). Consuming without one would run handlers with no deduplication — the failure the inbox exists to prevent.
+
+### Settlement
+
+| Situation | Action | Why |
+|---|---|---|
+| `InboxDispatchOutcome.Processed` | Complete | Side effects and the dedup row committed together. |
+| `InboxDispatchOutcome.SkippedDuplicate` | Complete | Durably accounted for already. Abandoning would loop forever, since every redelivery reaches the same conclusion. |
+| Handler throws | Abandon (by the SDK) | The dispatcher rolled back, so nothing was applied. `MaxDeliveryCount` eventually dead-letters a persistently failing message. |
+| Unusable id, missing or unknown `Subject`, malformed body | Dead-letter with a reason code | A property of the bytes, not of this consumer's state — retrying cannot change the outcome. |
+
+The subscriber identity used for deduplication is `InboxOptions.ConsumerId`, not a transport setting, so a message arriving twice by two different routes is still processed once.
+
+## Testing against the emulator
+
+```
+docker compose -f Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml up -d
+```
+
+The emulator declares its entities in `Config.json` at startup and cannot create them at runtime, which is why the compose file and its entity list are part of the test fixture. Duplicate detection is deliberately **off** on the test topic: if the broker collapsed duplicate ids, the tests would pass even if the transport invented a fresh id per publish. The suite skips visibly when no emulator is reachable, so it never passes against a substitute.

--- a/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusConsumerOptions.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusConsumerOptions.cs
@@ -60,17 +60,34 @@ public sealed class AzureServiceBusConsumerOptions
     /// Controls how event bodies are deserialized. Must agree with the producer's settings; defaults to
     /// <see cref="JsonSerializerOptions.Web"/>, matching <see cref="AzureServiceBusPublisherOptions"/>.
     /// </summary>
-    public JsonSerializerOptions JsonSerializerOptions { get; set; } = JsonSerializerOptions.Web;
+    public JsonSerializerOptions JsonSerializerOptions
+    {
+        get => _jsonSerializerOptions;
+        set => _jsonSerializerOptions = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private JsonSerializerOptions _jsonSerializerOptions = JsonSerializerOptions.Web;
 
     /// <summary>
     /// Adds a subscription to receive from.
     /// </summary>
+    /// <remarks>
+    /// Rejects a duplicate here rather than only in <see cref="Validate"/>, because configuration accumulates
+    /// across every <c>AddAzureServiceBusIntegrationEventConsumer</c> call onto one options instance. Two
+    /// calls each valid on their own can still add the same subscription twice, and the result is two
+    /// processors on one subscription competing for the same messages.
+    /// </remarks>
     /// <param name="topicName">The topic name.</param>
     /// <param name="subscriptionName">The subscription name.</param>
     /// <returns>The same options instance, for chaining.</returns>
     public AzureServiceBusConsumerOptions Subscribe(string topicName, string subscriptionName)
     {
-        Subscriptions.Add(new ServiceBusSubscription(topicName, subscriptionName));
+        var subscription = new ServiceBusSubscription(topicName, subscriptionName);
+
+        if (Subscriptions.Contains(subscription))
+            throw new InvalidOperationException(DuplicateMessage(topicName, subscriptionName));
+
+        Subscriptions.Add(subscription);
         return this;
     }
 
@@ -96,7 +113,10 @@ public sealed class AzureServiceBusConsumerOptions
 
         if (duplicate is not null)
             throw new InvalidOperationException(
-                $"Subscription '{duplicate.Key.SubscriptionName}' on topic '{duplicate.Key.TopicName}' is registered more than once; " +
-                "each registration starts its own processor, so the duplicate only competes with itself for the same messages.");
+                DuplicateMessage(duplicate.Key.TopicName, duplicate.Key.SubscriptionName));
     }
+
+    private static string DuplicateMessage(string topicName, string subscriptionName) =>
+        $"Subscription '{subscriptionName}' on topic '{topicName}' is registered more than once; " +
+        "each registration starts its own processor, so the duplicate only competes with itself for the same messages.";
 }

--- a/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusConsumerOptions.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusConsumerOptions.cs
@@ -1,0 +1,102 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using System.Text.Json;
+
+/// <summary>
+/// One Service Bus subscription this service consumes from.
+/// </summary>
+/// <param name="TopicName">The topic. With the default topic-per-contract layout this is the event's wire name.</param>
+/// <param name="SubscriptionName">The subscription on that topic belonging to this service.</param>
+public sealed record ServiceBusSubscription(string TopicName, string SubscriptionName)
+{
+    /// <summary>Gets the topic name.</summary>
+    public string TopicName { get; init; } = !string.IsNullOrWhiteSpace(TopicName)
+        ? TopicName
+        : throw new ArgumentException("Topic name must not be blank.", nameof(TopicName));
+
+    /// <summary>Gets the subscription name.</summary>
+    public string SubscriptionName { get; init; } = !string.IsNullOrWhiteSpace(SubscriptionName)
+        ? SubscriptionName
+        : throw new ArgumentException("Subscription name must not be blank.", nameof(SubscriptionName));
+}
+
+/// <summary>
+/// Tuning for consuming integration events from Azure Service Bus into the transactional inbox.
+/// </summary>
+/// <remarks>
+/// The subscriber identity used for deduplication is <b>not</b> configured here — it is
+/// <c>InboxOptions.ConsumerId</c>, so every transport a service consumes from shares one dedup namespace and
+/// a message that arrives twice by two routes is still processed once.
+/// </remarks>
+public sealed class AzureServiceBusConsumerOptions
+{
+    /// <summary>
+    /// The subscriptions to receive from. Each gets its own processor.
+    /// </summary>
+    public IList<ServiceBusSubscription> Subscriptions { get; } = [];
+
+    /// <summary>
+    /// How many messages one subscription processes concurrently. Defaults to 1.
+    /// </summary>
+    /// <remarks>
+    /// The default is deliberately conservative: each concurrent message runs handlers inside its own
+    /// database transaction, so raising this raises pressure on the connection pool and the odds of write
+    /// contention between handlers. Deduplication stays correct at any value — concurrent delivery of the
+    /// same message is resolved by the inbox's composite primary key — so this is purely a throughput knob.
+    /// </remarks>
+    public int MaxConcurrentCalls { get; set; } = 1;
+
+    /// <summary>
+    /// How many messages the client fetches ahead of processing. Defaults to 0 (no prefetch).
+    /// </summary>
+    /// <remarks>
+    /// Prefetched messages have their lock clock already running, so a large prefetch combined with slow
+    /// handlers expires locks and causes redelivery. Redelivery is safe here (the inbox absorbs it) but it
+    /// wastes work; raise this only once handler latency is known to be well inside the lock duration.
+    /// </remarks>
+    public int PrefetchCount { get; set; }
+
+    /// <summary>
+    /// Controls how event bodies are deserialized. Must agree with the producer's settings; defaults to
+    /// <see cref="JsonSerializerOptions.Web"/>, matching <see cref="AzureServiceBusPublisherOptions"/>.
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions { get; set; } = JsonSerializerOptions.Web;
+
+    /// <summary>
+    /// Adds a subscription to receive from.
+    /// </summary>
+    /// <param name="topicName">The topic name.</param>
+    /// <param name="subscriptionName">The subscription name.</param>
+    /// <returns>The same options instance, for chaining.</returns>
+    public AzureServiceBusConsumerOptions Subscribe(string topicName, string subscriptionName)
+    {
+        Subscriptions.Add(new ServiceBusSubscription(topicName, subscriptionName));
+        return this;
+    }
+
+    /// <summary>
+    /// Validates the configured values, failing at registration rather than on the first message.
+    /// </summary>
+    internal void Validate()
+    {
+        if (Subscriptions.Count == 0)
+            throw new InvalidOperationException(
+                "AzureServiceBusConsumerOptions has no subscriptions; call Subscribe(topic, subscription) at least once, " +
+                "otherwise the consumer would start and silently receive nothing.");
+
+        if (MaxConcurrentCalls < 1)
+            throw new InvalidOperationException("AzureServiceBusConsumerOptions.MaxConcurrentCalls must be at least 1.");
+
+        if (PrefetchCount < 0)
+            throw new InvalidOperationException("AzureServiceBusConsumerOptions.PrefetchCount must not be negative.");
+
+        var duplicate = Subscriptions
+            .GroupBy(static s => (s.TopicName, s.SubscriptionName))
+            .FirstOrDefault(static g => g.Count() > 1);
+
+        if (duplicate is not null)
+            throw new InvalidOperationException(
+                $"Subscription '{duplicate.Key.SubscriptionName}' on topic '{duplicate.Key.TopicName}' is registered more than once; " +
+                "each registration starts its own processor, so the duplicate only competes with itself for the same messages.");
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusPublisherOptions.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusPublisherOptions.cs
@@ -26,7 +26,13 @@ public sealed class AzureServiceBusPublisherOptions
     /// <c>sys.Label</c> (the message's <c>Subject</c>, which always carries the wire name) so a subscriber
     /// does not receive contracts it cannot deserialize.
     /// </remarks>
-    public Func<string, string> TopicNameResolver { get; set; } = static wireName => wireName;
+    public Func<string, string> TopicNameResolver
+    {
+        get => _topicNameResolver;
+        set => _topicNameResolver = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private Func<string, string> _topicNameResolver = static wireName => wireName;
 
     /// <summary>
     /// Controls how event bodies are serialized to JSON. Defaults to <see cref="JsonSerializerOptions.Web"/>
@@ -37,5 +43,11 @@ public sealed class AzureServiceBusPublisherOptions
     /// message ships, or accept that in-flight messages written with the previous settings must still
     /// deserialize.
     /// </remarks>
-    public JsonSerializerOptions JsonSerializerOptions { get; set; } = JsonSerializerOptions.Web;
+    public JsonSerializerOptions JsonSerializerOptions
+    {
+        get => _jsonSerializerOptions;
+        set => _jsonSerializerOptions = value ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    private JsonSerializerOptions _jsonSerializerOptions = JsonSerializerOptions.Web;
 }

--- a/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusPublisherOptions.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusPublisherOptions.cs
@@ -1,0 +1,41 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using System.Text.Json;
+
+/// <summary>
+/// Tuning for publishing integration events to Azure Service Bus.
+/// </summary>
+public sealed class AzureServiceBusPublisherOptions
+{
+    /// <summary>
+    /// The producing service or bounded context, stamped on each message and surfaced to consumers as
+    /// <see cref="Trellis.Mediator.IntegrationEnvelope.MessageSource"/>. Optional; observability only —
+    /// it never participates in deduplication or routing.
+    /// </summary>
+    public string? MessageSource { get; set; }
+
+    /// <summary>
+    /// Maps an event's stable wire name (from <c>[IntegrationEventName]</c>) to the Service Bus topic it is
+    /// published to. Defaults to using the wire name verbatim, which is the topic-per-event-type layout:
+    /// each contract owns a topic, and a subscriber declares interest by subscribing to the topics it wants
+    /// rather than by filtering a firehose.
+    /// </summary>
+    /// <remarks>
+    /// Override this to prefix an environment or team segment (<c>name => $"prod.{name}"</c>), or to collapse
+    /// several contracts onto one topic. If you do collapse them, subscriptions need a correlation filter on
+    /// <c>sys.Label</c> (the message's <c>Subject</c>, which always carries the wire name) so a subscriber
+    /// does not receive contracts it cannot deserialize.
+    /// </remarks>
+    public Func<string, string> TopicNameResolver { get; set; } = static wireName => wireName;
+
+    /// <summary>
+    /// Controls how event bodies are serialized to JSON. Defaults to <see cref="JsonSerializerOptions.Web"/>
+    /// (camelCase, case-insensitive reads), matching the convention most HTTP-facing services already use.
+    /// </summary>
+    /// <remarks>
+    /// This is a wire-format decision shared with every consumer of these messages. Change it before the first
+    /// message ships, or accept that in-flight messages written with the previous settings must still
+    /// deserialize.
+    /// </remarks>
+    public JsonSerializerOptions JsonSerializerOptions { get; set; } = JsonSerializerOptions.Web;
+}

--- a/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusServiceCollectionExtensions.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusServiceCollectionExtensions.cs
@@ -1,0 +1,92 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Trellis.Mediator;
+
+/// <summary>
+/// Registration for the Azure Service Bus integration-event transport.
+/// </summary>
+public static class AzureServiceBusServiceCollectionExtensions
+{
+    /// <summary>
+    /// Publishes integration events to Azure Service Bus instead of to in-process handlers.
+    /// </summary>
+    /// <remarks>
+    /// This <b>replaces</b> any existing <see cref="IIntegrationEventPublisher"/> registration rather than
+    /// adding to it. In-process fan-out and broker publication are alternatives, not layers: registering both
+    /// would deliver each event locally <i>and</i> over the wire, so a service subscribed to its own topic
+    /// would handle everything twice. Replacing makes the choice explicit and order-independent.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="nameMap">Maps each event type to the wire name that names its topic.</param>
+    /// <param name="configure">Optional publisher configuration.</param>
+    /// <returns>The same service collection, for chaining.</returns>
+    public static IServiceCollection AddAzureServiceBusIntegrationEventPublisher(
+        this IServiceCollection services,
+        IntegrationEventNameMap nameMap,
+        Action<AzureServiceBusPublisherOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(nameMap);
+
+        var options = services.AddOptions<AzureServiceBusPublisherOptions>();
+        if (configure is not null)
+            options.Configure(configure);
+
+        services.RemoveAll<IIntegrationEventPublisher>();
+        services.AddSingleton<IIntegrationEventPublisher>(provider => new ServiceBusIntegrationEventPublisher(
+            provider.GetRequiredService<ServiceBusClient>(),
+            nameMap,
+            provider.GetRequiredService<IOptions<AzureServiceBusPublisherOptions>>(),
+            provider.GetRequiredService<ILogger<ServiceBusIntegrationEventPublisher>>()));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Receives integration events from Azure Service Bus into the transactional inbox.
+    /// </summary>
+    /// <remarks>
+    /// Requires an <see cref="IInboxDispatcher"/> registration (<c>AddTrellisInbox&lt;TContext&gt;()</c>) —
+    /// consuming without one would run handlers without deduplication, which is the failure the inbox exists
+    /// to prevent. The dispatcher is resolved per message from a fresh scope, so it is not required to be
+    /// registered before this call.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="nameMap">Resolves a received message's wire name to its local event type.</param>
+    /// <param name="configure">Consumer configuration; must register at least one subscription.</param>
+    /// <returns>The same service collection, for chaining.</returns>
+    public static IServiceCollection AddAzureServiceBusIntegrationEventConsumer(
+        this IServiceCollection services,
+        IntegrationEventNameMap nameMap,
+        Action<AzureServiceBusConsumerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(nameMap);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Validate eagerly against a throwaway instance so a missing subscription is a registration-time
+        // error, not a service that starts cleanly and receives nothing.
+        var probe = new AzureServiceBusConsumerOptions();
+        configure(probe);
+        probe.Validate();
+
+        services.AddOptions<AzureServiceBusConsumerOptions>().Configure(configure);
+
+        // AddHostedService deduplicates on ServiceBusInboxConsumer even through a factory, so registering
+        // twice configures one consumer with both callers' subscriptions rather than running two.
+        services.AddHostedService(provider => new ServiceBusInboxConsumer(
+            provider.GetRequiredService<ServiceBusClient>(),
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            nameMap,
+            provider.GetRequiredService<IOptions<AzureServiceBusConsumerOptions>>(),
+            provider.GetRequiredService<ILogger<ServiceBusInboxConsumer>>()));
+
+        return services;
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusServiceCollectionExtensions.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/AzureServiceBusServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Trellis.Messaging.AzureServiceBus;
 
+using System.Runtime.CompilerServices;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -13,6 +14,12 @@ using Trellis.Mediator;
 /// </summary>
 public static class AzureServiceBusServiceCollectionExtensions
 {
+    /// <summary>
+    /// Per-collection accumulated consumer configuration, used only to validate at registration time.
+    /// Keyed weakly so it does not keep a service collection alive or leak between tests.
+    /// </summary>
+    private static readonly ConditionalWeakTable<IServiceCollection, AzureServiceBusConsumerOptions> s_consumerProbes = [];
+
     /// <summary>
     /// Publishes integration events to Azure Service Bus instead of to in-process handlers.
     /// </summary>
@@ -70,9 +77,11 @@ public static class AzureServiceBusServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(nameMap);
         ArgumentNullException.ThrowIfNull(configure);
 
-        // Validate eagerly against a throwaway instance so a missing subscription is a registration-time
-        // error, not a service that starts cleanly and receives nothing.
-        var probe = new AzureServiceBusConsumerOptions();
+        // Validate against a probe that accumulates every call's configuration, not a fresh one per call.
+        // Subscriptions add up across calls onto a single options instance at runtime, so a per-call probe
+        // would pass two registrations that are each fine alone and together start two processors competing
+        // on one subscription.
+        var probe = s_consumerProbes.GetOrCreateValue(services);
         configure(probe);
         probe.Validate();
 

--- a/Trellis.Messaging.AzureServiceBus/src/IMessageSettler.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/IMessageSettler.cs
@@ -1,0 +1,38 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using Azure.Messaging.ServiceBus;
+
+/// <summary>
+/// How a received message is settled, abstracted away from the SDK's <see cref="ProcessMessageEventArgs"/>.
+/// </summary>
+/// <remarks>
+/// Settlement is the consumer's most consequential decision — completing a message that was not durably
+/// accounted for loses it, and abandoning one that was replays it forever — yet in the SDK it is reachable
+/// only through a live receiver holding a real lock. This seam lets the decision be exercised directly, so
+/// the rules are pinned by tests that run on a build server with no broker, rather than only by tests that
+/// need Docker and are excluded from CI.
+/// </remarks>
+internal interface IMessageSettler
+{
+    /// <summary>Completes the message, removing it from the subscription.</summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the message is settled.</returns>
+    Task CompleteAsync(CancellationToken cancellationToken);
+
+    /// <summary>Dead-letters the message with a reason code and diagnosis.</summary>
+    /// <param name="reason">The reason code recorded on the dead-lettered message.</param>
+    /// <param name="description">The specific diagnosis.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task that completes when the message is settled.</returns>
+    Task DeadLetterAsync(string reason, string? description, CancellationToken cancellationToken);
+}
+
+/// <summary>Settles through the SDK's per-message event args.</summary>
+internal sealed class ProcessMessageEventArgsSettler(ProcessMessageEventArgs args) : IMessageSettler
+{
+    public Task CompleteAsync(CancellationToken cancellationToken) =>
+        args.CompleteMessageAsync(args.Message, cancellationToken);
+
+    public Task DeadLetterAsync(string reason, string? description, CancellationToken cancellationToken) =>
+        args.DeadLetterMessageAsync(args.Message, reason, description, cancellationToken);
+}

--- a/Trellis.Messaging.AzureServiceBus/src/InboxMessageHandler.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/InboxMessageHandler.cs
@@ -1,0 +1,69 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Trellis.Mediator;
+
+/// <summary>
+/// Turns a received Service Bus message into an inbox dispatch and settles it accordingly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Separated from <see cref="ServiceBusInboxConsumer"/> so the settlement rules do not depend on a live
+/// processor: the consumer owns the receive loops and lifetime, this owns what happens to one message.
+/// </para>
+/// <para>
+/// The rules, and why each is what it is:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Processed and SkippedDuplicate both complete.</b> Both mean the message is durably accounted for —
+/// either the handlers ran and the dedup row committed with them, or a previous delivery already did that.
+/// Abandoning a duplicate would redeliver it forever, because every attempt reaches the same conclusion.
+/// </description></item>
+/// <item><description>
+/// <b>Handler failures propagate.</b> The dispatcher rolled back, so nothing was applied and redelivery is
+/// correct. The SDK abandons an unsettled message whose handler threw, and <c>MaxDeliveryCount</c> eventually
+/// dead-letters one that keeps failing.
+/// </description></item>
+/// <item><description>
+/// <b>Unusable messages dead-letter immediately.</b> A missing id, a missing contract name, an unknown
+/// contract, or a body that will not deserialize are properties of the message, not of this consumer's
+/// state. Retrying the same bytes cannot succeed, so abandoning would only burn the delivery count and
+/// dead-letter anyway — with no diagnosis attached.
+/// </description></item>
+/// </list>
+/// </remarks>
+internal sealed class InboxMessageHandler(
+    IServiceScopeFactory scopeFactory,
+    IntegrationEventNameMap nameMap,
+    JsonSerializerOptions jsonOptions,
+    ILogger logger)
+{
+    public async Task HandleAsync(
+        ServiceBusReceivedMessage message,
+        IMessageSettler settler,
+        CancellationToken cancellationToken)
+    {
+        var envelopeResult = ServiceBusMessageFormatter.ToEnvelope(message, nameMap, jsonOptions);
+
+        if (!envelopeResult.TryGetValue(out var envelope, out var error))
+        {
+            ServiceBusTransportLog.DeadLettered(logger, message.MessageId, error.Code, error.Detail);
+
+            await settler.DeadLetterAsync(error.Code, error.Detail, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await using var scope = scopeFactory.CreateAsyncScope();
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IInboxDispatcher>();
+
+        var outcome = await dispatcher.DispatchAsync(envelope, cancellationToken).ConfigureAwait(false);
+
+        await settler.CompleteAsync(cancellationToken).ConfigureAwait(false);
+
+        ServiceBusTransportLog.Settled(logger, envelope.MessageId, message.Subject, outcome);
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusConsumerErrors.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusConsumerErrors.cs
@@ -1,0 +1,56 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+/// <summary>
+/// The ways a received message can violate the transport contract. Each is a property of the message bytes
+/// themselves, so redelivering the same message can never produce a different outcome — the processor
+/// dead-letters rather than abandoning, and the reason code below becomes the dead-letter reason.
+/// </summary>
+internal static class ServiceBusConsumerErrors
+{
+    /// <summary>Reason code for a message whose <c>MessageId</c> is absent or not a usable GUID.</summary>
+    public const string UnusableMessageIdCode = "servicebus_unusable_message_id";
+
+    /// <summary>Reason code for a message with no <c>Subject</c> to identify its contract.</summary>
+    public const string MissingSubjectCode = "servicebus_missing_subject";
+
+    /// <summary>Reason code for a contract name this application does not know.</summary>
+    public const string UnknownContractCode = "servicebus_unknown_contract";
+
+    /// <summary>Reason code for a body that does not deserialize to its declared contract.</summary>
+    public const string MalformedBodyCode = "servicebus_malformed_body";
+
+    /// <summary>
+    /// The message carries no usable dedup identity. Processing it would defeat the inbox: without a stable
+    /// id the consumer cannot tell a redelivery from a new message, so handlers would run again on every
+    /// delivery attempt.
+    /// </summary>
+    public static Error UnusableMessageId(string? messageId) =>
+        new Error.InvariantViolation(UnusableMessageIdCode)
+        {
+            Detail = $"MessageId '{messageId}' is not a non-empty GUID, so the message has no stable inbox dedup key.",
+        };
+
+    /// <summary>The message does not say which contract it carries, so no type can be chosen to deserialize it.</summary>
+    public static Error MissingSubject { get; } =
+        new Error.InvariantViolation(MissingSubjectCode)
+        {
+            Detail = "Subject is empty; Trellis carries the integration event's wire name there.",
+        };
+
+    /// <summary>
+    /// The contract name is well-formed but unknown here. This is normal traffic on a shared topic — a
+    /// producer may emit contracts this subscriber does not model — so it is a routing decision, not a bug.
+    /// </summary>
+    public static Error UnknownContract(string wireName) =>
+        new Error.InvariantViolation(UnknownContractCode)
+        {
+            Detail = $"No integration event type is registered for wire name '{wireName}'.",
+        };
+
+    /// <summary>The declared contract is known but the body does not match it.</summary>
+    public static Error MalformedBody(string wireName, string reason) =>
+        new Error.InvariantViolation(MalformedBodyCode)
+        {
+            Detail = $"The body of '{wireName}' could not be deserialized: {reason}",
+        };
+}

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusInboxConsumer.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusInboxConsumer.cs
@@ -47,6 +47,7 @@ public sealed class ServiceBusInboxConsumer : BackgroundService
     private readonly IntegrationEventNameMap _nameMap;
     private readonly AzureServiceBusConsumerOptions _options;
     private readonly ILogger<ServiceBusInboxConsumer> _logger;
+    private readonly InboxMessageHandler _handler;
     private readonly List<ServiceBusProcessor> _processors = [];
 
     /// <summary>
@@ -75,6 +76,12 @@ public sealed class ServiceBusInboxConsumer : BackgroundService
         _nameMap = nameMap;
         _options = options.Value;
         _logger = logger;
+
+        // The registration helper validates each caller's configuration in isolation; this validates what
+        // they actually add up to, which is the only instance the processors are built from.
+        _options.Validate();
+
+        _handler = new InboxMessageHandler(scopeFactory, nameMap, _options.JsonSerializerOptions, logger);
     }
 
     /// <inheritdoc />
@@ -120,29 +127,9 @@ public sealed class ServiceBusInboxConsumer : BackgroundService
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task ProcessMessageAsync(ProcessMessageEventArgs args)
-    {
-        var envelopeResult = ServiceBusMessageFormatter.ToEnvelope(
-            args.Message, _nameMap, _options.JsonSerializerOptions);
-
-        if (!envelopeResult.TryGetValue(out var envelope, out var error))
-        {
-            ServiceBusTransportLog.DeadLettered(_logger, args.Message.MessageId, error.Code, error.Detail);
-
-            await args.DeadLetterMessageAsync(args.Message, error.Code, error.Detail, args.CancellationToken)
-                .ConfigureAwait(false);
-            return;
-        }
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var dispatcher = scope.ServiceProvider.GetRequiredService<IInboxDispatcher>();
-
-        var outcome = await dispatcher.DispatchAsync(envelope, args.CancellationToken).ConfigureAwait(false);
-
-        await args.CompleteMessageAsync(args.Message, args.CancellationToken).ConfigureAwait(false);
-
-        ServiceBusTransportLog.Settled(_logger, envelope.MessageId, args.Message.Subject, outcome);
-    }
+    private async Task ProcessMessageAsync(ProcessMessageEventArgs args) =>
+        await _handler.HandleAsync(args.Message, new ProcessMessageEventArgsSettler(args), args.CancellationToken)
+            .ConfigureAwait(false);
 
     private Task ProcessErrorAsync(ProcessErrorEventArgs args)
     {

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusInboxConsumer.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusInboxConsumer.cs
@@ -1,0 +1,152 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Trellis.Mediator;
+
+/// <summary>
+/// Receives integration events from Azure Service Bus and feeds them to the transactional inbox.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The settlement rules are the whole design, and they follow from what <see cref="IInboxDispatcher"/>
+/// guarantees:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <b>Complete</b> on <see cref="InboxDispatchOutcome.Processed"/> <i>and</i> on
+/// <see cref="InboxDispatchOutcome.SkippedDuplicate"/>. Both mean the message is durably accounted for; a
+/// duplicate that was abandoned instead would be redelivered forever, since every attempt would reach the
+/// same conclusion.
+/// </description></item>
+/// <item><description>
+/// <b>Abandon</b> when a handler throws. The dispatcher rolls its transaction back, so nothing was applied
+/// and redelivery is the correct response. The exception is deliberately not caught here: the SDK abandons
+/// an unsettled message whose handler threw, and routes the exception to the error handler, which is exactly
+/// the behaviour wanted. Service Bus dead-letters the message once its <c>MaxDeliveryCount</c> is reached,
+/// which is where a persistently failing handler ends up.
+/// </description></item>
+/// <item><description>
+/// <b>Dead-letter</b> when the message itself is unusable — no parseable id, no contract name, an unknown
+/// contract, or a body that does not deserialize. Retrying the same bytes cannot change the outcome, so
+/// abandoning would only burn the delivery count before dead-lettering anyway, with no diagnosis attached.
+/// </description></item>
+/// </list>
+/// <para>
+/// Each message is dispatched inside its own DI scope, because the inbox commits handler side effects and
+/// the dedup row in one unit of work and that unit of work is scoped.
+/// </para>
+/// </remarks>
+public sealed class ServiceBusInboxConsumer : BackgroundService
+{
+    private readonly ServiceBusClient _client;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IntegrationEventNameMap _nameMap;
+    private readonly AzureServiceBusConsumerOptions _options;
+    private readonly ILogger<ServiceBusInboxConsumer> _logger;
+    private readonly List<ServiceBusProcessor> _processors = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceBusInboxConsumer"/> class.
+    /// </summary>
+    /// <param name="client">The Service Bus client.</param>
+    /// <param name="scopeFactory">Creates the per-message DI scope the inbox dispatch runs in.</param>
+    /// <param name="nameMap">Resolves a message's wire name to its local event type.</param>
+    /// <param name="options">Consumer options.</param>
+    /// <param name="logger">Logger.</param>
+    public ServiceBusInboxConsumer(
+        ServiceBusClient client,
+        IServiceScopeFactory scopeFactory,
+        IntegrationEventNameMap nameMap,
+        IOptions<AzureServiceBusConsumerOptions> options,
+        ILogger<ServiceBusInboxConsumer> logger)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(nameMap);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _client = client;
+        _scopeFactory = scopeFactory;
+        _nameMap = nameMap;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        foreach (var subscription in _options.Subscriptions)
+        {
+            var processor = _client.CreateProcessor(
+                subscription.TopicName,
+                subscription.SubscriptionName,
+                new ServiceBusProcessorOptions
+                {
+                    // Settlement is decided by the inbox outcome, so the processor must not settle for us.
+                    AutoCompleteMessages = false,
+                    MaxConcurrentCalls = _options.MaxConcurrentCalls,
+                    PrefetchCount = _options.PrefetchCount,
+                });
+
+            processor.ProcessMessageAsync += ProcessMessageAsync;
+            processor.ProcessErrorAsync += ProcessErrorAsync;
+            _processors.Add(processor);
+
+            await processor.StartProcessingAsync(stoppingToken).ConfigureAwait(false);
+
+            ServiceBusTransportLog.Consuming(_logger, subscription.SubscriptionName, subscription.TopicName);
+        }
+
+        // The processors own their own receive loops; this task just parks until shutdown.
+        await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        foreach (var processor in _processors)
+        {
+            await processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
+            await processor.DisposeAsync().ConfigureAwait(false);
+        }
+
+        _processors.Clear();
+
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ProcessMessageAsync(ProcessMessageEventArgs args)
+    {
+        var envelopeResult = ServiceBusMessageFormatter.ToEnvelope(
+            args.Message, _nameMap, _options.JsonSerializerOptions);
+
+        if (!envelopeResult.TryGetValue(out var envelope, out var error))
+        {
+            ServiceBusTransportLog.DeadLettered(_logger, args.Message.MessageId, error.Code, error.Detail);
+
+            await args.DeadLetterMessageAsync(args.Message, error.Code, error.Detail, args.CancellationToken)
+                .ConfigureAwait(false);
+            return;
+        }
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var dispatcher = scope.ServiceProvider.GetRequiredService<IInboxDispatcher>();
+
+        var outcome = await dispatcher.DispatchAsync(envelope, args.CancellationToken).ConfigureAwait(false);
+
+        await args.CompleteMessageAsync(args.Message, args.CancellationToken).ConfigureAwait(false);
+
+        ServiceBusTransportLog.Settled(_logger, envelope.MessageId, args.Message.Subject, outcome);
+    }
+
+    private Task ProcessErrorAsync(ProcessErrorEventArgs args)
+    {
+        ServiceBusTransportLog.ProcessingError(_logger, args.EntityPath, args.ErrorSource, args.Exception);
+        return Task.CompletedTask;
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusIntegrationEventPublisher.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusIntegrationEventPublisher.cs
@@ -1,0 +1,135 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using System.Collections.Concurrent;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Trellis.Mediator;
+
+/// <summary>
+/// Publishes integration events to Azure Service Bus, one topic per contract.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered in place of the in-process publisher, this is what turns the outbox from a local relay into a
+/// cross-service one. It is the transport half of the guarantee the inbox provides: the outbox row id is
+/// stamped on <see cref="ServiceBusMessage.MessageId"/> verbatim, so however many times the relay delivers a
+/// row, the consumer sees one message id and deduplicates on it.
+/// </para>
+/// <para>
+/// Senders are cached per topic and shared, which is the SDK's documented usage: a sender owns an AMQP link,
+/// and creating one per publish would make every message pay a link handshake.
+/// </para>
+/// </remarks>
+public sealed class ServiceBusIntegrationEventPublisher : IIntegrationEventPublisher, IAsyncDisposable
+{
+    private readonly ServiceBusClient _client;
+    private readonly IntegrationEventNameMap _nameMap;
+    private readonly AzureServiceBusPublisherOptions _options;
+    private readonly ILogger<ServiceBusIntegrationEventPublisher> _logger;
+    private readonly ConcurrentDictionary<string, ServiceBusSender> _senders = new(StringComparer.Ordinal);
+    private volatile bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceBusIntegrationEventPublisher"/> class.
+    /// </summary>
+    /// <param name="client">The Service Bus client. Its lifetime is owned by the container, not by this publisher.</param>
+    /// <param name="nameMap">Maps each event type to the stable wire name that names its topic.</param>
+    /// <param name="options">Publishing options.</param>
+    /// <param name="logger">Logger.</param>
+    public ServiceBusIntegrationEventPublisher(
+        ServiceBusClient client,
+        IntegrationEventNameMap nameMap,
+        IOptions<AzureServiceBusPublisherOptions> options,
+        ILogger<ServiceBusIntegrationEventPublisher> logger)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(nameMap);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _client = client;
+        _nameMap = nameMap;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    /// The event type has no registered wire name. This is a contract bug — the event cannot be named on the
+    /// wire, so no consumer could identify it — and it is deliberately fatal to the publish. The outbox row
+    /// stays unsent and the relay retries, which surfaces the missing <c>[IntegrationEventName]</c> as a
+    /// stuck message rather than as silently dropped traffic.
+    /// </exception>
+    public async ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var eventType = message.Event.GetType();
+        var wireName = _nameMap.NameFor(eventType);
+        if (!wireName.HasValue)
+            throw new InvalidOperationException(
+                $"Integration event '{eventType.FullName}' has no registered wire name. Annotate it with " +
+                "[IntegrationEventName(\"...\")] and include its assembly when building the IntegrationEventNameMap; " +
+                "without a wire name no consumer can identify the message.");
+
+        var topic = _options.TopicNameResolver(wireName.Value);
+        var serviceBusMessage = ServiceBusMessageFormatter.ToServiceBusMessage(
+            message, wireName.Value, _options.MessageSource, _options.JsonSerializerOptions);
+
+        var sender = await GetSenderAsync(topic).ConfigureAwait(false);
+
+        await sender.SendMessageAsync(serviceBusMessage, cancellationToken).ConfigureAwait(false);
+
+        ServiceBusTransportLog.Published(_logger, wireName.Value, message.MessageId, topic);
+    }
+
+    /// <summary>
+    /// Returns the cached sender for a topic, creating one if this is the first publish to it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>GetOrAdd</c> with a factory: that factory can run on several threads at once for
+    /// the same topic, and every instance but the winner is discarded without ever being closed. Creating the
+    /// candidate here and closing it when another thread got there first keeps the cache the sole owner of
+    /// every sender that exists, which is what makes <see cref="DisposeAsync"/> able to close all of them.
+    /// </remarks>
+    private async ValueTask<ServiceBusSender> GetSenderAsync(string topic)
+    {
+        if (_senders.TryGetValue(topic, out var existing))
+            return existing;
+
+        var candidate = _client.CreateSender(topic);
+        var winner = _senders.GetOrAdd(topic, candidate);
+        if (!ReferenceEquals(winner, candidate))
+            await candidate.DisposeAsync().ConfigureAwait(false);
+
+        return winner;
+    }
+
+    /// <summary>
+    /// Closes the cached senders. The <see cref="ServiceBusClient"/> itself is left alone — it is resolved
+    /// from the container and may be shared with consumers and other publishers.
+    /// </summary>
+    /// <remarks>
+    /// Draining until the cache is empty rather than iterating once: a publish that passed the disposed check
+    /// just before this ran can still add a sender afterwards, and a single pass would step straight past it.
+    /// The loop terminates because the flag is set first, so only calls already in flight can add anything.
+    /// A sender added after the very last emptiness check would still be missed; that residual case is left
+    /// to the container disposing the <see cref="ServiceBusClient"/>, which closes everything it created.
+    /// </remarks>
+    /// <returns>A task that completes when every sender has been closed.</returns>
+    public async ValueTask DisposeAsync()
+    {
+        _disposed = true;
+
+        while (!_senders.IsEmpty)
+        {
+            foreach (var topic in _senders.Keys)
+            {
+                if (_senders.TryRemove(topic, out var sender))
+                    await sender.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusMessageFormat.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusMessageFormat.cs
@@ -1,0 +1,25 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+/// <summary>
+/// The Service Bus message members Trellis assigns meaning to, so a producer and a consumer written
+/// against this package agree on the wire format without re-deriving it from the code.
+/// </summary>
+/// <remarks>
+/// Everything here maps onto a <i>standard</i> Service Bus member rather than a custom application
+/// property wherever one exists. `MessageId` and `Subject` are indexed by the broker and surfaced in the
+/// portal, Service Bus Explorer, and subscription filters, so a message stays diagnosable and routable by
+/// tools that know nothing about Trellis.
+/// </remarks>
+public static class ServiceBusMessageFormat
+{
+    /// <summary>
+    /// The application property carrying <see cref="Trellis.Mediator.IntegrationEnvelope.MessageSource"/> —
+    /// the producing service or bounded context. Optional; observability only.
+    /// </summary>
+    public const string MessageSourceProperty = "trellis-message-source";
+
+    /// <summary>
+    /// The content type stamped on every message body, which is UTF-8 JSON.
+    /// </summary>
+    public const string JsonContentType = "application/json";
+}

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusMessageFormatter.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusMessageFormatter.cs
@@ -1,0 +1,93 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Trellis.Mediator;
+
+/// <summary>
+/// Translates between Trellis's publish/consume contracts and Service Bus messages. Kept separate from the
+/// publisher and the processor so the wire format can be asserted without a broker.
+/// </summary>
+internal static class ServiceBusMessageFormatter
+{
+    /// <summary>
+    /// Builds the Service Bus message for an outbound integration event.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ServiceBusMessage.MessageId"/> is the outbox row id, carried verbatim. This is the single
+    /// most important line in the package: relay delivery is at-least-once, so the same row can reach the
+    /// broker more than once, and the consumer's <c>(ConsumerId, MessageId)</c> inbox dedup only collapses
+    /// those copies if they all carry the same id. Generating one here — which is what the SDK does if the
+    /// member is left unset — would make every redelivery look like a new message.
+    /// </remarks>
+    public static ServiceBusMessage ToServiceBusMessage(
+        OutboundIntegrationMessage message,
+        string wireName,
+        string? messageSource,
+        JsonSerializerOptions jsonOptions)
+    {
+        var body = JsonSerializer.SerializeToUtf8Bytes(message.Event, message.Event.GetType(), jsonOptions);
+
+        var serviceBusMessage = new ServiceBusMessage(body)
+        {
+            MessageId = message.MessageId.ToString(),
+            Subject = wireName,
+            ContentType = ServiceBusMessageFormat.JsonContentType,
+        };
+
+        if (!string.IsNullOrWhiteSpace(messageSource))
+            serviceBusMessage.ApplicationProperties[ServiceBusMessageFormat.MessageSourceProperty] = messageSource;
+
+        return serviceBusMessage;
+    }
+
+    /// <summary>
+    /// Rebuilds the inbox envelope from a received message, or explains why the message is undeliverable.
+    /// </summary>
+    /// <remarks>
+    /// Every failure here is a property of the message itself, not of this consumer's state, so retrying the
+    /// same bytes can never succeed. The caller dead-letters rather than abandons.
+    /// </remarks>
+    public static Result<IntegrationEnvelope> ToEnvelope(
+        ServiceBusReceivedMessage message,
+        IntegrationEventNameMap nameMap,
+        JsonSerializerOptions jsonOptions)
+    {
+        if (!Guid.TryParse(message.MessageId, out var messageId) || messageId == Guid.Empty)
+            return Result.Fail<IntegrationEnvelope>(ServiceBusConsumerErrors.UnusableMessageId(message.MessageId));
+
+        if (string.IsNullOrWhiteSpace(message.Subject))
+            return Result.Fail<IntegrationEnvelope>(ServiceBusConsumerErrors.MissingSubject);
+
+        var eventType = nameMap.TypeFor(message.Subject);
+        if (!eventType.HasValue)
+            return Result.Fail<IntegrationEnvelope>(ServiceBusConsumerErrors.UnknownContract(message.Subject));
+
+        IIntegrationEvent? integrationEvent;
+        try
+        {
+            integrationEvent = JsonSerializer.Deserialize(message.Body.ToMemory().Span, eventType.Value, jsonOptions)
+                as IIntegrationEvent;
+        }
+        catch (JsonException ex)
+        {
+            return Result.Fail<IntegrationEnvelope>(ServiceBusConsumerErrors.MalformedBody(message.Subject, ex.Message));
+        }
+        catch (NotSupportedException ex)
+        {
+            // The contract itself cannot be materialized — an abstract or interface-typed member, or a shape
+            // with no converter. Every future delivery of these bytes fails identically, so this belongs with
+            // the dead-letter failures rather than escaping as a fault the consumer would retry.
+            return Result.Fail<IntegrationEnvelope>(ServiceBusConsumerErrors.MalformedBody(message.Subject, ex.Message));
+        }
+
+        if (integrationEvent is null)
+            return Result.Fail<IntegrationEnvelope>(ServiceBusConsumerErrors.MalformedBody(message.Subject, "the body deserialized to null"));
+
+        var source = message.ApplicationProperties.TryGetValue(ServiceBusMessageFormat.MessageSourceProperty, out var raw)
+            ? raw as string
+            : null;
+
+        return Result.Ok(new IntegrationEnvelope(messageId, integrationEvent) { MessageSource = source });
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/src/ServiceBusTransportLog.cs
+++ b/Trellis.Messaging.AzureServiceBus/src/ServiceBusTransportLog.cs
@@ -1,0 +1,54 @@
+﻿namespace Trellis.Messaging.AzureServiceBus;
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Trellis.Mediator;
+
+/// <summary>High-performance log delegates for the Service Bus transport (satisfies CA1848).</summary>
+internal static class ServiceBusTransportLog
+{
+    private static readonly Action<ILogger, string, Guid, string, Exception?> s_published =
+        LoggerMessage.Define<string, Guid, string>(
+            LogLevel.Debug,
+            new EventId(1, "ServiceBus.Published"),
+            "Published integration event {WireName} (message {MessageId}) to Service Bus topic {Topic}.");
+
+    private static readonly Action<ILogger, string, string, Exception?> s_consuming =
+        LoggerMessage.Define<string, string>(
+            LogLevel.Information,
+            new EventId(2, "ServiceBus.Consuming"),
+            "Consuming integration events from Service Bus subscription {Subscription} on topic {Topic}.");
+
+    private static readonly Action<ILogger, string?, string, string?, Exception?> s_deadLettered =
+        LoggerMessage.Define<string?, string, string?>(
+            LogLevel.Warning,
+            new EventId(3, "ServiceBus.DeadLettered"),
+            "Dead-lettering Service Bus message {ServiceBusMessageId}: {Reason} — {Detail}");
+
+    private static readonly Action<ILogger, Guid, string?, InboxDispatchOutcome, Exception?> s_settled =
+        LoggerMessage.Define<Guid, string?, InboxDispatchOutcome>(
+            LogLevel.Debug,
+            new EventId(4, "ServiceBus.Settled"),
+            "Message {MessageId} ({WireName}) completed as {Outcome}.");
+
+    private static readonly Action<ILogger, string, ServiceBusErrorSource, Exception?> s_processingError =
+        LoggerMessage.Define<string, ServiceBusErrorSource>(
+            LogLevel.Error,
+            new EventId(5, "ServiceBus.ProcessingError"),
+            "Service Bus processing error on {EntityPath} during {ErrorSource}.");
+
+    public static void Published(ILogger logger, string wireName, Guid messageId, string topic) =>
+        s_published(logger, wireName, messageId, topic, null);
+
+    public static void Consuming(ILogger logger, string subscription, string topic) =>
+        s_consuming(logger, subscription, topic, null);
+
+    public static void DeadLettered(ILogger logger, string? serviceBusMessageId, string reason, string? detail) =>
+        s_deadLettered(logger, serviceBusMessageId, reason, detail, null);
+
+    public static void Settled(ILogger logger, Guid messageId, string? wireName, InboxDispatchOutcome outcome) =>
+        s_settled(logger, messageId, wireName, outcome, null);
+
+    public static void ProcessingError(ILogger logger, string entityPath, ServiceBusErrorSource errorSource, Exception exception) =>
+        s_processingError(logger, entityPath, errorSource, exception);
+}

--- a/Trellis.Messaging.AzureServiceBus/src/Trellis.Messaging.AzureServiceBus.csproj
+++ b/Trellis.Messaging.AzureServiceBus/src/Trellis.Messaging.AzureServiceBus.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
+    <Description>Azure Service Bus transport for Trellis — the wire between the transactional outbox and the deduplicating inbox. Publishes integration events with the outbox row id as the Service Bus MessageId so redeliveries stay idempotent end to end, and consumes them back into the inbox dispatcher.</Description>
+    <PackageTags>trellis;azure-service-bus;messaging;integration-events;outbox;inbox;idempotency;ddd;reliability</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TrellisApiRefName>messaging-azureservicebus</TrellisApiRefName>
+    <!-- Azure.Messaging.ServiceBus is not annotated for trimming, and the wire-name map resolves
+         types by reflection; opts out of AOT/trim like the EF Core siblings. -->
+    <IsAotCompatible>false</IsAotCompatible>
+    <IsTrimmable>false</IsTrimmable>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />
+    <ProjectReference Include="..\..\Trellis.Mediator\src\Trellis.Mediator.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Trellis.Messaging.AzureServiceBus.Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+  </ItemGroup>
+</Project>

--- a/Trellis.Messaging.AzureServiceBus/tests/AzureServiceBusRegistrationTests.cs
+++ b/Trellis.Messaging.AzureServiceBus/tests/AzureServiceBusRegistrationTests.cs
@@ -1,0 +1,223 @@
+﻿namespace Trellis.Messaging.AzureServiceBus.Tests;
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Trellis.Mediator;
+
+public class AzureServiceBusRegistrationTests
+{
+    private static readonly IntegrationEventNameMap Map = new(
+    [
+        new KeyValuePair<string, Type>(OrderPlaced.WireName, typeof(OrderPlaced)),
+    ]);
+
+    [Fact]
+    public void AddPublisher_ReplacesAnyExistingPublisherRatherThanAddingToIt()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IIntegrationEventPublisher, NoOpPublisher>();
+
+        services.AddAzureServiceBusIntegrationEventPublisher(Map);
+
+        services.Where(d => d.ServiceType == typeof(IIntegrationEventPublisher)).Should().ContainSingle();
+        Resolve<IIntegrationEventPublisher>(services).Should().BeOfType<ServiceBusIntegrationEventPublisher>();
+    }
+
+    [Fact]
+    public void AddPublisher_IsOrderIndependentWithRespectToAnExistingPublisher()
+    {
+        var services = new ServiceCollection();
+        services.AddAzureServiceBusIntegrationEventPublisher(Map);
+        services.AddSingleton<IIntegrationEventPublisher, NoOpPublisher>();
+        services.AddAzureServiceBusIntegrationEventPublisher(Map);
+
+        services.Where(d => d.ServiceType == typeof(IIntegrationEventPublisher)).Should().ContainSingle();
+        Resolve<IIntegrationEventPublisher>(services).Should().BeOfType<ServiceBusIntegrationEventPublisher>();
+    }
+
+    [Fact]
+    public void AddConsumer_RegistersTheHostedService()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureServiceBusIntegrationEventConsumer(
+            Map, o => o.Subscribe(OrderPlaced.WireName, "billing"));
+
+        WithInfrastructure(services).BuildServiceProvider().GetServices<IHostedService>()
+            .Should().ContainSingle(s => s is ServiceBusInboxConsumer);
+    }
+
+    [Fact]
+    public void AddConsumer_CalledTwice_RunsOneConsumerCarryingBothCallersSubscriptions()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureServiceBusIntegrationEventConsumer(Map, static o => o.Subscribe("topic-a", "s"));
+        services.AddAzureServiceBusIntegrationEventConsumer(Map, static o => o.Subscribe("topic-b", "s"));
+
+        var provider = WithInfrastructure(services).BuildServiceProvider();
+
+        // Two hosted services would each open a receiver on every configured subscription, doubling delivery.
+        provider.GetServices<IHostedService>().Should().ContainSingle(s => s is ServiceBusInboxConsumer);
+        provider.GetRequiredService<IOptions<AzureServiceBusConsumerOptions>>().Value.Subscriptions
+            .Select(s => s.TopicName).Should().BeEquivalentTo(["topic-a", "topic-b"]);
+    }
+
+    [Fact]
+    public void AddConsumer_WithoutSubscriptions_ThrowsAtRegistration()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddAzureServiceBusIntegrationEventConsumer(Map, static _ => { });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*no subscriptions*");
+    }
+
+    [Fact]
+    public void AddConsumer_WithDuplicateSubscription_ThrowsAtRegistration()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddAzureServiceBusIntegrationEventConsumer(
+            Map, static o => o.Subscribe("t", "s").Subscribe("t", "s"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*more than once*");
+    }
+
+    [Fact]
+    public void AddConsumer_WithZeroConcurrency_ThrowsAtRegistration()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddAzureServiceBusIntegrationEventConsumer(
+            Map, static o => o.Subscribe("t", "s").MaxConcurrentCalls = 0);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*MaxConcurrentCalls*");
+    }
+
+    [Fact]
+    public void AddConsumer_WithNegativePrefetch_ThrowsAtRegistration()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddAzureServiceBusIntegrationEventConsumer(
+            Map, static o => o.Subscribe("t", "s").PrefetchCount = -1);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*PrefetchCount*");
+    }
+
+    [Fact]
+    public void Subscription_WithBlankNames_Throws()
+    {
+        var blankTopic = () => new ServiceBusSubscription(" ", "s");
+        var blankSubscription = () => new ServiceBusSubscription("t", " ");
+
+        blankTopic.Should().Throw<ArgumentException>();
+        blankSubscription.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Publisher_WithAnUnmappedEventType_ThrowsRatherThanPublishingAnUnidentifiableMessage()
+    {
+        var publisher = new ServiceBusIntegrationEventPublisher(
+            new ServiceBusClient("Endpoint=sb://localhost;SharedAccessKeyName=k;SharedAccessKey=v;UseDevelopmentEmulator=true;"),
+            IntegrationEventNameMap.Empty,
+            Microsoft.Extensions.Options.Options.Create(new AzureServiceBusPublisherOptions()),
+            NullLogger<ServiceBusIntegrationEventPublisher>.Instance);
+
+        var act = async () => await publisher.PublishAsync(
+            new OutboundIntegrationMessage(Guid.CreateVersion7(), new OrderPlaced("ORD-1", DateTimeOffset.UnixEpoch)),
+            CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*IntegrationEventName*");
+    }
+
+    private sealed class NoOpPublisher : IIntegrationEventPublisher
+    {
+        public ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken) =>
+            ValueTask.CompletedTask;
+    }
+
+    private const string OfflineConnectionString =
+        "Endpoint=sb://localhost;SharedAccessKeyName=k;SharedAccessKey=v;UseDevelopmentEmulator=true;";
+
+    private static IServiceCollection WithInfrastructure(IServiceCollection services)
+    {
+        services.AddSingleton(new ServiceBusClient(OfflineConnectionString));
+        services.AddLogging();
+        return services;
+    }
+
+    private static T Resolve<T>(IServiceCollection services)
+        where T : notnull =>
+        WithInfrastructure(services).BuildServiceProvider().GetRequiredService<T>();
+
+    private sealed class TopicResolverReached : Exception
+    {
+        public TopicResolverReached() { }
+
+        public TopicResolverReached(string message) : base(message) { }
+
+        public TopicResolverReached(string message, Exception innerException) : base(message, innerException) { }
+    }
+
+    [Fact]
+    public async Task AddPublisher_UsesTheMapItWasGiven_EvenWhenAConsumerRegisteredADifferentOneFirst()
+    {
+        var services = new ServiceCollection();
+
+        // A consumer that models no contracts at all, registered first.
+        services.AddAzureServiceBusIntegrationEventConsumer(
+            IntegrationEventNameMap.Empty, static o => o.Subscribe("t", "s"));
+
+        // The publisher knows OrderPlaced. Sharing one map through the container would let the
+        // consumer's empty map win and make this publisher reject an event it can name.
+        services.AddAzureServiceBusIntegrationEventPublisher(
+            Map, static o => o.TopicNameResolver = _ => throw new TopicResolverReached());
+
+        var publisher = Resolve<IIntegrationEventPublisher>(services);
+
+        var act = async () => await publisher.PublishAsync(
+            new OutboundIntegrationMessage(Guid.CreateVersion7(), new OrderPlaced("ORD-1", DateTimeOffset.UnixEpoch)),
+            TestContext.Current.CancellationToken);
+
+        // Reaching the topic resolver proves the wire name resolved against the publisher's own map.
+        await act.Should().ThrowAsync<TopicResolverReached>();
+    }
+
+    [Fact]
+    public void Registration_DoesNotPublishTheNameMapAsASharedService()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureServiceBusIntegrationEventPublisher(Map);
+        services.AddAzureServiceBusIntegrationEventConsumer(
+            IntegrationEventNameMap.Empty, static o => o.Subscribe("t", "s"));
+
+        // Each component owns the map it was registered with. A shared registration would make the
+        // first caller win and silently discard the second caller's argument.
+        services.Should().NotContain(d => d.ServiceType == typeof(IntegrationEventNameMap));
+    }
+
+    [Fact]
+    public async Task Publisher_AfterDisposal_RefusesToPublishRatherThanCachingASenderNobodyWillClose()
+    {
+        var publisher = new ServiceBusIntegrationEventPublisher(
+            new ServiceBusClient(OfflineConnectionString),
+            Map,
+            Microsoft.Extensions.Options.Options.Create(new AzureServiceBusPublisherOptions()),
+            NullLogger<ServiceBusIntegrationEventPublisher>.Instance);
+
+        await publisher.DisposeAsync();
+
+        var act = async () => await publisher.PublishAsync(
+            new OutboundIntegrationMessage(Guid.CreateVersion7(), new OrderPlaced("ORD-1", DateTimeOffset.UnixEpoch)),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ObjectDisposedException>();
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/tests/AzureServiceBusRegistrationTests.cs
+++ b/Trellis.Messaging.AzureServiceBus/tests/AzureServiceBusRegistrationTests.cs
@@ -136,6 +136,70 @@ public class AzureServiceBusRegistrationTests
             .WithMessage("*IntegrationEventName*");
     }
 
+    [Fact]
+    public void AddConsumer_CalledTwiceWithTheSameSubscription_ThrowsRatherThanRunningTwoCompetingProcessors()
+    {
+        var services = new ServiceCollection();
+        services.AddAzureServiceBusIntegrationEventConsumer(Map, static o => o.Subscribe("topic-a", "s"));
+
+        // Each call validates its own configuration and passes; only the accumulated instance is wrong.
+        var act = () => services.AddAzureServiceBusIntegrationEventConsumer(
+            Map, static o => o.Subscribe("topic-a", "s"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*more than once*");
+    }
+
+    [Fact]
+    public void PublisherOptions_RejectNullRatherThanFailingWithANullReferenceOnTheFirstPublish()
+    {
+        var options = new AzureServiceBusPublisherOptions();
+
+        var nullResolver = () => options.TopicNameResolver = null!;
+        var nullJson = () => options.JsonSerializerOptions = null!;
+
+        nullResolver.Should().Throw<ArgumentNullException>();
+        nullJson.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ConsumerOptions_RejectNullJsonSerializerOptions()
+    {
+        var options = new AzureServiceBusConsumerOptions();
+
+        var act = () => options.JsonSerializerOptions = null!;
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void PublisherOptions_DefaultToTopicPerContract()
+    {
+        var options = new AzureServiceBusPublisherOptions();
+
+        // The documented default layout: each contract owns a topic named after its wire name.
+        options.TopicNameResolver(OrderPlaced.WireName).Should().Be(OrderPlaced.WireName);
+        options.MessageSource.Should().BeNull();
+    }
+
+    [Fact]
+    public void Consumer_RejectsDuplicateSubscriptionsReachingItByAnyRoute()
+    {
+        // Subscriptions is a mutable list, so Subscribe's guard is not the only way in. The consumer
+        // validates what it was actually handed, because it is the thing that starts a processor per entry.
+        var options = new AzureServiceBusConsumerOptions();
+        options.Subscriptions.Add(new ServiceBusSubscription("orders", "billing"));
+        options.Subscriptions.Add(new ServiceBusSubscription("orders", "billing"));
+
+        var act = () => new ServiceBusInboxConsumer(
+            new ServiceBusClient(OfflineConnectionString),
+            new ServiceCollection().BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            Map,
+            Microsoft.Extensions.Options.Options.Create(options),
+            NullLogger<ServiceBusInboxConsumer>.Instance);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*more than once*");
+    }
+
     private sealed class NoOpPublisher : IIntegrationEventPublisher
     {
         public ValueTask PublishAsync(OutboundIntegrationMessage message, CancellationToken cancellationToken) =>

--- a/Trellis.Messaging.AzureServiceBus/tests/InboxMessageHandlerTests.cs
+++ b/Trellis.Messaging.AzureServiceBus/tests/InboxMessageHandlerTests.cs
@@ -1,0 +1,199 @@
+﻿namespace Trellis.Messaging.AzureServiceBus.Tests;
+
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Trellis.Mediator;
+
+/// <summary>
+/// Pins the settlement rules — the consumer's most consequential logic — without a broker, so a build server
+/// with no Docker still enforces them.
+/// </summary>
+public class InboxMessageHandlerTests
+{
+    private static readonly IntegrationEventNameMap Map = new(
+    [
+        new KeyValuePair<string, Type>(OrderPlaced.WireName, typeof(OrderPlaced)),
+    ]);
+
+    [Fact]
+    public async Task Processed_CompletesTheMessage()
+    {
+        var (settler, dispatcher) = await HandleAsync(ValidMessage(), InboxDispatchOutcome.Processed);
+
+        settler.Completed.Should().BeTrue();
+        settler.DeadLetterReason.Should().BeNull();
+        dispatcher.Dispatched.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SkippedDuplicate_CompletesTheMessageRatherThanAbandoningItIntoAnEndlessRedeliveryLoop()
+    {
+        var (settler, _) = await HandleAsync(ValidMessage(), InboxDispatchOutcome.SkippedDuplicate);
+
+        // Abandoning would redeliver forever: every attempt reaches the same "already processed" conclusion.
+        settler.Completed.Should().BeTrue();
+        settler.DeadLetterReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task HandlerFailure_PropagatesAndLeavesTheMessageUnsettled()
+    {
+        var settler = new RecordingSettler();
+        var handler = HandlerFor(new ThrowingDispatcher());
+
+        var act = async () => await handler.HandleAsync(
+            ValidMessage(), settler, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+
+        // Unsettled is the point: the SDK abandons it and the broker redelivers, because the dispatcher
+        // rolled back and nothing was applied.
+        settler.Completed.Should().BeFalse();
+        settler.DeadLetterReason.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null, OrderPlaced.WireName, ServiceBusConsumerErrors.UnusableMessageIdCode)]
+    [InlineData("not-a-guid", OrderPlaced.WireName, ServiceBusConsumerErrors.UnusableMessageIdCode)]
+    [InlineData(null, null, ServiceBusConsumerErrors.UnusableMessageIdCode)]
+    public async Task UnusableMessage_DeadLettersWithTheReasonCode(string? messageId, string? subject, string expected)
+    {
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"),
+            messageId: messageId,
+            subject: subject);
+
+        var (settler, dispatcher) = await HandleAsync(message, InboxDispatchOutcome.Processed);
+
+        settler.DeadLetterReason.Should().Be(expected);
+        settler.Completed.Should().BeFalse();
+        dispatcher.Dispatched.Should().BeEmpty("an unreadable message must never reach a handler");
+    }
+
+    [Fact]
+    public async Task MissingSubject_DeadLetters()
+    {
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"),
+            messageId: Guid.CreateVersion7().ToString(),
+            subject: null);
+
+        var (settler, _) = await HandleAsync(message, InboxDispatchOutcome.Processed);
+
+        settler.DeadLetterReason.Should().Be(ServiceBusConsumerErrors.MissingSubjectCode);
+    }
+
+    [Fact]
+    public async Task UnknownContract_DeadLetters()
+    {
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"),
+            messageId: Guid.CreateVersion7().ToString(),
+            subject: "orders.never-heard-of-it.v1");
+
+        var (settler, _) = await HandleAsync(message, InboxDispatchOutcome.Processed);
+
+        settler.DeadLetterReason.Should().Be(ServiceBusConsumerErrors.UnknownContractCode);
+    }
+
+    [Fact]
+    public async Task MalformedBody_DeadLetters()
+    {
+        var message = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{ not json"),
+            messageId: Guid.CreateVersion7().ToString(),
+            subject: OrderPlaced.WireName);
+
+        var (settler, _) = await HandleAsync(message, InboxDispatchOutcome.Processed);
+
+        settler.DeadLetterReason.Should().Be(ServiceBusConsumerErrors.MalformedBodyCode);
+        settler.DeadLetterDescription.Should().NotBeNullOrWhiteSpace("the dead-letter must carry the diagnosis");
+    }
+
+    [Fact]
+    public async Task TheEnvelopeHandedToTheInboxCarriesTheServiceBusMessageId()
+    {
+        var messageId = Guid.CreateVersion7();
+        var message = ValidMessage(messageId);
+
+        var (_, dispatcher) = await HandleAsync(message, InboxDispatchOutcome.Processed);
+
+        // This is the whole point of the transport: the id the producer staged is the id the inbox dedups on.
+        dispatcher.Dispatched.Should().ContainSingle().Which.MessageId.Should().Be(messageId);
+    }
+
+    private static async Task<(RecordingSettler Settler, RecordingDispatcher Dispatcher)> HandleAsync(
+        ServiceBusReceivedMessage message,
+        InboxDispatchOutcome outcome)
+    {
+        var settler = new RecordingSettler();
+        var dispatcher = new RecordingDispatcher(outcome);
+
+        await HandlerFor(dispatcher).HandleAsync(message, settler, TestContext.Current.CancellationToken);
+
+        return (settler, dispatcher);
+    }
+
+    private static InboxMessageHandler HandlerFor(IInboxDispatcher dispatcher)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(dispatcher);
+
+        return new InboxMessageHandler(
+            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            Map,
+            JsonSerializerOptions.Web,
+            NullLogger.Instance);
+    }
+
+    private static ServiceBusReceivedMessage ValidMessage(Guid? messageId = null) =>
+        ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("""{"orderNumber":"ORD-1","occurredAt":"1970-01-01T00:00:00+00:00"}"""),
+            messageId: (messageId ?? Guid.CreateVersion7()).ToString(),
+            subject: OrderPlaced.WireName);
+
+    private sealed class RecordingSettler : IMessageSettler
+    {
+        public bool Completed { get; private set; }
+
+        public string? DeadLetterReason { get; private set; }
+
+        public string? DeadLetterDescription { get; private set; }
+
+        public Task CompleteAsync(CancellationToken cancellationToken)
+        {
+            Completed = true;
+            return Task.CompletedTask;
+        }
+
+        public Task DeadLetterAsync(string reason, string? description, CancellationToken cancellationToken)
+        {
+            DeadLetterReason = reason;
+            DeadLetterDescription = description;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingDispatcher(InboxDispatchOutcome outcome) : IInboxDispatcher
+    {
+        public List<IntegrationEnvelope> Dispatched { get; } = [];
+
+        public Task<InboxDispatchOutcome> DispatchAsync(
+            IntegrationEnvelope envelope,
+            CancellationToken cancellationToken)
+        {
+            Dispatched.Add(envelope);
+            return Task.FromResult(outcome);
+        }
+    }
+
+    private sealed class ThrowingDispatcher : IInboxDispatcher
+    {
+        public Task<InboxDispatchOutcome> DispatchAsync(
+            IntegrationEnvelope envelope,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("handler blew up");
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/tests/ServiceBusEmulator.cs
+++ b/Trellis.Messaging.AzureServiceBus/tests/ServiceBusEmulator.cs
@@ -1,0 +1,59 @@
+﻿namespace Trellis.Messaging.AzureServiceBus.Tests;
+
+using System.Net.Sockets;
+using Azure.Messaging.ServiceBus;
+
+/// <summary>
+/// Resolves the Service Bus client the transport integration tests run against, once per test process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The emulator is not present on every machine or CI agent, so probing is a first-class outcome rather
+/// than a failure: <see cref="TryGetClientAsync"/> returns <c>null</c> when nothing is listening and the
+/// tests skip visibly. The suite either runs against a real broker or is seen not to run — it never passes
+/// against a substitute.
+/// </para>
+/// <para>
+/// Entities are declared in <c>emulator/Config.json</c> and cannot be created at runtime, so
+/// <see cref="Topic"/> and the subscription names below must match that file.
+/// </para>
+/// </remarks>
+internal static class ServiceBusEmulator
+{
+    /// <summary>
+    /// The well-known emulator connection string. Published by Microsoft and identical on every
+    /// installation, so this is a fixed test constant rather than a secret.
+    /// </summary>
+    private const string ConnectionString =
+        "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+    private const string Host = "localhost";
+    private const int AmqpPort = 5672;
+
+    /// <summary>The topic declared in <c>emulator/Config.json</c>, named after the event's wire name.</summary>
+    public const string Topic = OrderPlaced.WireName;
+
+    private static readonly Lazy<Task<ServiceBusClient?>> Client = new(ProbeAsync);
+
+    /// <summary>Returns a shared client, or <c>null</c> when no emulator is reachable.</summary>
+    public static Task<ServiceBusClient?> TryGetClientAsync() => Client.Value;
+
+    private static async Task<ServiceBusClient?> ProbeAsync()
+    {
+        using var probe = new TcpClient();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await probe.ConnectAsync(Host, AmqpPort, timeout.Token);
+        }
+        catch (Exception ex) when (ex is SocketException or OperationCanceledException)
+        {
+            // Narrow by design: these are the shapes "no emulator here" takes. Anything else is a real
+            // defect and must surface rather than silently skipping the whole suite.
+            return null;
+        }
+
+        return new ServiceBusClient(ConnectionString);
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/tests/ServiceBusMessageFormatterTests.cs
+++ b/Trellis.Messaging.AzureServiceBus/tests/ServiceBusMessageFormatterTests.cs
@@ -1,0 +1,198 @@
+﻿namespace Trellis.Messaging.AzureServiceBus.Tests;
+
+using System.Text;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using Trellis.Mediator;
+
+public class ServiceBusMessageFormatterTests
+{
+    private static readonly IntegrationEventNameMap Map = new(
+    [
+        new KeyValuePair<string, Type>(OrderPlaced.WireName, typeof(OrderPlaced)),
+    ]);
+
+    private static readonly JsonSerializerOptions Json = JsonSerializerOptions.Web;
+
+    [Fact]
+    public void ToServiceBusMessage_CarriesTheOutboxIdAsTheServiceBusMessageId()
+    {
+        var outboxId = Guid.CreateVersion7();
+        var message = new OutboundIntegrationMessage(outboxId, SampleEvent());
+
+        var sent = ServiceBusMessageFormatter.ToServiceBusMessage(message, OrderPlaced.WireName, messageSource: null, Json);
+
+        sent.MessageId.Should().Be(outboxId.ToString());
+    }
+
+    [Fact]
+    public void ToServiceBusMessage_PutsTheWireNameOnTheSubject()
+    {
+        var message = new OutboundIntegrationMessage(Guid.CreateVersion7(), SampleEvent());
+
+        var sent = ServiceBusMessageFormatter.ToServiceBusMessage(message, OrderPlaced.WireName, messageSource: null, Json);
+
+        sent.Subject.Should().Be(OrderPlaced.WireName);
+        sent.ContentType.Should().Be(ServiceBusMessageFormat.JsonContentType);
+    }
+
+    [Fact]
+    public void ToServiceBusMessage_OmitsTheSourcePropertyWhenNoSourceIsConfigured()
+    {
+        var message = new OutboundIntegrationMessage(Guid.CreateVersion7(), SampleEvent());
+
+        var sent = ServiceBusMessageFormatter.ToServiceBusMessage(message, OrderPlaced.WireName, messageSource: "  ", Json);
+
+        sent.ApplicationProperties.Should().NotContainKey(ServiceBusMessageFormat.MessageSourceProperty);
+    }
+
+    [Fact]
+    public void ToServiceBusMessage_SerializesTheRuntimeTypeNotTheStaticInterface()
+    {
+        var message = new OutboundIntegrationMessage(Guid.CreateVersion7(), SampleEvent());
+
+        var sent = ServiceBusMessageFormatter.ToServiceBusMessage(message, OrderPlaced.WireName, messageSource: null, Json);
+
+        Encoding.UTF8.GetString(sent.Body.ToArray()).Should().Contain("orderNumber");
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesTheMessageIdEventAndSource()
+    {
+        var outboxId = Guid.CreateVersion7();
+        var original = SampleEvent();
+        var sent = ServiceBusMessageFormatter.ToServiceBusMessage(
+            new OutboundIntegrationMessage(outboxId, original), OrderPlaced.WireName, "orders-service", Json);
+
+        var received = Receive(sent);
+
+        received.TryGetValue(out var envelope, out _).Should().BeTrue();
+        envelope!.MessageId.Should().Be(outboxId);
+        envelope.MessageSource.Should().Be("orders-service");
+        envelope.Event.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void ToEnvelope_NonGuidMessageId_Fails()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"), messageId: "not-a-guid", subject: OrderPlaced.WireName);
+
+        AssertFailsWith(received, ServiceBusConsumerErrors.UnusableMessageIdCode);
+    }
+
+    [Fact]
+    public void ToEnvelope_EmptyGuidMessageId_Fails()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"), messageId: Guid.Empty.ToString(), subject: OrderPlaced.WireName);
+
+        AssertFailsWith(received, ServiceBusConsumerErrors.UnusableMessageIdCode);
+    }
+
+    [Fact]
+    public void ToEnvelope_MissingSubject_Fails()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"), messageId: Guid.CreateVersion7().ToString(), subject: null);
+
+        AssertFailsWith(received, ServiceBusConsumerErrors.MissingSubjectCode);
+    }
+
+    [Fact]
+    public void ToEnvelope_UnknownContract_Fails()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{}"), messageId: Guid.CreateVersion7().ToString(), subject: "orders.unheard-of.v1");
+
+        AssertFailsWith(received, ServiceBusConsumerErrors.UnknownContractCode);
+    }
+
+    [Fact]
+    public void ToEnvelope_MalformedBody_Fails()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("{ this is not json"),
+            messageId: Guid.CreateVersion7().ToString(),
+            subject: OrderPlaced.WireName);
+
+        AssertFailsWith(received, ServiceBusConsumerErrors.MalformedBodyCode);
+    }
+
+    [Fact]
+    public void ToEnvelope_NullBody_Fails()
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("null"),
+            messageId: Guid.CreateVersion7().ToString(),
+            subject: OrderPlaced.WireName);
+
+        AssertFailsWith(received, ServiceBusConsumerErrors.MalformedBodyCode);
+    }
+
+    [Fact]
+    public void ToEnvelope_ContractTheSerializerCannotConstruct_FailsRatherThanThrowing()
+    {
+        // A contract whose member the serializer has no way to materialize throws NotSupportedException
+        // rather than JsonException. It is still a message that can never be read, so it must come back as
+        // a failed result and be dead-lettered — not escape as an exception the consumer treats as a
+        // transient handler fault and retries until the delivery count is exhausted.
+        var map = new IntegrationEventNameMap(
+        [
+            new KeyValuePair<string, Type>(UnreadableContract.WireName, typeof(UnreadableContract)),
+        ]);
+
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: BinaryData.FromString("""{"value":{"amount":1}}"""),
+            messageId: Guid.CreateVersion7().ToString(),
+            subject: UnreadableContract.WireName);
+
+        var result = ServiceBusMessageFormatter.ToEnvelope(received, map, Json);
+
+        result.TryGetError(out var error).Should().BeTrue();
+        error!.Code.Should().Be(ServiceBusConsumerErrors.MalformedBodyCode);
+    }
+
+    private static void AssertFailsWith(ServiceBusReceivedMessage received, string reasonCode)
+    {
+        var result = ServiceBusMessageFormatter.ToEnvelope(received, Map, Json);
+
+        result.TryGetError(out var error).Should().BeTrue();
+        error!.Code.Should().Be(reasonCode);
+        error.Detail.Should().NotBeNullOrWhiteSpace();
+    }
+
+    private static Result<IntegrationEnvelope> Receive(ServiceBusMessage sent)
+    {
+        var received = ServiceBusModelFactory.ServiceBusReceivedMessage(
+            body: sent.Body,
+            messageId: sent.MessageId,
+            subject: sent.Subject,
+            contentType: sent.ContentType,
+            properties: sent.ApplicationProperties);
+
+        return ServiceBusMessageFormatter.ToEnvelope(received, Map, Json);
+    }
+
+    private static OrderPlaced SampleEvent() => new("ORD-1", DateTimeOffset.UnixEpoch);
+}
+
+[IntegrationEventName(OrderPlaced.WireName)]
+public sealed record OrderPlaced(string OrderNumber, DateTimeOffset OccurredAt) : IIntegrationEvent
+{
+    public const string WireName = "orders.order-placed.v1";
+}
+
+/// <summary>
+/// A contract the serializer cannot deserialize into: <see cref="UnreadableValue"/> is abstract, so
+/// <c>JsonSerializer</c> has no concrete type to construct and reports it as <see cref="NotSupportedException"/>
+/// rather than as a malformed document.
+/// </summary>
+[IntegrationEventName(UnreadableContract.WireName)]
+public sealed record UnreadableContract(UnreadableValue Value, DateTimeOffset OccurredAt) : IIntegrationEvent
+{
+    public const string WireName = "orders.unreadable.v1";
+}
+
+/// <summary>An abstract member type, which the serializer cannot materialize.</summary>
+public abstract record UnreadableValue(int Amount);

--- a/Trellis.Messaging.AzureServiceBus/tests/ServiceBusTransportIntegrationTests.cs
+++ b/Trellis.Messaging.AzureServiceBus/tests/ServiceBusTransportIntegrationTests.cs
@@ -1,0 +1,280 @@
+﻿namespace Trellis.Messaging.AzureServiceBus.Tests;
+
+using System.Collections.Concurrent;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Trellis.Mediator;
+
+/// <summary>
+/// End-to-end tests over a real Azure Service Bus emulator: publish through the outbox's publish seam and
+/// consume back into the inbox dispatch seam.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These exist because the property that matters cannot be observed in a unit test. The transport's job is
+/// to carry the producer's outbox message id verbatim so that a redelivered outbox row still deduplicates at
+/// the consumer, and only a real broker round trip proves the id survives serialization, AMQP, and the
+/// receive path.
+/// </para>
+/// <para>
+/// Duplicate detection is deliberately <b>off</b> on the emulator topic. If the broker collapsed duplicate
+/// message ids for us, these tests would pass even if the transport minted a fresh id per publish — the
+/// assertion is that Trellis carries the id, not that Service Bus can be configured to hide the problem.
+/// </para>
+/// <para>
+/// Start the broker with
+/// <c>docker compose -f Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml up -d</c>.
+/// Without it the tests skip visibly rather than passing.
+/// </para>
+/// </remarks>
+[Trait("Category", "Integration")]
+public sealed class ServiceBusTransportIntegrationTests
+{
+    private static readonly IntegrationEventNameMap Map = new(
+    [
+        new KeyValuePair<string, Type>(OrderPlaced.WireName, typeof(OrderPlaced)),
+    ]);
+
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task RoundTrip_DeliversTheEventAndItsSourceToTheInboxDispatcher()
+    {
+        var client = await RequireEmulatorAsync();
+        const string Subscription = "roundtrip";
+        await DrainAsync(client, Subscription);
+
+        var recorder = new RecordingInboxDispatcher();
+        await using var host = BuildConsumer(client, Subscription, recorder);
+        await StartAsync(host);
+
+        var placed = new OrderPlaced($"ORD-{Guid.NewGuid():N}", DateTimeOffset.UnixEpoch);
+        var messageId = Guid.CreateVersion7();
+        await PublishAsync(client, new OutboundIntegrationMessage(messageId, placed), messageSource: "orders-service");
+
+        var envelope = await recorder.WaitForAsync(messageId);
+
+        envelope.Event.Should().BeEquivalentTo(placed);
+        envelope.MessageSource.Should().Be("orders-service");
+    }
+
+    [Fact]
+    public async Task RepublishingTheSameOutboxRow_ArrivesTwiceUnderOneMessageId()
+    {
+        var client = await RequireEmulatorAsync();
+        const string Subscription = "duplicate";
+        await DrainAsync(client, Subscription);
+
+        var recorder = new RecordingInboxDispatcher();
+        await using var host = BuildConsumer(client, Subscription, recorder);
+        await StartAsync(host);
+
+        // One outbox row, published twice: exactly what an at-least-once relay does when it crashes
+        // between publishing and saving its bookkeeping.
+        var row = new OutboundIntegrationMessage(
+            Guid.CreateVersion7(), new OrderPlaced($"ORD-{Guid.NewGuid():N}", DateTimeOffset.UnixEpoch));
+
+        await PublishAsync(client, row, messageSource: null);
+        await PublishAsync(client, row, messageSource: null);
+
+        await recorder.WaitForCountAsync(row.MessageId, 2);
+
+        // Both copies carry the producer's id, so the inbox sees one (ConsumerId, MessageId) pair and
+        // deduplicates. Had the transport generated its own id, these would be two distinct messages and
+        // the handlers would run twice.
+        recorder.Received.Select(e => e.MessageId).Should().AllBeEquivalentTo(row.MessageId);
+    }
+
+    [Fact]
+    public async Task ADuplicateTheInboxSkips_IsCompletedNotRedelivered()
+    {
+        var client = await RequireEmulatorAsync();
+        const string Subscription = "duplicate";
+        await DrainAsync(client, Subscription);
+
+        var recorder = new RecordingInboxDispatcher { Outcome = InboxDispatchOutcome.SkippedDuplicate };
+        await using var host = BuildConsumer(client, Subscription, recorder);
+        await StartAsync(host);
+
+        var row = new OutboundIntegrationMessage(
+            Guid.CreateVersion7(), new OrderPlaced($"ORD-{Guid.NewGuid():N}", DateTimeOffset.UnixEpoch));
+        await PublishAsync(client, row, messageSource: null);
+
+        await recorder.WaitForAsync(row.MessageId);
+
+        // SkippedDuplicate means the message is durably accounted for. Abandoning it instead would loop
+        // forever, because every redelivery would reach the same conclusion.
+        await Task.Delay(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        recorder.CountFor(row.MessageId).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AMessageWhoseContractIsUnknown_IsDeadLetteredWithADiagnosis()
+    {
+        var client = await RequireEmulatorAsync();
+        const string Subscription = "poison";
+        await DrainAsync(client, Subscription);
+
+        var recorder = new RecordingInboxDispatcher();
+        await using var host = BuildConsumer(client, Subscription, recorder);
+        await StartAsync(host);
+
+        var messageId = Guid.CreateVersion7();
+        await using (var sender = client.CreateSender(ServiceBusEmulator.Topic))
+        {
+            await sender.SendMessageAsync(
+                new ServiceBusMessage(BinaryData.FromString("{}"))
+                {
+                    MessageId = messageId.ToString(),
+                    Subject = "orders.never-heard-of.v1",
+                },
+                TestContext.Current.CancellationToken);
+        }
+
+        var deadLettered = await WaitForDeadLetterAsync(client, Subscription, messageId);
+
+        deadLettered.DeadLetterReason.Should().Be(ServiceBusConsumerErrors.UnknownContractCode);
+        deadLettered.DeadLetterErrorDescription.Should().Contain("orders.never-heard-of.v1");
+        recorder.Received.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AMessageWhoseHandlerThrows_IsRedelivered()
+    {
+        var client = await RequireEmulatorAsync();
+        const string Subscription = "failing";
+        await DrainAsync(client, Subscription);
+
+        var recorder = new RecordingInboxDispatcher { ThrowOnFirstAttempt = true };
+        await using var host = BuildConsumer(client, Subscription, recorder);
+        await StartAsync(host);
+
+        var row = new OutboundIntegrationMessage(
+            Guid.CreateVersion7(), new OrderPlaced($"ORD-{Guid.NewGuid():N}", DateTimeOffset.UnixEpoch));
+        await PublishAsync(client, row, messageSource: null);
+
+        // The dispatcher rolled back, so nothing was applied; the SDK abandons an unsettled message whose
+        // handler threw and Service Bus redelivers it.
+        await recorder.WaitForCountAsync(row.MessageId, 2);
+    }
+
+    private static async Task<ServiceBusClient> RequireEmulatorAsync()
+    {
+        var client = await ServiceBusEmulator.TryGetClientAsync();
+        Assert.SkipWhen(
+            client is null,
+            "No Azure Service Bus emulator reachable on localhost:5672, so the transport integration tests did not run. " +
+            "Start it with: docker compose -f Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml up -d");
+
+        return client!;
+    }
+
+    private static async Task PublishAsync(ServiceBusClient client, OutboundIntegrationMessage message, string? messageSource)
+    {
+        await using var publisher = new ServiceBusIntegrationEventPublisher(
+            client,
+            Map,
+            Options.Create(new AzureServiceBusPublisherOptions { MessageSource = messageSource }),
+            NullLogger<ServiceBusIntegrationEventPublisher>.Instance);
+
+        await publisher.PublishAsync(message, CancellationToken.None);
+    }
+
+    private static ServiceProvider BuildConsumer(ServiceBusClient client, string subscription, RecordingInboxDispatcher recorder)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(client);
+        services.AddSingleton<IInboxDispatcher>(recorder);
+        services.AddAzureServiceBusIntegrationEventConsumer(
+            Map, o => o.Subscribe(ServiceBusEmulator.Topic, subscription));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static Task StartAsync(ServiceProvider host) =>
+        host.GetServices<IHostedService>().OfType<ServiceBusInboxConsumer>().Single()
+            .StartAsync(CancellationToken.None);
+
+    private static async Task DrainAsync(ServiceBusClient client, string subscription)
+    {
+        await using var receiver = client.CreateReceiver(ServiceBusEmulator.Topic, subscription);
+
+        while (true)
+        {
+            var batch = await receiver.ReceiveMessagesAsync(50, TimeSpan.FromMilliseconds(500));
+            if (batch.Count == 0)
+                return;
+
+            foreach (var message in batch)
+                await receiver.CompleteMessageAsync(message);
+        }
+    }
+
+    private static async Task<ServiceBusReceivedMessage> WaitForDeadLetterAsync(
+        ServiceBusClient client, string subscription, Guid messageId)
+    {
+        await using var receiver = client.CreateReceiver(
+            ServiceBusEmulator.Topic, subscription, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+
+        var deadline = DateTime.UtcNow + Patience;
+        while (DateTime.UtcNow < deadline)
+        {
+            var message = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(2));
+            if (message is null)
+                continue;
+
+            await receiver.CompleteMessageAsync(message);
+            if (message.MessageId == messageId.ToString())
+                return message;
+        }
+
+        throw new TimeoutException($"Message {messageId} was not dead-lettered within {Patience}.");
+    }
+
+    private sealed class RecordingInboxDispatcher : IInboxDispatcher
+    {
+        private readonly ConcurrentQueue<IntegrationEnvelope> _received = new();
+        private readonly ConcurrentDictionary<Guid, int> _attempts = new();
+
+        public IReadOnlyCollection<IntegrationEnvelope> Received => _received;
+
+        public InboxDispatchOutcome Outcome { get; init; } = InboxDispatchOutcome.Processed;
+
+        public bool ThrowOnFirstAttempt { get; init; }
+
+        public int CountFor(Guid messageId) => _received.Count(e => e.MessageId == messageId);
+
+        public Task<InboxDispatchOutcome> DispatchAsync(IntegrationEnvelope envelope, CancellationToken cancellationToken = default)
+        {
+            _received.Enqueue(envelope);
+            var attempt = _attempts.AddOrUpdate(envelope.MessageId, 1, static (_, n) => n + 1);
+
+            if (ThrowOnFirstAttempt && attempt == 1)
+                throw new InvalidOperationException("Simulated handler failure.");
+
+            return Task.FromResult(Outcome);
+        }
+
+        public Task<IntegrationEnvelope> WaitForAsync(Guid messageId) => WaitForCountAsync(messageId, 1);
+
+        public async Task<IntegrationEnvelope> WaitForCountAsync(Guid messageId, int count)
+        {
+            var deadline = DateTime.UtcNow + Patience;
+            while (DateTime.UtcNow < deadline)
+            {
+                var matches = _received.Where(e => e.MessageId == messageId).ToList();
+                if (matches.Count >= count)
+                    return matches[^1];
+
+                await Task.Delay(200);
+            }
+
+            throw new TimeoutException(
+                $"Expected {count} delivery/deliveries of message {messageId} within {Patience}, saw {CountFor(messageId)}.");
+        }
+    }
+}

--- a/Trellis.Messaging.AzureServiceBus/tests/Trellis.Messaging.AzureServiceBus.Tests.csproj
+++ b/Trellis.Messaging.AzureServiceBus/tests/Trellis.Messaging.AzureServiceBus.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <Using Include="Trellis.Messaging.AzureServiceBus" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Trellis.Messaging.AzureServiceBus.csproj" />
+    <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />
+    <ProjectReference Include="..\..\Trellis.Mediator\src\Trellis.Mediator.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+</Project>

--- a/Trellis.Messaging.AzureServiceBus/tests/emulator/Config.json
+++ b/Trellis.Messaging.AzureServiceBus/tests/emulator/Config.json
@@ -1,0 +1,69 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [],
+        "Topics": [
+          {
+            "Name": "orders.order-placed.v1",
+            "Properties": {
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "RequiresDuplicateDetection": false
+            },
+            "Subscriptions": [
+              {
+                "Name": "roundtrip",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "RequiresSession": false
+                },
+                "Rules": []
+              },
+              {
+                "Name": "duplicate",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "RequiresSession": false
+                },
+                "Rules": []
+              },
+              {
+                "Name": "poison",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT1M",
+                  "MaxDeliveryCount": 10,
+                  "RequiresSession": false
+                },
+                "Rules": []
+              },
+              {
+                "Name": "failing",
+                "Properties": {
+                  "DeadLetteringOnMessageExpiration": false,
+                  "DefaultMessageTimeToLive": "PT1H",
+                  "LockDuration": "PT10S",
+                  "MaxDeliveryCount": 3,
+                  "RequiresSession": false
+                },
+                "Rules": []
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Logging": {
+      "Type": "File"
+    }
+  }
+}

--- a/Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml
+++ b/Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml
@@ -1,0 +1,48 @@
+name: trellis-servicebus-emulator
+
+# Repo-owned Azure Service Bus emulator for the Trellis.Messaging.AzureServiceBus integration tests.
+#
+# The emulator cannot create entities at runtime — every topic and subscription must be declared in
+# Config.json before the container starts. That is why this file exists rather than the tests
+# provisioning what they need: the entity list *is* part of the test fixture.
+#
+#   docker compose -f Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml up -d
+#
+# The tests skip visibly when nothing is listening on localhost:5672, so this is optional for a
+# normal build.
+
+services:
+  emulator:
+    container_name: trellis-servicebus-emulator
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    volumes:
+      - "./Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+      - "5300:5300"
+    environment:
+      SQL_SERVER: sqledge
+      MSSQL_SA_PASSWORD: "TrellisEmulator1!"
+      ACCEPT_EULA: "Y"
+    depends_on:
+      sqledge:
+        condition: service_started
+    networks:
+      servicebus:
+        aliases:
+          - "sb-emulator"
+
+  # The emulator keeps its entity state in SQL; it will not start without this sidecar.
+  sqledge:
+    container_name: trellis-servicebus-emulator-sql
+    image: mcr.microsoft.com/azure-sql-edge:latest
+    networks:
+      servicebus:
+        aliases:
+          - "sqledge"
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "TrellisEmulator1!"
+
+networks:
+  servicebus:

--- a/Trellis.slnx
+++ b/Trellis.slnx
@@ -124,6 +124,10 @@
     <Project Path="Trellis.Http.Abstractions/src/Trellis.Http.Abstractions.csproj" />
     <Project Path="Trellis.Http.Abstractions/tests/Trellis.Http.Abstractions.Tests.csproj" />
   </Folder>
+  <Folder Name="/Trellis.Messaging.AzureServiceBus/">
+    <Project Path="Trellis.Messaging.AzureServiceBus/src/Trellis.Messaging.AzureServiceBus.csproj" />
+    <Project Path="Trellis.Messaging.AzureServiceBus/tests/Trellis.Messaging.AzureServiceBus.Tests.csproj" />
+  </Folder>
   <Folder Name="/Trellis.Persistence.Abstractions/">
     <Project Path="Trellis.Persistence.Abstractions/src/Trellis.Persistence.Abstractions.csproj" />
   </Folder>

--- a/docs/docfx_project/api_reference/trellis-api-messaging-azureservicebus.md
+++ b/docs/docfx_project/api_reference/trellis-api-messaging-azureservicebus.md
@@ -99,6 +99,10 @@ public sealed class AzureServiceBusConsumerOptions
 
 Validation runs at registration, not on the first message: no subscriptions, `MaxConcurrentCalls < 1`, a negative `PrefetchCount`, or the same `(topic, subscription)` registered twice each throw `InvalidOperationException` from the `AddAzureServiceBusIntegrationEventConsumer` call.
 
+The duplicate check spans calls. Configuration accumulates onto one options instance, so two registrations that are each valid alone can still add the same subscription twice — which would start two processors competing on one subscription. Registration validates the accumulated configuration, and the consumer re-validates what it was actually handed, since `Subscriptions` is a mutable list that can be appended to directly.
+
+`TopicNameResolver` and both `JsonSerializerOptions` properties reject `null` on assignment rather than failing with a `NullReferenceException` on the first message.
+
 ## Registration
 
 ```csharp

--- a/docs/docfx_project/api_reference/trellis-api-messaging-azureservicebus.md
+++ b/docs/docfx_project/api_reference/trellis-api-messaging-azureservicebus.md
@@ -1,0 +1,160 @@
+﻿---
+package: Trellis.Messaging.AzureServiceBus
+namespaces: [Trellis.Messaging.AzureServiceBus]
+types: [ServiceBusIntegrationEventPublisher, ServiceBusInboxConsumer, AzureServiceBusPublisherOptions, AzureServiceBusConsumerOptions, ServiceBusSubscription, ServiceBusMessageFormat, AzureServiceBusServiceCollectionExtensions]
+version: v1
+last_verified: 2026-06-19
+audience: [llm]
+---
+# Trellis.Messaging.AzureServiceBus &mdash; API Reference
+
+**Package:** `Trellis.Messaging.AzureServiceBus`
+**Namespace:** `Trellis.Messaging.AzureServiceBus`
+**Purpose:** Carry integration events between services over Azure Service Bus, preserving the message identity the transactional inbox deduplicates on.
+
+See also: [trellis-api-efcore-outbox.md](trellis-api-efcore-outbox.md#outboxmessage), [trellis-api-efcore-inbox.md](trellis-api-efcore-inbox.md#integrationenvelope), [trellis-api-mediator.md](trellis-api-mediator.md#iintegrationeventpublisher).
+
+## Use this file when
+
+- You are publishing integration events to another service rather than fanning them out in process.
+- You are consuming integration events from Service Bus into a Trellis inbox.
+- You need the exact wire format (which Service Bus member carries what).
+- You are deciding how a received message should be settled.
+
+## Why this package exists
+
+Trellis ships both ends of reliable messaging and, until this package, no wire between them:
+
+| Stage | Component | Guarantee |
+|---|---|---|
+| Produce | `OutboxCaptureInterceptor` + `OutboxRelay` | The event is staged in the same transaction as the business change, then relayed at-least-once. |
+| **Transport** | **this package** | **The producer's message identity survives the wire.** |
+| Consume | `IInboxDispatcher` + `IInboxStore` | Handler side effects and the `(ConsumerId, MessageId)` dedup row commit together, so a redelivery is skipped. |
+
+The middle row is load-bearing. `OutboxRelay` delivery is at-least-once — a crash between publishing and the relay's bookkeeping save republishes the row — so a transport that minted its own id per attempt would put a *different* `MessageId` on each copy. The consumer's dedup would miss and handlers would run twice. Because [`IIntegrationEventPublisher`](trellis-api-mediator.md#iintegrationeventpublisher) takes an `OutboundIntegrationMessage`, which carries the outbox row id, publishing without it is not expressible.
+
+This collapses redeliveries of a *single* outbox row. It does not collapse the other duplicate the outbox can produce — a retried domain row re-running its translator stages a genuinely new row with a new id — which still needs business-identity deduplication. See [the outbox reference](trellis-api-efcore-outbox.md#two-different-duplicates--only-one-is-the-message-ids-job) for the distinction.
+
+## Wire format
+
+`ServiceBusMessageFormat` names the members Trellis assigns meaning to.
+
+| Service Bus member | Carries | Notes |
+|---|---|---|
+| `MessageId` | The producer's outbox row id (UUIDv7) | The consumer's dedup key. Must parse as a non-empty `Guid`. |
+| `Subject` | The event's stable wire name | From `[IntegrationEventName]`; resolved through `IntegrationEventNameMap`. |
+| `Body` | The event as UTF-8 JSON | Serialized against the event's **runtime** type. |
+| `ContentType` | `ServiceBusMessageFormat.JsonContentType` (`application/json`) | |
+| `trellis-message-source` (application property) | `IntegrationEnvelope.MessageSource` | Optional; observability only. Omitted when unset or blank. |
+
+Standard Service Bus members are preferred over custom application properties wherever one exists: `MessageId` and `Subject` are indexed by the broker, surfaced in the portal and Service Bus Explorer, and usable in subscription filters, so a message stays diagnosable and routable by tools that know nothing about Trellis.
+
+`IntegrationEnvelope`'s lineage members `CausationId` and `CorrelationId` are **not** on the wire, because nothing on the publish side can populate them: `OutboundIntegrationMessage` deliberately omits them until the outbox persists them.
+
+## Topology
+
+The default layout is **one topic per contract**, named after the wire name. A subscriber declares interest by subscribing to the topics it wants, rather than filtering a firehose.
+
+`AzureServiceBusPublisherOptions.TopicNameResolver` changes that mapping — prefix an environment segment (`name => $"prod.{name}"`), or collapse several contracts onto one topic. If you collapse them, add a correlation filter on `sys.Label` (the message's `Subject`) to each subscription, or a subscriber will receive contracts it cannot deserialize and dead-letter them.
+
+## AzureServiceBusPublisherOptions
+
+```csharp
+public sealed class AzureServiceBusPublisherOptions
+{
+    public string? MessageSource { get; set; }
+    public Func<string, string> TopicNameResolver { get; set; }
+    public JsonSerializerOptions JsonSerializerOptions { get; set; }
+}
+```
+
+| Member | Default | Notes |
+|---|---|---|
+| `MessageSource` | `null` | The producing service or bounded context. Observability only — never affects dedup or routing. |
+| `TopicNameResolver` | identity | Wire name → topic name. |
+| `JsonSerializerOptions` | `JsonSerializerOptions.Web` | A wire-format decision shared with every consumer. Change it before the first message ships, or accept that in-flight messages written with the previous settings must still deserialize. |
+
+## AzureServiceBusConsumerOptions
+
+```csharp
+public sealed class AzureServiceBusConsumerOptions
+{
+    public IList<ServiceBusSubscription> Subscriptions { get; }
+    public int MaxConcurrentCalls { get; set; }
+    public int PrefetchCount { get; set; }
+    public JsonSerializerOptions JsonSerializerOptions { get; set; }
+
+    public AzureServiceBusConsumerOptions Subscribe(string topicName, string subscriptionName);
+}
+```
+
+| Member | Default | Notes |
+|---|---|---|
+| `Subscriptions` | empty | Each gets its own processor. At least one is required. |
+| `MaxConcurrentCalls` | `1` | Each concurrent message runs handlers in its own database transaction, so raising this raises connection-pool pressure and write contention. Deduplication stays correct at any value — concurrent delivery of the same message is resolved by the inbox's composite primary key — so this is purely a throughput knob. |
+| `PrefetchCount` | `0` | Prefetched messages have their lock clock already running; a large prefetch with slow handlers expires locks and causes redelivery. Safe (the inbox absorbs it) but wasteful. |
+| `JsonSerializerOptions` | `JsonSerializerOptions.Web` | Must agree with the producer. |
+
+**The subscriber identity is not here.** Deduplication keys on `InboxOptions.ConsumerId`, so every transport a service consumes from shares one dedup namespace and a message arriving twice by two routes is still processed once.
+
+Validation runs at registration, not on the first message: no subscriptions, `MaxConcurrentCalls < 1`, a negative `PrefetchCount`, or the same `(topic, subscription)` registered twice each throw `InvalidOperationException` from the `AddAzureServiceBusIntegrationEventConsumer` call.
+
+## Registration
+
+```csharp
+public static IServiceCollection AddAzureServiceBusIntegrationEventPublisher(
+    this IServiceCollection services,
+    IntegrationEventNameMap nameMap,
+    Action<AzureServiceBusPublisherOptions>? configure = null);
+
+public static IServiceCollection AddAzureServiceBusIntegrationEventConsumer(
+    this IServiceCollection services,
+    IntegrationEventNameMap nameMap,
+    Action<AzureServiceBusConsumerOptions> configure);
+```
+
+Both require a `ServiceBusClient` in the container; neither owns its lifetime.
+
+`AddAzureServiceBusIntegrationEventPublisher` **replaces** any existing `IIntegrationEventPublisher` registration rather than adding to it. In-process fan-out and broker publication are alternatives, not layers: registering both would deliver each event locally *and* over the wire, so a service subscribed to its own topic would handle everything twice. Replacing also makes the registration order-independent.
+
+`AddAzureServiceBusIntegrationEventConsumer` requires an `IInboxDispatcher` (`AddTrellisInbox<TContext>()`); consuming without one runs handlers with no deduplication, which is the failure the inbox exists to prevent. The dispatcher is resolved per message from a fresh scope, so it need not be registered before this call.
+
+**Each helper keeps the map it was handed.** The `nameMap` argument is captured by the component being registered rather than published as a shared container service, so a service that publishes one set of contracts and consumes another can pass a different map to each call without the first silently winning. Calling the consumer helper more than once still runs a single consumer, configured with every caller's subscriptions.
+
+**Neither helper has a `TrellisServiceBuilder.UseXxx()` slot.** Surfacing them would force every `Trellis.ServiceDefaults` consumer to take a transitive dependency on the Azure SDK to use features unrelated to Azure. This matches `Trellis.Asp.Idempotency.Cosmos`; see [trellis-api-servicedefaults.md](trellis-api-servicedefaults.md#registrations-without-a-builder-slot).
+
+## Settlement
+
+`ServiceBusInboxConsumer` runs with `AutoCompleteMessages = false`, because settlement follows from the inbox outcome.
+
+| Situation | Action | Why |
+|---|---|---|
+| `InboxDispatchOutcome.Processed` | Complete | Handler side effects and the dedup row committed together. |
+| `InboxDispatchOutcome.SkippedDuplicate` | Complete | Already durably accounted for. Abandoning would redeliver forever, because every attempt reaches the same conclusion. |
+| Handler throws | Abandon | The dispatcher rolled its transaction back, so nothing was applied. The exception is deliberately not caught: the SDK abandons an unsettled message whose handler threw and routes the exception to the error handler. `MaxDeliveryCount` dead-letters a persistently failing message. |
+| Message is unusable | Dead-letter with a reason code | A property of the bytes, not of this consumer's state, so retrying cannot change the outcome. Abandoning would burn the delivery count and dead-letter anyway, with no diagnosis attached. |
+
+Dead-letter reasons:
+
+| Reason | Meaning |
+|---|---|
+| `servicebus_unusable_message_id` | `MessageId` is absent or not a non-empty GUID, so the message has no stable inbox dedup key. |
+| `servicebus_missing_subject` | No `Subject`, so no contract can be chosen to deserialize the body. |
+| `servicebus_unknown_contract` | The wire name is well-formed but unregistered here. Normal traffic on a shared topic, not necessarily a bug. |
+| `servicebus_malformed_body` | The contract is known but the body does not deserialize to it — either the JSON is invalid for that shape, or the contract itself cannot be materialized (an abstract or interface-typed member, or a shape with no converter). Both are permanent for these bytes, so both dead-letter rather than escaping as a fault the consumer would retry until the delivery count is exhausted. |
+
+The dead-letter description carries the specific diagnosis (the offending wire name, the JSON error, and so on).
+
+## Publishing an unmapped event
+
+`ServiceBusIntegrationEventPublisher.PublishAsync` throws `InvalidOperationException` when the event type has no registered wire name. This is deliberately fatal to the publish rather than a skip: the event cannot be named on the wire, so no consumer could identify it. The outbox row stays unsent and the relay retries, surfacing a missing `[IntegrationEventName]` as a stuck message rather than as silently dropped traffic.
+
+## Testing
+
+Integration tests are marked `[Trait("Category", "Integration")]` and skip visibly when no emulator is reachable, so they never pass against a substitute.
+
+```
+docker compose -f Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml up -d
+```
+
+The emulator declares its entities in `Config.json` at container start and cannot create them at runtime, so the compose file and its entity list are part of the fixture. Duplicate detection is deliberately **off** on the test topic: if the broker collapsed duplicate message ids, the suite would pass even if the transport minted a fresh id per publish. The assertion is that Trellis carries the id — not that Service Bus can be configured to hide the consequences of losing it.

--- a/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
+++ b/docs/docfx_project/api_reference/trellis-api-servicedefaults.md
@@ -196,3 +196,19 @@ services.AddTrellis(options => options
     .UseDomainEvents(typeof(Program).Assembly)
     .UseEntityFrameworkUnitOfWork<AppDbContext>());
 ```
+
+## Registrations without a builder slot
+
+Not every `services.AddXxx()` Trellis ships has a matching `UseXxx()` slot, and the omissions are deliberate.
+
+| Registration | Package | Why no slot |
+|---|---|---|
+| `AddInMemoryIdempotencyStore` | `Trellis.Asp.Idempotency` | A leaf store, chosen by the store registration rather than by the composition root. |
+| `AddTrellisRouteConstraint` / `AddTrellisRouteConstraints` | `Trellis.Asp` | Called by `UseAsp()`; surfacing it twice would let the two disagree. |
+| `AddTransactionalCommandBehavior` | `Trellis.Mediator` | Provider-neutral; invoked by `AddTrellisUnitOfWork<TContext>()`, which *is* surfaced as `UseEntityFrameworkUnitOfWork<TContext>()`. |
+| `AddCosmosIdempotencyStore` | `Trellis.Asp.Idempotency.Cosmos` | Vendor SDK. |
+| `AddAzureServiceBusIntegrationEventPublisher` / `AddAzureServiceBusIntegrationEventConsumer` | `Trellis.Messaging.AzureServiceBus` | Vendor SDK. |
+
+The vendor-SDK rule is the important one: `Trellis.ServiceDefaults` references no cloud SDK, and a builder slot is a compile-time reference. Adding one would make every consumer of the meta-package carry the Azure SDK in order to use features that have nothing to do with Azure. Call these registrations directly on `IServiceCollection` alongside `AddTrellis(...)`.
+
+`AddAzureServiceBusIntegrationEventPublisher` in particular is order-independent by construction: it *replaces* any existing `IIntegrationEventPublisher` registration rather than appending to it, so it can be called before or after `AddTrellis(options => options.UseIntegrationEvents(...))` with the same result.

--- a/docs/docfx_project/articles/integration-azure-service-bus.md
+++ b/docs/docfx_project/articles/integration-azure-service-bus.md
@@ -1,0 +1,96 @@
+﻿# Azure Service Bus Transport
+
+The [transactional outbox](integration-outbox.md) stages integration events durably, and the [transactional inbox](integration-inbox.md) makes consuming them idempotent. `Trellis.Messaging.AzureServiceBus` is the wire between the two, so those guarantees hold across service boundaries instead of only inside one process.
+
+## The guarantee that matters
+
+Everything in this package exists to preserve one value.
+
+Outbox relay delivery is **at-least-once**. If the process crashes between publishing a row and saving the relay's bookkeeping, that row is published again. The consumer's inbox deduplicates on `(ConsumerId, MessageId)`, so those two copies only collapse into one effective processing if they arrive under the *same* message id.
+
+That id is the producer's outbox row id, and the transport's job is to carry it verbatim:
+
+```csharp
+var serviceBusMessage = new ServiceBusMessage(body)
+{
+    MessageId = message.MessageId.ToString(),  // the outbox row id, unchanged
+    Subject = wireName,
+    ContentType = "application/json",
+};
+```
+
+A transport that generated its own id per publish attempt would put a different `MessageId` on each copy. The inbox would still be there, still look correct, and still deduplicate nothing. That is why `IIntegrationEventPublisher` takes an `OutboundIntegrationMessage` carrying the id, rather than the bare event: publishing without the identity is not expressible.
+
+> [!NOTE]
+> This collapses redeliveries of a *single* outbox row. A retried domain row re-runs its translator and stages a genuinely new integration row with a new id — a different duplicate that still needs business-identity deduplication. See [Transactional Outbox](integration-outbox.md) for the distinction.
+
+## Naming events on the wire
+
+The outbox stores `Type.AssemblyQualifiedName`, which is fine for relaying inside one process and useless across services: the consumer's assemblies differ, and the string embeds an assembly version that a routine upgrade invalidates.
+
+Give each contract a stable name it owns:
+
+```csharp
+[IntegrationEventName("orders.order-placed.v1")]
+public sealed record OrderPlaced(string OrderNumber, DateTimeOffset OccurredAt) : IIntegrationEvent;
+```
+
+Both sides build an `IntegrationEventNameMap` and resolve the name in whichever direction they need. The producer never has to know what the consumer calls the type.
+
+## Producing
+
+```csharp
+builder.Services.AddSingleton(new ServiceBusClient(connectionString));
+
+builder.Services.AddAzureServiceBusIntegrationEventPublisher(
+    IntegrationEventNameMap.FromAssemblies(typeof(OrderPlaced).Assembly),
+    options => options.MessageSource = "orders-service");
+```
+
+That is the only change to a service that already has an outbox. The relay keeps draining rows; they now leave the process.
+
+This **replaces** the in-process publisher rather than adding to it. The two are alternatives, not layers — running both would deliver each event locally *and* over the wire, so a service subscribed to its own topic would handle everything twice.
+
+By default each contract gets its own topic, named after its wire name. Subscribers declare interest by subscribing to the topics they want rather than filtering everything. Use `TopicNameResolver` to prefix an environment segment or to collapse contracts onto a shared topic — and if you collapse them, filter each subscription on `sys.Label`, which always carries the wire name.
+
+## Consuming
+
+```csharp
+builder.Services.AddSingleton(new ServiceBusClient(connectionString));
+
+builder.Services.AddTrellisInbox<BillingDbContext>(o => o.ConsumerId = "billing");
+
+builder.Services.AddAzureServiceBusIntegrationEventConsumer(
+    IntegrationEventNameMap.FromAssemblies(typeof(OrderPlaced).Assembly),
+    options => options.Subscribe("orders.order-placed.v1", "billing"));
+```
+
+The dedup identity is `InboxOptions.ConsumerId`, not a transport setting. That is deliberate: a service that consumes the same logical message from two routes should still process it once.
+
+## How messages are settled
+
+Settlement follows from what the inbox reports, so `AutoCompleteMessages` is off.
+
+| Outcome | Action | Why |
+|---|---|---|
+| `Processed` | Complete | Handler side effects and the dedup row committed together. |
+| `SkippedDuplicate` | Complete | Already durably accounted for. Abandoning it would redeliver forever — every attempt would reach the same conclusion. |
+| Handler threw | Abandon | The dispatcher rolled back, so nothing was applied. Redelivery is correct; `MaxDeliveryCount` dead-letters a persistently failing message. |
+| Message unusable | Dead-letter | No parseable id, no contract name, an unknown contract, or a body that will not deserialize. Retrying the same bytes cannot change the outcome, so the message is dead-lettered immediately with a reason code rather than after burning the delivery count. |
+
+Dead-letter reasons are `servicebus_unusable_message_id`, `servicebus_missing_subject`, `servicebus_unknown_contract`, and `servicebus_malformed_body`, each with a description naming the specific problem.
+
+`servicebus_unknown_contract` is worth calling out: on a shared topic it is normal traffic, not a defect. A producer may emit contracts you do not model. Dead-lettering is a routing decision you can monitor, not a crash.
+
+## Running the tests locally
+
+```
+docker compose -f Trellis.Messaging.AzureServiceBus/tests/emulator/docker-compose.yml up -d
+```
+
+The emulator declares its topics and subscriptions in `Config.json` before it starts and cannot create them at runtime, so that file is part of the test fixture rather than something the tests provision.
+
+Two details in that fixture are deliberate:
+
+- **Duplicate detection is off.** If the broker collapsed duplicate message ids, the tests would pass even if the transport invented a fresh id per publish. The suite asserts that Trellis carries the id, not that Service Bus can be configured to hide the consequences of losing it.
+- **The tests skip visibly** when no emulator is reachable, rather than passing against an in-memory stand-in. A suite that quietly substitutes a fake proves nothing about a transport.

--- a/docs/docfx_project/articles/toc.yml
+++ b/docs/docfx_project/articles/toc.yml
@@ -74,6 +74,8 @@
     href: integration-outbox.md
   - name: Transactional Inbox
     href: integration-inbox.md
+  - name: Azure Service Bus Transport
+    href: integration-azure-service-bus.md
   - name: Mediator Pipeline
     href: integration-mediator.md
   - name: Service Defaults (Composition Root)

--- a/docs/docfx_project/docfx.json
+++ b/docs/docfx_project/docfx.json
@@ -24,7 +24,8 @@
             "Trellis.Mediator.FluentValidation/src/Trellis.Mediator.FluentValidation.csproj",
             "Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj",
             "Trellis.EntityFrameworkCore.Outbox/src/Trellis.EntityFrameworkCore.Outbox.csproj",
-            "Trellis.EntityFrameworkCore.Inbox/src/Trellis.EntityFrameworkCore.Inbox.csproj"
+            "Trellis.EntityFrameworkCore.Inbox/src/Trellis.EntityFrameworkCore.Inbox.csproj",
+            "Trellis.Messaging.AzureServiceBus/src/Trellis.Messaging.AzureServiceBus.csproj"
           ]
         }
       ],


### PR DESCRIPTION
Trellis shipped both ends of reliable cross-service messaging and nothing in between: a transactional outbox that stages integration events with the business change, and an inbox that deduplicates them on `(ConsumerId, MessageId)`. This adds the transport that connects them.

## The guarantee this exists to preserve

Outbox relay delivery is at-least-once, so one row can be published more than once. The consumer's inbox only collapses those copies if they arrive under the **same** message id. The publisher therefore stamps the producer's outbox row id onto `ServiceBusMessage.MessageId` verbatim.

A transport that minted its own id per attempt would leave the inbox in place, looking correct, and deduplicating nothing — a failure that is invisible until it costs you a double charge in production.

I did not take the tests' word for this. Mutating that one line to `Guid.NewGuid().ToString()` fails **six tests**, including every end-to-end one. The suite pins the contract rather than passing vacuously.

Note this collapses redeliveries of a *single* outbox row. A retried domain row re-runs its translator and stages a genuinely new row with a new id — a different duplicate that still needs business-identity deduplication. The docs draw that distinction explicitly so nobody over-reads the guarantee.

## Design decisions worth reviewing

**Wire format prefers standard Service Bus members over custom properties.** `MessageId` for the dedup key, `Subject` for the stable wire name from `[IntegrationEventName]`. Both are broker-indexed, visible in the portal and Service Bus Explorer, and usable in subscription filters — so messages stay diagnosable and routable by tools that know nothing about Trellis.

**One topic per contract by default.** Subscribers declare interest by subscribing to what they want rather than filtering a firehose. `TopicNameResolver` collapses or prefixes that when a deployment needs something else.

**Settlement follows from what the inbox reports**, so `AutoCompleteMessages` is off:

| Outcome | Action | Why |
|---|---|---|
| `Processed` | Complete | Side effects and dedup row committed together. |
| `SkippedDuplicate` | Complete | Already durably accounted for. Abandoning redelivers forever — every attempt reaches the same conclusion. |
| Handler threw | Abandon | Dispatcher rolled back; nothing was applied. `MaxDeliveryCount` eventually dead-letters. |
| Message unusable | Dead-letter immediately | Retrying the same bytes cannot succeed. Abandoning would only burn the delivery count and dead-letter anyway, with no diagnosis attached. |

**The publisher replaces rather than appends.** In-process fan-out and broker publication are alternatives, not layers: registering both would deliver each event locally *and* over the wire, so a service subscribed to its own topic would handle everything twice. Replacing also makes the call order-independent.

**Each registration captures the `IntegrationEventNameMap` it was handed** instead of publishing a shared container service. Sharing one would let the first caller win and silently discard the second's argument — so a service that publishes one set of contracts and consumes another could have its publisher reject events it can perfectly well name. This is the same bug class the repo already fixed once for repeated outbox/inbox registration.

**No `TrellisServiceBuilder.UseXxx()` slot** for either registration, matching `Trellis.Asp.Idempotency.Cosmos`. A builder slot is a compile-time reference, and surfacing one here would make every `Trellis.ServiceDefaults` consumer carry the Azure SDK to use features unrelated to Azure. Per the contributing rules this is called out explicitly: the rule and its exception list are now recorded in `trellis-api-servicedefaults.md` and `.github/copilot-instructions.md` so the next session doesn't re-litigate it.

## Testing against a real broker

Integration tests run against the actual Azure Service Bus emulator via a repo-owned compose file and `Config.json`. The emulator declares entities at startup and cannot create them at runtime, so the entity list is part of the fixture.

Two deliberate choices there:

- **Duplicate detection is off on the test topic.** If the broker collapsed duplicate ids, the suite would pass even if the transport invented a fresh id per publish. The tests assert that Trellis carries the id, not that Service Bus can be configured to hide the consequences of losing it.
- **Tests skip visibly when no emulator is reachable**, rather than silently passing against an in-memory stand-in. A suite that quietly substitutes a fake proves nothing about a transport.

They carry `Category=Integration`, which CI already excludes, so the build server stays green without Docker.

## Bugs found and fixed during review

A `gpt-5.5` review raised three findings; all three were verified against the source before adopting, and each got a failing test first.

1. **`NotSupportedException` escaped the dead-letter path.** `ToEnvelope` caught only `JsonException`. I probed this rather than assuming — an *abstract* member type throws `NotSupportedException`, while interface members happen to get wrapped in `JsonException`. My first attempt at the test used the wrong trigger and passed vacuously. Permanently unreadable messages were escaping as exceptions the consumer treated as transient faults and retried until the delivery count burned out.
2. **Sender cache leaked and raced disposal.** `GetOrAdd`'s factory can run on several threads and every loser was discarded unclosed; publishing after disposal repopulated a cache nothing would drain again. Now create-then-`TryAdd` closing the loser, plus a disposal gate and drain loop. The one residual race is documented honestly rather than papered over — the container disposing `ServiceBusClient` is the backstop.
3. **`TryAddSingleton(nameMap)` silently discarded the second caller's map** (see above).

While fixing #3 I nearly introduced a worse bug: switching to `AddSingleton<IHostedService>` would have run *two* consumers if the helper were called twice, doubling delivery. Kept `AddHostedService`, which deduplicates correctly even through a factory, and added a test pinning that.

## Validation

- `dotnet build Trellis.slnx -c Release` — 0 warnings
- `dotnet test Trellis.slnx -c Release --filter-not-trait "Category=Integration"` — **7,492 passing**
- All **30** ASB tests pass against the live emulator, 0 skipped
- Docs lint clean; package packs with README, icon, XML docs and the AI API reference bundled

## Known gap

The integration tests use a recording fake `IInboxDispatcher` rather than the real EF Core inbox, to keep an EF dependency out of the transport test project. The transport's half of the contract is well covered; the join between transport and the real EF inbox is not yet exercised end to end. Reasonable follow-up if you want it.