### PR TITLE
Cover the bare non-ASP AOT configuration in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,21 @@ jobs:
           /p:PublishAot=true \
           /p:TreatWarningsAsErrors=true
 
+    - name: AOT publish gate (bare non-ASP console)
+      # The Showcase gate above references Trellis.Asp, which roots the scalar-value surface
+      # and so keeps IScalarValue<,> alive through trimming. A console app using only
+      # Trellis.Core + Trellis.Primitives has nothing doing that rooting and trims differently
+      # -- the one configuration proven to behave differently under AOT, and previously
+      # uncovered. Publishes with warnings-as-errors, then runs the native binary: the probe
+      # asserts scalar value objects still round-trip and that the composite converter, which
+      # is allowed to fail here, fails with a message naming the cause and the remedy.
+      run: |
+        dotnet publish Examples/AotConsoleProbe/AotConsoleProbe.csproj \
+          -c Release -r linux-x64 \
+          /p:PublishAot=true \
+          /p:TreatWarningsAsErrors=true
+        Examples/AotConsoleProbe/bin/Release/net10.0/linux-x64/publish/AotConsoleProbe
+
     - name: Showcase runtime smoke tests (AOT MinimalApi + JIT MVC)
       # Proves both Showcase samples actually serve traffic. Catches runtime
       # regressions that build/publish-time analysis cannot see — e.g., anonymous

--- a/Examples/AotConsoleProbe/AotConsoleProbe.csproj
+++ b/Examples/AotConsoleProbe/AotConsoleProbe.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Bare non-ASP Native AOT probe.
+
+    The Showcase proves Trellis publishes cleanly under AOT, but it references Trellis.Asp,
+    which roots the scalar-value surface and therefore keeps IScalarValue<,> alive through
+    trimming. A console app using only Trellis.Core and Trellis.Primitives has nothing
+    performing that rooting, so it trims differently. That is the configuration this probe
+    covers; nothing else in CI exercises it.
+
+    Deliberately does NOT reference Trellis.Asp; doing so would defeat the probe's purpose.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Trellis.AotConsoleProbe</RootNamespace>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />
+    <ProjectReference Include="..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
+    <ProjectReference Include="..\..\Trellis.Core\generator\Trellis.Core.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/Examples/AotConsoleProbe/Program.cs
+++ b/Examples/AotConsoleProbe/Program.cs
@@ -1,0 +1,130 @@
+﻿namespace Trellis.AotConsoleProbe;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Trellis;
+using Trellis.Primitives;
+
+/// <summary>
+/// A scalar value object declared in the same compilation as the serializer context.
+/// System.Text.Json's generator only observes attributes present in original source, so the
+/// converter is declared here rather than left to the Trellis generator.
+/// </summary>
+[JsonConverter(typeof(ParsableJsonConverter<ProbeOrderId>))]
+public partial class ProbeOrderId : RequiredGuid<ProbeOrderId>
+{
+}
+
+public sealed class ProbeOrder
+{
+    public ProbeOrderId? Id { get; set; }
+
+    public Money? Total { get; set; }
+}
+
+[JsonSerializable(typeof(ProbeOrder))]
+[JsonSerializable(typeof(ProbeOrderId))]
+public partial class ProbeJsonContext : JsonSerializerContext
+{
+}
+
+public static class Program
+{
+    /// <summary>
+    /// The composite converter is allowed to fail under AOT, but its message must still name the
+    /// cause and the way out. These terms are the difference between a usable error and the one
+    /// that previously sent readers to debug a correct <c>TryCreate</c>.
+    /// </summary>
+    private static readonly string[] RequiredDiagnosisTerms = ["trimmed", "Native AOT", "JsonConverter"];
+
+    public static int Main()
+    {
+        var failures = new List<string>();
+
+        Check(failures, "scalar value object round-trips", static () =>
+        {
+            var id = ProbeOrderId.Create(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+            var json = JsonSerializer.Serialize(id, ProbeJsonContext.Default.ProbeOrderId);
+            if (json != "\"11111111-1111-1111-1111-111111111111\"")
+                throw new InvalidOperationException($"expected a bare scalar, got {json}");
+
+            var restored = JsonSerializer.Deserialize(json, ProbeJsonContext.Default.ProbeOrderId);
+            if (restored is null || restored.Value != id.Value)
+                throw new InvalidOperationException($"round-trip lost the value: {restored?.Value}");
+        });
+
+        Check(failures, "scalar validation still rejects bad input", static () =>
+        {
+            var result = ProbeOrderId.TryCreate((Guid?)null);
+            if (result.IsSuccess)
+                throw new InvalidOperationException("null should not produce a valid value object");
+        });
+
+        Check(failures, "composite value object behaves predictably", static () =>
+        {
+            var money = Money.Create(19.99m, "USD");
+            var order = new ProbeOrder { Id = ProbeOrderId.Create(Guid.NewGuid()), Total = money };
+
+            string json;
+            try
+            {
+                json = JsonSerializer.Serialize(order, ProbeJsonContext.Default.ProbeOrder);
+            }
+            catch (Exception ex)
+            {
+                // A composite value object relies on reflection the trimmer may remove. Failing is
+                // acceptable; failing without explaining why is not. The earlier regression threw an
+                // InvalidOperationException blaming a TryCreate overload that was in fact correct,
+                // sending readers to debug the wrong thing. Assert the diagnosis and the remedy.
+                Report("composite serialize threw", ex);
+
+                foreach (var expected in RequiredDiagnosisTerms)
+                {
+                    if (!ex.Message.Contains(expected, StringComparison.OrdinalIgnoreCase))
+                        throw new InvalidOperationException(
+                            $"composite failure message must explain the cause and remedy; missing '{expected}' in: {ex.Message}");
+                }
+
+                return;
+            }
+
+            Console.WriteLine($"  composite serialized: {json}");
+
+            var restored = JsonSerializer.Deserialize(json, ProbeJsonContext.Default.ProbeOrder);
+            if (restored?.Total is null)
+                throw new InvalidOperationException("composite round-trip lost Total");
+            if (restored.Total.Amount != money.Amount || restored.Total.Currency != money.Currency)
+                throw new InvalidOperationException(
+                    $"composite round-trip changed the value: {restored.Total.Amount} {restored.Total.Currency}");
+        });
+
+        if (failures.Count == 0)
+        {
+            Console.WriteLine("AOT console probe: PASS");
+            return 0;
+        }
+
+        Console.WriteLine("AOT console probe: FAIL");
+        foreach (var failure in failures)
+            Console.WriteLine($"  - {failure}");
+
+        return 1;
+    }
+
+    private static void Check(List<string> failures, string description, Action assertion)
+    {
+        try
+        {
+            assertion();
+            Console.WriteLine($"[ok]   {description}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[FAIL] {description}: {ex.GetType().Name}: {ex.Message}");
+            failures.Add($"{description}: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static void Report(string label, Exception ex) =>
+        Console.WriteLine($"  {label}: {ex.GetType().Name}: {ex.Message}");
+}

--- a/Trellis.slnx
+++ b/Trellis.slnx
@@ -33,6 +33,7 @@
     <File Path="docs/docfx_project/articles/toc.yml" />
   </Folder>
   <Folder Name="/Examples/">
+    <Project Path="Examples/AotConsoleProbe/AotConsoleProbe.csproj" />
     <Project Path="Examples/CookbookSnippets/CookbookSnippets.csproj" />
     <Project Path="Examples/EfCoreExample/EfCoreExample.csproj" />
     <Project Path="Examples/EfCoreExample.Tests/EfCoreExample.Tests.csproj" />


### PR DESCRIPTION
## The gap

The existing AOT gate publishes `Showcase.MinimalApi`, which references `Trellis.Asp`. That reference roots the scalar-value surface, so `IScalarValue<,>` survives trimming and value objects behave exactly as they do under JIT. It is a real gate, but it cannot see the configuration that actually differs.

A console app using only `Trellis.Core` and `Trellis.Primitives` has nothing performing that rooting, so it trims differently. That divergence was established earlier by hand with throwaway probes; nothing in CI covered it, which meant the improved AOT diagnostics shipped with no regression guard at all.

## What this adds

`Examples/AotConsoleProbe` -- a bare console app that deliberately does **not** reference `Trellis.Asp`. CI publishes it with `/p:PublishAot=true /p:TreatWarningsAsErrors=true`, then **runs the native binary**. Publish-time IL analysis alone would not have caught the behaviour below, because it is a runtime outcome.

Three assertions:

1. **Scalar value objects still round-trip** through a source-generated `JsonSerializerContext` -- serialize to a bare scalar, deserialize back to the same value.
2. **Validation still rejects bad input** (`TryCreate(null)` must fail) -- proving the guard survives trimming rather than being silently optimised away.
3. **The composite converter fails *usefully*.** `Money` relies on reflection the trimmer removes, so failing is acceptable and expected here. Failing *without explaining why* is not. The probe requires the message to name the cause and the remedy, currently by asserting it contains `trimmed`, `Native AOT`, and `JsonConverter`.

That third assertion is the one worth having. The earlier regression threw an `InvalidOperationException` blaming a `TryCreate` overload that was in fact correct, which sent readers off to debug the wrong thing. The current message is good:

```
CompositeValueObjectJsonConverter<Money> could not reduce [CurrencyCode] to a JSON primitive,
and no 'TryCreate' overload matched [CurrencyCode, Decimal]. Either the type is not a supported
primitive and not an IScalarValue<,> scalar value object, or it is one whose IScalarValue<,>
interface was trimmed away (common in a Native AOT or trimmed build when nothing else roots it).
Root the scalar value type, or hand-write a JsonConverter<Money> and apply it with
[JsonConverter(typeof(MyMoneyConverter))].
```

Nothing was guarding that wording. Now something is.

## Verification

Published a real native binary locally (`win-x64`) rather than trusting the build:

```
[ok]   scalar value object round-trips
[ok]   scalar validation still rejects bad input
[ok]   composite value object behaves predictably
AOT console probe: PASS      EXIT CODE: 0
```

Zero IL warnings under `TreatWarningsAsErrors=true`.

**Confirmed the probe is not vacuous.** A passing check that cannot fail is worse than no check, so I injected a sentinel term into the required-diagnosis list, republished native, and confirmed it fails properly:

```
[FAIL] composite value object behaves predictably: ... missing 'SENTINEL_MUST_NOT_MATCH' in: ...
AOT console probe: FAIL      EXIT CODE: 1
```

Sentinel reverted.

Solution build 0 warnings / 0 errors; `dotnet test Trellis.slnx -c Release` 7546 passed, 0 failed, 39 skipped. Workflow YAML parsed to confirm validity. Project added to `Trellis.slnx` so it compiles on every build, not just in CI.

## Note on scope

This is deliberately a *probe*, not an example -- it exists to fail the build, and the csproj comment says so, including a warning not to "fix" it by adding a `Trellis.Asp` reference, which would silently defeat the whole thing.
