### PR TITLE
fix: key resource collection name overrides on the emitted resource name

### DIFF
--- a/Trellis.Asp/src/Response/ResourceCollectionNameServiceCollectionExtensions.cs
+++ b/Trellis.Asp/src/Response/ResourceCollectionNameServiceCollectionExtensions.cs
@@ -14,10 +14,11 @@ using Trellis;
 public static class ResourceCollectionNameServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers a single resource-type-to-collection-name override. The <typeparamref name="TResource"/>
-    /// CLR name (with generic backtick suffix stripped via <see cref="ResourceRef.FormatTypeName"/>)
-    /// is used as the lookup key — match the name that <see cref="ResourceRef.For{TResource}(object?)"/>
-    /// emits. Safe under trimming/AOT — does not perform assembly scanning.
+    /// Registers a single resource-type-to-collection-name override. The lookup key is the resource
+    /// name <see cref="ResourceRef.For{TResource}(object?)"/> emits for <typeparamref name="TResource"/>,
+    /// which is the simple CLR name with any generic backtick suffix stripped and any
+    /// <see cref="Maybe{T}"/> wrapper peeled — so registering <c>Maybe&lt;Order&gt;</c> and
+    /// <c>Order</c> produce the same entry. Safe under trimming/AOT — does not perform assembly scanning.
     /// </summary>
     /// <typeparam name="TResource">The CLR resource type whose <see cref="ResourceRef.Type"/> name should map to <paramref name="collectionName"/>.</typeparam>
     /// <param name="services">The service collection.</param>
@@ -28,7 +29,12 @@ public static class ResourceCollectionNameServiceCollectionExtensions
         string collectionName)
     {
         ArgumentNullException.ThrowIfNull(services);
-        return services.AddResourceCollectionName(ResourceRef.FormatTypeName(typeof(TResource)), collectionName);
+
+        // Deriving the key from For<TResource> rather than FormatTypeName(typeof(TResource)) keeps
+        // registration and lookup on one code path. FormatTypeName deliberately does not peel Maybe,
+        // so using it here keyed Maybe<Order> as "Maybe" while lookups arrived as "Order" -- an
+        // override that never matched and never reported why.
+        return services.AddResourceCollectionName(ResourceRef.For<TResource>().Type, collectionName);
     }
 
     /// <summary>

--- a/Trellis.Asp/tests/ResourceCollectionNameRegistrationTests.cs
+++ b/Trellis.Asp/tests/ResourceCollectionNameRegistrationTests.cs
@@ -1,0 +1,76 @@
+namespace Trellis.Asp.Tests;
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Trellis;
+using Trellis.Asp;
+using Xunit;
+
+/// <summary>
+/// Guards the contract that <c>AddResourceCollectionName&lt;TResource&gt;</c> keys overrides on the
+/// same resource-type name <see cref="ResourceRef.For{TResource}(object?)"/> emits. Registration and
+/// lookup are separate code paths, so a divergence produces no error — the override simply never
+/// matches and callers silently fall back to the naive plural.
+/// </summary>
+public sealed class ResourceCollectionNameRegistrationTests
+{
+    private sealed class Person;
+
+    private static ResourceCollectionNameRegistry BuildRegistry(IServiceCollection services) =>
+        services.BuildServiceProvider().GetRequiredService<ResourceCollectionNameRegistry>();
+
+    [Fact]
+    public void AddResourceCollectionName_generic_keys_on_the_name_For_emits()
+    {
+        var services = new ServiceCollection();
+        services.AddResourceCollectionName<Person>("people");
+
+        BuildRegistry(services).Resolve(ResourceRef.For<Person>().Type).Should().Be("people");
+    }
+
+    [Fact]
+    public void AddResourceCollectionName_generic_keys_on_the_name_For_emits_for_Maybe_wrapped_resources()
+    {
+        var services = new ServiceCollection();
+        services.AddResourceCollectionName<Maybe<Person>>("people");
+
+        BuildRegistry(services).Resolve(ResourceRef.For<Maybe<Person>>().Type).Should().Be("people");
+    }
+
+    [Fact]
+    public void AddResourceCollectionName_generic_unwraps_Maybe_to_the_same_key_as_the_bare_resource()
+    {
+        var services = new ServiceCollection();
+        services.AddResourceCollectionName<Maybe<Person>>("people");
+
+        BuildRegistry(services).Resolve(ResourceRef.For<Person>().Type).Should().Be("people");
+    }
+
+    [Fact]
+    public void AddResourceCollectionName_generic_treats_nested_Maybe_as_the_innermost_resource()
+    {
+        var services = new ServiceCollection();
+        services.AddResourceCollectionName<Maybe<Maybe<Person>>>("people");
+
+        BuildRegistry(services).Resolve(ResourceRef.For<Person>().Type).Should().Be("people");
+    }
+
+    [Fact]
+    public void Registering_the_bare_and_Maybe_wrapped_resource_with_the_same_name_does_not_conflict()
+    {
+        var services = new ServiceCollection();
+        services.AddResourceCollectionName<Person>("people");
+        services.AddResourceCollectionName<Maybe<Person>>("people");
+
+        BuildRegistry(services).Resolve(ResourceRef.For<Person>().Type).Should().Be("people");
+    }
+
+    [Fact]
+    public void Unregistered_resource_still_falls_back_to_the_naive_plural()
+    {
+        var services = new ServiceCollection();
+        services.AddResourceCollectionName<Person>("people");
+
+        BuildRegistry(services).Resolve("Order").Should().Be("orders");
+    }
+}

--- a/Trellis.Asp/tests/ResourceCollectionNameRegistrationTests.cs
+++ b/Trellis.Asp/tests/ResourceCollectionNameRegistrationTests.cs
@@ -1,4 +1,4 @@
-namespace Trellis.Asp.Tests;
+﻿namespace Trellis.Asp.Tests;
 
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -419,7 +419,7 @@ The main DI surface for `Trellis.Asp` (in folder `Extensions/`).
 public static class ResourceCollectionNameServiceCollectionExtensions
 ```
 
-Registers `ResourceCollectionNameOverride` entries and the consuming `ResourceCollectionNameRegistry`. The lookup key is `ResourceRef.FormatTypeName` of the resource type, which for ordinary resource types is the same name `ResourceRef.For<TResource>(...)` emits — an override matches only when the two agree. They diverge in one case: `For<TResource>` peels a `Maybe<T>` wrapper before formatting, while `FormatTypeName` deliberately does not, so registering an override for `Maybe<Order>` would key on `Maybe` and never match a `ResourceRef.For<Maybe<Order>>()` that emits `Order`. Register the unwrapped type.
+Registers `ResourceCollectionNameOverride` entries and the consuming `ResourceCollectionNameRegistry`. The generic overload derives its lookup key from `ResourceRef.For<TResource>(...)`, so registration and lookup are guaranteed to agree — including for `Maybe<T>`, which is peeled on both sides (`Maybe<Order>` and `Order` register the same entry, and nested `Maybe<Maybe<Order>>` resolves to `Order`). The string overload keys on the value you pass, for resources named through `ResourceRef.For(string, object?)`. The assembly-scanning overloads key on `ResourceRef.FormatTypeName` of the annotated type.
 
 | Signature | Returns | Description |
 | --- | --- | --- |


### PR DESCRIPTION
## The bug

`AddResourceCollectionName<TResource>` computed its registry key with `ResourceRef.FormatTypeName(typeof(TResource))`, but lookups arrive as `ResourceRef.Type` — the name `ResourceRef.For<TResource>` emitted.

Those two disagree for `Maybe<T>`:

| | peels `Maybe<T>` | strips backtick suffix |
|---|---|---|
| `ResourceRef.For<TResource>()` | yes | yes |
| `ResourceRef.FormatTypeName(type)` | **no** (deliberately) | yes |

So registering an override for `Maybe<Order>` keyed on `"Maybe"`, while every lookup arrived as `"Order"`. The override never matched and callers silently fell back to the naive plural (`type.ToLowerInvariant() + "s"`).

Nothing raised an error — which is what makes it worth fixing. It is a configuration change that appears to take effect and does not.

The method's own XML doc already promised the key would "match the name that `ResourceRef.For<TResource>()` emits", so the code contradicted its documented contract rather than implementing a different one.

## The fix

Derive the key from `ResourceRef.For<TResource>().Type`. Registration and lookup now share a single code path, so they agree **by construction** rather than by convention — the failure mode cannot be reintroduced by editing one side.

```csharp
return services.AddResourceCollectionName(ResourceRef.For<TResource>().Type, collectionName);
```

Consequences:
- `Maybe<Order>` and `Order` register the same entry.
- Nested `Maybe<Maybe<Order>>` resolves to `Order`.
- Non-`Maybe` registrations — the overwhelmingly common case — produce exactly the same key as before.

## Deliberately unchanged

`AddResourceCollectionNames(Assembly)` keeps using `FormatTypeName`. It discovers types annotated with `ResourceCollectionNameAttribute`, which can never be a constructed `Maybe<Order>`, so the asymmetry is unreachable there.

## Tests

New `Trellis.Asp/tests/ResourceCollectionNameRegistrationTests.cs` (6 cases). The three `Maybe` cases fail against the old key and pass with the fix:

- generic registration keys on the name `For` emits (bare and `Maybe`-wrapped)
- `Maybe<Person>` unwraps to the same key as `Person`
- nested `Maybe<Maybe<Person>>` resolves to the innermost resource
- registering bare + wrapped with the same name does not trip the duplicate-override guard
- unregistered resources still fall back to the naive plural

## Validation

- `dotnet build Trellis.slnx -c Release` — 0 warnings, 0 errors
- `dotnet test Trellis.slnx -c Release` — **7591 passed**, 0 failed (+6)
- API reference lint — exit 0; TRLDOC005 + TRLDOC008 audits — exit 0
- `trellis-api-asp.md` updated to describe the new guarantee

Found during the reference-documentation pass in #703, where it was documented as a footgun; documenting a footgun is the weaker fix.