### PR TITLE
Name the publish workflows after their destination

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -1,4 +1,4 @@
-name: Publish Trellis Alpha
+name: Publish to GitHub Packages
 
 on:
   workflow_dispatch:
@@ -43,8 +43,8 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
-      - name: Pack Alpha
-        run: dotnet pack --no-build --configuration Release --version-suffix "alpha.${{ github.run_number }}" --output ./dist
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release --output ./dist
 
       - name: Push to GitHub Packages
         run: dotnet nuget push ./dist/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --skip-duplicate

--- a/.github/workflows/publish-nuget-org.yml
+++ b/.github/workflows/publish-nuget-org.yml
@@ -1,4 +1,4 @@
-name: Publish NuGet Package
+name: Publish to NuGet.org
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The two publish workflows were distinguished by "Alpha", which is not actually the difference between them. `publish.yml` already ships alpha versions (`3.0.0-alpha.446`) to nuget.org, and `publish-alpha.yml` ships **the same version** to GitHub Packages. The destination is the difference, so they are now named for it.

| Before | After | Publishes to |
| --- | --- | --- |
| `publish.yml` — "Publish NuGet Package" | `publish-nuget-org.yml` — **Publish to NuGet.org** | `api.nuget.org` |
| `publish-alpha.yml` — "Publish Trellis Alpha" | `publish-github-packages.yml` — **Publish to GitHub Packages** | `nuget.pkg.github.com` |

## Dead flag removed

The GitHub Packages workflow passed `--version-suffix "alpha.${{ github.run_number }}"` to `dotnet pack`. It never applied: `nbgv` sets `PackageVersion` explicitly and wins. Verified by packing with an obviously distinct suffix:

```
dotnet pack ... --version-suffix "alpha.999"
  -> Trellis.Persistence.Abstractions.3.0.0-alpha.446.nupkg
```

The flag read as though that workflow produced distinctly versioned alphas when it does not, so anyone later adjusting alpha versioning there would have been editing a no-op. Removing it changes no output. Per-run versions on that feed would need `nbgv` configuration instead. The step is renamed `Pack Alpha` -> `Pack` to match what it does.

## Notes

- No behaviour change. Both workflows are `workflow_dispatch` only, and nothing else in the repository referenced either one by name or path.
- Git recorded both as renames, so file history follows.
- The Actions tab will keep the old "Publish NuGet Package" entry with its historical runs as a separate inactive workflow. That is normal for a path rename.
- **Dispatch command changes after merge:** `gh workflow run publish-nuget-org.yml --ref main -f dry_run=false`.