### PR TITLE
Report Money component validation errors at distinct JSON Pointers

### DIFF
--- a/Trellis.Primitives/src/Primitives/Money.cs
+++ b/Trellis.Primitives/src/Primitives/Money.cs
@@ -39,9 +39,23 @@ public class Money : ValueObject
 
     /// <summary>
     /// Creates a Money instance with the specified amount and currency code.
-    /// If <paramref name="fieldName"/> is not provided, amount validation errors use "amount" and currency validation errors use "currencyCode" as the field name.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// <paramref name="fieldName"/> names the <see cref="Money"/> value as a whole, and validation
+    /// errors are reported against a nested JSON Pointer under it — one segment per component, matching
+    /// the serialized shape <c>{ "amount": …, "currency": … }</c>. Passing <c>"price"</c> therefore
+    /// yields <c>/price/amount</c> for amount failures and <c>/price/currency</c> for currency failures,
+    /// so a client can bind each error to the field that produced it. When
+    /// <paramref name="fieldName"/> is omitted the pointers are <c>/amount</c> and <c>/currency</c>.
+    /// A <paramref name="fieldName"/> that is already a JSON Pointer (starts with <c>'/'</c>) is
+    /// composed onto rather than escaped, so <c>"/items/0/price"</c> yields <c>/items/0/price/amount</c>.
+    /// </para>
+    /// <para>
+    /// Use <see cref="TryCreate(decimal, string, string?, string?)"/> instead when the amount and
+    /// currency arrive as sibling fields of a flat payload rather than as a nested object.
+    /// </para>
+    /// <para>
     /// Currency validation is delegated to <see cref="CurrencyCode.TryCreate"/> and is
     /// syntactic only (three ASCII letters per ISO 4217 format; input is case-insensitive,
     /// stored uppercase via <c>ToUpperInvariant</c>). The ISO 4217 active-code list is not
@@ -49,22 +63,56 @@ public class Money : ValueObject
     /// will be accepted. Applications that need to restrict to a specific set of currencies
     /// (e.g., those a payment processor supports, or excluding ISO reserved/test codes)
     /// should layer an allow-list at the application boundary before calling
-    /// <see cref="TryCreate"/>.
+    /// <see cref="TryCreate(decimal, string, string?)"/>.
+    /// </para>
     /// </remarks>
     /// <param name="amount">The monetary amount.</param>
     /// <param name="currencyCode">ISO 4217 currency code (e.g., "USD", "EUR"); case-insensitive.</param>
-    /// <param name="fieldName">Optional field name for validation error messages. If not provided, defaults to "amount" for amount validation and "currencyCode" for currency validation.</param>
+    /// <param name="fieldName">Optional name of the money field itself; component errors are reported beneath it.</param>
     /// <returns>Result containing the Money instance or validation errors.</returns>
-    public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)
+    public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null) =>
+        TryCreateCore(
+            amount,
+            currencyCode,
+            ComponentPointer(fieldName, AmountFieldName),
+            ComponentPointer(fieldName, CurrencyFieldName));
+
+    /// <summary>
+    /// Creates a Money instance whose amount and currency are validated against independently
+    /// named fields, for payloads that carry the two as siblings rather than as a nested object.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload when the incoming document looks like <c>{ "price": 10, "currency": "XX" }</c>.
+    /// The nested-pointer composition performed by <see cref="TryCreate(decimal, string, string?)"/>
+    /// would report such a failure at <c>/price/currency</c> — a location that does not exist in the
+    /// payload. Each argument accepts a simple property name or a full JSON Pointer.
+    /// </remarks>
+    /// <param name="amount">The monetary amount.</param>
+    /// <param name="currencyCode">ISO 4217 currency code (e.g., "USD", "EUR"); case-insensitive.</param>
+    /// <param name="amountFieldName">Field carrying the amount; defaults to <c>amount</c> when null or empty.</param>
+    /// <param name="currencyFieldName">Field carrying the currency; defaults to <c>currency</c> when null or empty.</param>
+    /// <returns>Result containing the Money instance or validation errors.</returns>
+    public static Result<Money> TryCreate(decimal amount, string currencyCode, string? amountFieldName, string? currencyFieldName) =>
+        TryCreateCore(
+            amount,
+            currencyCode,
+            InputPointer.ForProperty(amountFieldName.NormalizeFieldName(AmountFieldName)),
+            InputPointer.ForProperty(currencyFieldName.NormalizeFieldName(CurrencyFieldName)));
+
+    private const string AmountFieldName = "amount";
+    private const string CurrencyFieldName = "currency";
+
+    private static InputPointer ComponentPointer(string? fieldName, string component) =>
+        new(InputPointer.ForProperty(fieldName.NormalizeFieldName(string.Empty)).Path + '/' + component);
+
+    private static Result<Money> TryCreateCore(decimal amount, string currencyCode, InputPointer amountField, InputPointer currencyField)
     {
         using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(nameof(Money) + '.' + nameof(TryCreate));
 
-        var field = fieldName.NormalizeFieldName("amount");
-
         if (amount < 0)
-            return Result.Fail<Money>(Error.InvalidInput.ForField(field, "validation.error", "Amount cannot be negative."));
+            return Result.Fail<Money>(Error.InvalidInput.ForField(amountField, "validation.error", "Amount cannot be negative."));
 
-        return CurrencyCode.TryCreate(currencyCode, fieldName.NormalizeFieldName("currencyCode"))
+        return CurrencyCode.TryCreate(currencyCode, currencyField.Path)
             .Map(currency => new Money(Math.Round(amount, GetDecimalPlaces(currency), MidpointRounding.AwayFromZero), currency));
     }
 
@@ -78,7 +126,7 @@ public class Money : ValueObject
     /// <exception cref="InvalidOperationException">Thrown when amount is negative or currency is invalid.</exception>
     /// <remarks>
     /// Use this method when you know the values are valid (e.g., in tests or with constants).
-    /// For user input, use <see cref="TryCreate"/> instead.
+    /// For user input, use <see cref="TryCreate(decimal, string, string?)"/> instead.
     /// </remarks>
     public static Money Create(decimal amount, string currencyCode) =>
         TryCreate(amount, currencyCode).Match(

--- a/Trellis.Primitives/tests/MoneyTests.cs
+++ b/Trellis.Primitives/tests/MoneyTests.cs
@@ -57,7 +57,7 @@ public class MoneyTests
         // Assert
         result.IsFailure.Should().BeTrue();
         var validation = (Error.InvalidInput)result.UnwrapError();
-        validation.Fields[0].Field.Path.Should().Be("/unitPrice");
+        validation.Fields[0].Field.Path.Should().Be("/unitPrice/currency");
     }
 
     [Fact]
@@ -655,6 +655,72 @@ public class MoneyTests
         var act = () => Money.TryCreate(-1m, "USD", fieldName: "");
 
         act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void TryCreate_without_fieldName_points_amount_failure_at_amount()
+    {
+        var result = Money.TryCreate(-1m, "USD");
+
+        PathOf(result).Should().Be("/amount");
+    }
+
+    [Fact]
+    public void TryCreate_without_fieldName_points_currency_failure_at_currency()
+    {
+        var result = Money.TryCreate(1m, "INVALID");
+
+        PathOf(result).Should().Be("/currency");
+    }
+
+    [Fact]
+    public void TryCreate_with_empty_string_fieldName_falls_back_to_component_defaults()
+    {
+        PathOf(Money.TryCreate(-1m, "USD", fieldName: "")).Should().Be("/amount");
+        PathOf(Money.TryCreate(1m, "INVALID", fieldName: "")).Should().Be("/currency");
+    }
+
+    [Fact]
+    public void TryCreate_with_fieldName_distinguishes_the_two_components()
+    {
+        var amountFailure = PathOf(Money.TryCreate(-1m, "USD", "price"));
+        var currencyFailure = PathOf(Money.TryCreate(1m, "INVALID", "price"));
+
+        amountFailure.Should().Be("/price/amount");
+        currencyFailure.Should().Be("/price/currency");
+        amountFailure.Should().NotBe(currencyFailure);
+    }
+
+    [Fact]
+    public void TryCreate_with_fieldName_camel_cases_the_parent_segment() =>
+        PathOf(Money.TryCreate(-1m, "USD", "UnitPrice")).Should().Be("/unitPrice/amount");
+
+    [Fact]
+    public void TryCreate_with_json_pointer_fieldName_composes_rather_than_escaping() =>
+        PathOf(Money.TryCreate(-1m, "USD", "/items/0/price")).Should().Be("/items/0/price/amount");
+
+    [Fact]
+    public void TryCreate_with_fieldName_containing_pointer_characters_escapes_the_parent_segment() =>
+        PathOf(Money.TryCreate(-1m, "USD", "a/b")).Should().Be("/a~1b/amount");
+
+    [Fact]
+    public void TryCreate_with_per_component_field_names_targets_flat_payload_fields()
+    {
+        PathOf(Money.TryCreate(-1m, "USD", "price", "currency")).Should().Be("/price");
+        PathOf(Money.TryCreate(1m, "INVALID", "price", "isoCurrency")).Should().Be("/isoCurrency");
+    }
+
+    [Fact]
+    public void TryCreate_with_null_per_component_field_names_falls_back_to_component_defaults()
+    {
+        PathOf(Money.TryCreate(-1m, "USD", null, null)).Should().Be("/amount");
+        PathOf(Money.TryCreate(1m, "INVALID", null, null)).Should().Be("/currency");
+    }
+
+    private static string PathOf(Result<Money> result)
+    {
+        result.IsFailure.Should().BeTrue();
+        return ((Error.InvalidInput)result.UnwrapError()).Fields[0].Field.Path;
     }
 
     #endregion

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -327,7 +327,8 @@ public class Money : ValueObject
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)` | `Result<Money>` | Rejects negative amounts. Currency validation is delegated to [`CurrencyCode.TryCreate`](#currencycode) and is syntactic only — three ASCII letters (case-insensitive input; normalized to uppercase). Codes outside the ISO 4217 active list (`XXX`, `XTS`, `ZZZ`, etc.) are accepted because they satisfy the format. Layer an application-level allow-list when active-code enforcement is required. |
+| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? fieldName = null)` | `Result<Money>` | Rejects negative amounts. `fieldName` names the money value as a whole; component failures are reported at nested pointers beneath it (`/price/amount`, `/price/currency`), defaulting to `/amount` and `/currency`. Currency validation is delegated to [`CurrencyCode.TryCreate`](#currencycode) and is syntactic only — three ASCII letters (case-insensitive input; normalized to uppercase). Codes outside the ISO 4217 active list (`XXX`, `XTS`, `ZZZ`, etc.) are accepted because they satisfy the format. Layer an application-level allow-list when active-code enforcement is required. |
+| `public static Result<Money> TryCreate(decimal amount, string currencyCode, string? amountFieldName, string? currencyFieldName)` | `Result<Money>` | Flat-payload overload: names each component independently instead of nesting, for documents that carry amount and currency as siblings. Each argument accepts a simple property name or a full JSON Pointer, and falls back to `amount` / `currency` when null or empty. The last two parameters intentionally have no default values, which keeps this overload out of the set `CompositeValueObjectJsonConverter<Money>` resolves. |
 | `public static Money Create(decimal amount, string currencyCode)` | `Money` | Throwing factory. |
 | `public Result<Money> Add(Money other)` | `Result<Money>` | Requires matching currencies. Throws `ArgumentNullException` when `other` is null. Returns `Error.InvalidInput` on currency mismatch or addition overflow. |
 | `public Result<Money> Subtract(Money other)` | `Result<Money>` | Requires matching currencies and non-negative result. Throws `ArgumentNullException` when `other` is null. |
@@ -470,12 +471,14 @@ Every `TryCreate` overload takes an optional `fieldName`. When it is omitted, th
 | `IpAddress` | `ipAddress` | `TryCreate` |
 | `LanguageCode` | `languageCode` | `TryCreate` |
 | `MonetaryAmount` | **`amount`** — not `monetaryAmount` | `TryCreate` |
-| `Money` | `amount` for the amount, `currencyCode` for the currency component | `TryCreate` |
+| `Money` | `amount` for the amount, `currency` for the currency component | `TryCreate` |
 | `Percentage` | `percentage` | `TryCreate` |
 | `Percentage` | `fraction` | `FromFraction` |
 | `PhoneNumber` | `phoneNumber` | `TryCreate` |
 | `Slug` | `slug` | `TryCreate` |
 | `Url` | `url` | `TryCreate` |
+
+`EmailAddress` and `MonetaryAmount` keep the shorter defaults deliberately: `email` and `amount` are the names those values almost always carry in a payload, so the default is right more often than a type-derived `emailAddress` or `monetaryAmount` would be. Override with `fieldName` in the minority of cases where it isn't.
 
 Pass `fieldName` explicitly whenever the value object is bound to a differently-named request property, so the error key matches the client's payload shape rather than the primitive's own name:
 
@@ -484,7 +487,24 @@ Pass `fieldName` explicitly whenever the value object is bound to a differently-
 var email = EmailAddress.TryCreate(request.BillingEmail, nameof(request.BillingEmail));
 ```
 
-> **`Money` takes a single `fieldName` for two components.** `Money.TryCreate(amount, currencyCode, fieldName)` applies the supplied name to *both* the amount and the currency failure, so an explicit `fieldName` makes the two indistinguishable by key. Only the defaults (`amount` / `currencyCode`) tell them apart — validate the components separately if the client needs to know which one failed.
+> **`Money` reports each component at its own JSON Pointer.** `Money` is the one structured primitive with two independently-validatable components, so `fieldName` names the *money value*, not a single error key, and component failures are reported beneath it — matching the serialized shape `{ "amount": …, "currency": … }`:
+>
+> ```csharp
+> Money.TryCreate(-1m, "USD", "price");      // → /price/amount
+> Money.TryCreate(10m, "INVALID", "price");  // → /price/currency
+> Money.TryCreate(-1m, "USD");               // → /amount
+> ```
+>
+> A `fieldName` that is already a JSON Pointer is composed onto rather than escaped, so `"/items/0/price"` yields `/items/0/price/amount`.
+>
+> When the amount and currency arrive as *siblings* of a flat payload — `{ "price": 10, "currency": "XX" }` — nesting would point at a location the document does not have. Use the four-argument overload to name each component independently:
+>
+> ```csharp
+> // → /price and /currency respectively
+> Money.TryCreate(request.Price, request.Currency, nameof(request.Price), nameof(request.Currency));
+> ```
+>
+> The four-argument overload deliberately has **no default values** on its last two parameters; that is what keeps it out of the overload set `CompositeValueObjectJsonConverter<Money>` resolves, which requires an unambiguous `TryCreate` whose trailing parameters are all optional.
 
 ## Code examples
 


### PR DESCRIPTION
## Problem

`Money` is a structured value object with two independently-validatable components, serialized as `{ "amount": number, "currency": string }`. But `TryCreate` passed the **same** caller-supplied `fieldName` to both validations:

```csharp
var field = fieldName.NormalizeFieldName("amount");
if (amount < 0) return Result.Fail<Money>(Error.InvalidInput.ForField(field, ...));
return CurrencyCode.TryCreate(currencyCode, fieldName.NormalizeFieldName("currencyCode"))
```

So `TryCreate(amount, currency, "price")` reported **both** failures at `/price`. A client receiving a 400 could not tell which component was rejected. The reference docs had this written up as a known limitation with a "validate the components separately" workaround.

## Change

`fieldName` now names the *money value*, and each component failure is reported at a nested RFC 6901 pointer beneath it:

| Call | Amount failure | Currency failure |
| --- | --- | --- |
| `TryCreate(a, c, "price")` | `/price/amount` | `/price/currency` |
| `TryCreate(a, c)` | `/amount` | `/currency` |
| `TryCreate(a, c, "/items/0/price")` | `/items/0/price/amount` | `/items/0/price/currency` |

Composition falls out of `InputPointer.ForProperty`: null or empty yields `Root`, so the defaults and the nested case share a single code path, and a `fieldName` that is already a pointer is composed onto rather than escaped.

### New flat-payload overload

Nesting is wrong when the two arrive as *siblings* — `{ "price": 10, "currency": "XX" }` — because `/price/currency` names a location the document does not have. That would trade an ambiguous pointer for a **misleading** one, so:

```csharp
public static Result<Money> TryCreate(decimal amount, string currencyCode, string? amountFieldName, string? currencyFieldName)
```

Its last two parameters deliberately have **no default values**. `CompositeValueObjectJsonConverter<T>.BuildInvoker` throws `"found multiple ambiguous 'TryCreate' overloads"` when more than one overload matches the primitive prefix with all trailing parameters optional; omitting the defaults keeps this overload out of that set. This is load-bearing, and is called out in both the XML doc and the reference.

## Breaking changes

Authorized as breaking; both change observable 400 payloads.

1. **The currency component default moves `currencyCode` -> `currency`.** The old default named a property that does not exist in the serialized payload, and disagreed with `Money`'s own arithmetic errors (`Add`/`Subtract`/`Sum` already report on `currency`).
2. **Callers passing an explicit `fieldName` now receive nested pointers** instead of the flat key.

## Tests

8 new tests covering both defaults, empty-string `fieldName`, camel-casing of the parent segment, a pointer-shaped `fieldName`, `~1` escaping of a `/` inside a simple name, and both flat-overload paths — plus an explicit assertion that the two components are now **distinguishable**. The one existing test asserting the old collapsed `/unitPrice` was updated to `/unitPrice/currency`; it is the regression witness for the old behaviour.

I also walked the throw-risk inputs (`"/"`, `"~"`, trailing `/`, malformed escape sequences) against `InputPointer`'s validator: no new failure path is introduced — a malformed pointer threw identically before this change.

## Validation

- `dotnet build Trellis.slnx -c Release` — 0 warnings, 0 errors
- `dotnet test Trellis.slnx -c Release` — 7597 passed, 0 failed
- `docs\lint-api-reference.ps1` — exit 0
- completeness + documented-symbol audits — exit 0

## Docs

`trellis-api-primitives.md`: the `Money` signature table gains the new overload and describes nesting on the existing one; the default-field-name row updated; the blockquote that documented the shared-`fieldName` defect as a limitation is replaced with the new semantics and flat-vs-nested guidance. Also recorded the rationale for leaving `EmailAddress` -> `email` and `MonetaryAmount` -> `amount` alone: those defaults match what the values are actually called in a payload more often than type-derived names would.