### PR TITLE
Pin the real provider exception shapes DbExceptionClassifier reflects on

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,6 +65,12 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.8.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.62.1" />
+    <!-- Test-only ADO.NET drivers. DbExceptionClassifier deliberately takes no driver
+         dependency and matches provider exceptions by type name, so these are referenced
+         solely to assert the real types still carry the names and properties it reflects on
+         (see DbExceptionClassifierProviderContractTests). They never ship. -->
+    <PackageVersion Include="Npgsql" Version="10.0.3" />
+    <PackageVersion Include="MySqlConnector" Version="2.6.2" />
     <!-- The Cosmos DB SDK uses Newtonsoft.Json internally but deliberately omits it from its
          dependencies so consumers pin the version. Its build target fails without an explicit
          reference. -->

--- a/Trellis.EntityFrameworkCore/src/DbExceptionClassifier.cs
+++ b/Trellis.EntityFrameworkCore/src/DbExceptionClassifier.cs
@@ -122,7 +122,7 @@ public static class DbExceptionClassifier
         // PostgreSQL: try ConstraintName property
         if (typeName == "PostgresException")
         {
-            var constraintProp = inner.GetType().GetProperty("ConstraintName");
+            var constraintProp = FindProperty(inner.GetType(), "ConstraintName");
             if (constraintProp?.GetValue(inner) is string constraintName && !string.IsNullOrEmpty(constraintName))
                 return $"Constraint: {constraintName}";
         }
@@ -200,7 +200,7 @@ public static class DbExceptionClassifier
     private static bool TryGetSqlServerNumber(Exception ex, out int number)
     {
         number = 0;
-        var prop = ex.GetType().GetProperty("Number");
+        var prop = FindProperty(ex.GetType(), "Number");
         if (prop?.GetValue(ex) is int n)
         {
             number = n;
@@ -213,9 +213,37 @@ public static class DbExceptionClassifier
     private static bool TryGetPostgresSqlState(Exception ex, out string? state)
     {
         state = null;
-        var prop = ex.GetType().GetProperty("SqlState");
+        var prop = FindProperty(ex.GetType(), "SqlState");
         state = prop?.GetValue(ex) as string;
         return state is not null;
+    }
+
+    /// <summary>
+    /// Resolves a public instance property by walking the type hierarchy most-derived first,
+    /// asking each level for its own declarations.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Type.GetProperty(string)"/> throws <see cref="System.Reflection.AmbiguousMatchException"/>
+    /// when a derived type shadows a base property with a different type — which real drivers do:
+    /// <c>MySqlConnector.MySqlException</c> re-declares <c>ErrorCode</c> as an enum over
+    /// <see cref="System.Runtime.InteropServices.ExternalException"/>'s <see cref="int"/>. These
+    /// helpers run inside exception handlers, so an escaping reflection failure would turn a
+    /// classified conflict into an unhandled error.
+    /// </remarks>
+    private static System.Reflection.PropertyInfo? FindProperty(Type type, string name)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            var property = current.GetProperty(
+                name,
+                System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.DeclaredOnly);
+            if (property is not null)
+                return property;
+        }
+
+        return null;
     }
 
     private static bool TryGetMySqlNumber(Exception ex, out int number)
@@ -224,14 +252,14 @@ public static class DbExceptionClassifier
         // MySql.Data.MySqlClient.MySqlException exposes a Number property; MySqlConnector's
         // MySqlException exposes ErrorCode (an enum convertible to int) and Number.
         var type = ex.GetType();
-        var numberProp = type.GetProperty("Number");
+        var numberProp = FindProperty(type, "Number");
         if (numberProp?.GetValue(ex) is int n)
         {
             number = n;
             return true;
         }
 
-        var errorCodeProp = type.GetProperty("ErrorCode");
+        var errorCodeProp = FindProperty(type, "ErrorCode");
         if (errorCodeProp?.GetValue(ex) is { } errorCode)
         {
             try
@@ -251,9 +279,9 @@ public static class DbExceptionClassifier
     private static (string? ConstraintName, string? TableName) ExtractPostgresIdentity(Exception inner)
     {
         var type = inner.GetType();
-        var name = type.GetProperty("ConstraintName")?.GetValue(inner) as string;
-        var table = type.GetProperty("TableName")?.GetValue(inner) as string;
-        var schema = type.GetProperty("SchemaName")?.GetValue(inner) as string;
+        var name = FindProperty(type, "ConstraintName")?.GetValue(inner) as string;
+        var table = FindProperty(type, "TableName")?.GetValue(inner) as string;
+        var schema = FindProperty(type, "SchemaName")?.GetValue(inner) as string;
 
         if (string.IsNullOrEmpty(name))
             name = null;

--- a/Trellis.EntityFrameworkCore/tests/DbExceptionClassifierProviderContractTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/DbExceptionClassifierProviderContractTests.cs
@@ -1,0 +1,330 @@
+﻿namespace Trellis.EntityFrameworkCore.Tests;
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Guards <see cref="DbExceptionClassifier"/> against provider drift.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The classifier deliberately takes no driver dependency and matches provider exceptions by
+/// <see cref="Type.Name"/>, reading error codes through reflection. That trade-off avoids
+/// transitive dependencies on every supported driver, but it means a provider renaming its
+/// exception type — or removing the property the classifier reads — turns a duplicate-key
+/// violation into an unhandled <see cref="DbUpdateException"/> at runtime. It fails open, and
+/// silently.
+/// </para>
+/// <para>
+/// <see cref="DbExceptionClassifierTests"/> cannot catch that: it uses locally-declared fakes
+/// named after the providers, so it asserts the classifier matches strings the tests themselves
+/// supply. These tests reference the <b>real</b> driver types instead (test-only package
+/// references; nothing ships), so a rename or property removal breaks the build on package
+/// upgrade rather than in production.
+/// </para>
+/// <para>
+/// Where a driver exposes a public constructor (PostgreSQL) the real exception is classified
+/// end to end. SQLite goes further and provokes a genuine constraint violation through EF Core
+/// against an in-memory database, so the real driver's real message is parsed. SQL Server and
+/// MySQL expose no public constructor, so those are pinned at the type/property contract level.
+/// </para>
+/// </remarks>
+public class DbExceptionClassifierProviderContractTests
+{
+    #region Real driver type contracts — a rename must break the build
+
+    [Fact]
+    public void SqlServer_exception_still_carries_the_name_and_number_the_classifier_reads()
+    {
+        var type = typeof(Microsoft.Data.SqlClient.SqlException);
+
+        type.Name.Should().Be("SqlException",
+            "DbExceptionClassifier matches SQL Server by this exact type name");
+        DeclaredProperty(type, "Number")!.PropertyType.Should().Be<int>(
+            "the classifier reads Number to match 2601 / 2627 / 547");
+    }
+
+    [Fact]
+    public void Postgres_exception_still_carries_the_name_and_properties_the_classifier_reads()
+    {
+        var type = typeof(Npgsql.PostgresException);
+
+        type.Name.Should().Be("PostgresException",
+            "DbExceptionClassifier matches PostgreSQL by this exact type name");
+        DeclaredProperty(type, "SqlState")!.PropertyType.Should().Be<string>(
+            "the classifier reads SqlState to match 23505 / 23503");
+        DeclaredProperty(type, "ConstraintName")!.PropertyType.Should().Be<string>();
+        DeclaredProperty(type, "TableName")!.PropertyType.Should().Be<string>();
+        DeclaredProperty(type, "SchemaName")!.PropertyType.Should().Be<string>();
+    }
+
+    [Fact]
+    public void Sqlite_exception_still_carries_the_name_the_classifier_reads() =>
+        typeof(SqliteException).Name.Should().Be("SqliteException",
+            "DbExceptionClassifier matches SQLite by this exact type name, then parses the message");
+
+    [Fact]
+    public void MySql_exception_still_carries_the_name_and_number_the_classifier_reads()
+    {
+        var type = typeof(MySqlConnector.MySqlException);
+
+        type.Name.Should().Be("MySqlException",
+            "DbExceptionClassifier matches MySQL/MariaDB by this exact type name");
+        DeclaredProperty(type, "Number")!.PropertyType.Should().Be<int>(
+            "the classifier reads Number to match 1062 / 1451 / 1452");
+    }
+
+    [Fact]
+    public void MySql_exception_shadows_ErrorCode_with_a_different_type()
+    {
+        // Pins the reason the classifier must not use a plain Type.GetProperty("ErrorCode"):
+        // MySqlConnector re-declares ErrorCode as an enum over ExternalException's int, and
+        // reflection reports that as an ambiguous match. This test documents the real shape
+        // that MySqlExceptionWithoutNumber below imitates.
+        var type = typeof(MySqlConnector.MySqlException);
+
+        DeclaredProperty(type, "ErrorCode")!.PropertyType.IsEnum.Should().BeTrue();
+        typeof(ExternalException).GetProperty("ErrorCode")!.PropertyType.Should().Be<int>();
+
+        var ambiguous = () => type.GetProperty("ErrorCode");
+        ambiguous.Should().Throw<AmbiguousMatchException>(
+            "the classifier must resolve shadowed properties per declaring type, not by name alone");
+    }
+
+    #endregion
+
+    #region Real PostgreSQL exceptions — constructed, then classified
+
+    [Fact]
+    public void IsDuplicateKey_RealPostgresException_ReturnsTrue()
+    {
+        var ex = new DbUpdateException("save failed", NewPostgresException("23505"));
+
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsForeignKeyViolation_RealPostgresException_ReturnsTrue()
+    {
+        var ex = new DbUpdateException("save failed", NewPostgresException("23503"));
+
+        DbExceptionClassifier.IsForeignKeyViolation(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDuplicateKey_RealPostgresForeignKeyException_ReturnsFalse()
+    {
+        var ex = new DbUpdateException("save failed", NewPostgresException("23503"));
+
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeFalse(
+            "a foreign-key violation must not be reported as a conflict");
+    }
+
+    [Fact]
+    public void ExtractConstraintIdentity_RealPostgresException_ReadsTypedProperties()
+    {
+        var ex = new DbUpdateException("save failed", NewPostgresException("23505"));
+
+        var (constraintName, tableName) = DbExceptionClassifier.ExtractConstraintIdentity(ex);
+
+        constraintName.Should().Be("ix_users_email");
+        tableName.Should().Be("public.users");
+    }
+
+    #endregion
+
+    #region Real SQLite violations — provoked through EF Core, then classified
+
+    [Fact]
+    public async Task IsDuplicateKey_RealSqliteUniqueViolation_ReturnsTrue()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=True");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = NewProbeContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        context.Users.Add(new ProbeUser { Id = 1, Email = "a@example.com" });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.Users.Add(new ProbeUser { Id = 2, Email = "a@example.com" });
+
+        var act = async () => await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+
+        ex.InnerException.Should().BeOfType<SqliteException>(
+            "the assertions below must run against the driver's real exception, not an EF wrapper");
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeTrue();
+        DbExceptionClassifier.IsForeignKeyViolation(ex).Should().BeFalse();
+        DbExceptionClassifier.ExtractConstraintIdentity(ex).TableName.Should().Be("Users");
+    }
+
+    [Fact]
+    public async Task IsForeignKeyViolation_RealSqliteForeignKeyViolation_ReturnsTrue()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=True");
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+        await using var context = NewProbeContext(connection);
+        await context.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+
+        context.Orders.Add(new ProbeOrder { Id = 1, UserId = 404 });
+
+        var act = async () => await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+
+        ex.InnerException.Should().BeOfType<SqliteException>();
+        DbExceptionClassifier.IsForeignKeyViolation(ex).Should().BeTrue();
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeFalse(
+            "SaveChangesResultAsync checks IsDuplicateKey first, so a false positive here would "
+            + "map a foreign-key violation to 409 Conflict");
+    }
+
+    #endregion
+
+    #region Shadowed ErrorCode — the classifier must not throw out of an exception handler
+
+    [Fact]
+    public void IsDuplicateKey_MySqlExceptionExposingOnlyShadowedErrorCode_ReturnsTrue()
+    {
+        // Drivers that surface the code only as a shadowing enum (the shape pinned above) must
+        // still classify. Reading the property by name alone throws AmbiguousMatchException,
+        // which would escape IsDuplicateKey — called from inside a catch — and turn a 409 into
+        // a 500.
+        var inner = new MySqlException("Error 1062 raised by the server.", MySqlErrorCode.DuplicateKeyEntry);
+        var ex = new DbUpdateException("save failed", inner);
+
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsForeignKeyViolation_MySqlExceptionExposingOnlyShadowedErrorCode_ReturnsTrue()
+    {
+        var inner = new MySqlException("Error 1452 raised by the server.", MySqlErrorCode.NoReferencedRow2);
+        var ex = new DbUpdateException("save failed", inner);
+
+        DbExceptionClassifier.IsForeignKeyViolation(ex).Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static PropertyInfo? DeclaredProperty(Type type, string name)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            var property = current.GetProperty(
+                name,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            if (property is not null)
+                return property;
+        }
+
+        return null;
+    }
+
+    private static Npgsql.PostgresException NewPostgresException(string sqlState) =>
+        new(
+            messageText: "constraint violation",
+            severity: "ERROR",
+            invariantSeverity: "ERROR",
+            sqlState: sqlState,
+            detail: null!,
+            hint: null!,
+            position: 0,
+            internalPosition: 0,
+            internalQuery: null!,
+            where: null!,
+            schemaName: "public",
+            tableName: "users",
+            columnName: "email",
+            dataTypeName: null!,
+            constraintName: "ix_users_email",
+            file: null!,
+            line: null!,
+            routine: null!);
+
+    private static ProbeContext NewProbeContext(SqliteConnection connection) =>
+        new(new DbContextOptionsBuilder<ProbeContext>()
+            .UseSqlite(connection)
+            .IgnoreManyServiceProvidersCreatedWarning()
+            .Options);
+
+    private sealed class ProbeContext(DbContextOptions<ProbeContext> options) : DbContext(options)
+    {
+        public DbSet<ProbeUser> Users => Set<ProbeUser>();
+
+        public DbSet<ProbeOrder> Orders => Set<ProbeOrder>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ProbeUser>(b =>
+            {
+                b.ToTable("Users");
+                b.HasKey(u => u.Id);
+                b.Property(u => u.Id).ValueGeneratedNever();
+                b.HasIndex(u => u.Email).IsUnique();
+            });
+
+            modelBuilder.Entity<ProbeOrder>(b =>
+            {
+                b.ToTable("Orders");
+                b.HasKey(o => o.Id);
+                b.Property(o => o.Id).ValueGeneratedNever();
+                b.HasOne<ProbeUser>().WithMany().HasForeignKey(o => o.UserId);
+            });
+        }
+    }
+
+    private sealed class ProbeUser
+    {
+        public int Id { get; set; }
+
+        public string Email { get; set; } = string.Empty;
+    }
+
+    private sealed class ProbeOrder
+    {
+        public int Id { get; set; }
+
+        public int UserId { get; set; }
+    }
+
+    private enum MySqlErrorCode
+    {
+        DuplicateKeyEntry = 1062,
+        NoReferencedRow2 = 1452,
+    }
+
+    /// <summary>
+    /// Imitates the real <c>MySqlConnector.MySqlException</c> shape pinned by
+    /// <see cref="MySql_exception_shadows_ErrorCode_with_a_different_type"/>: named
+    /// <c>MySqlException</c>, no <c>Number</c>, and <c>ErrorCode</c> re-declared as an enum
+    /// over <see cref="ExternalException"/>'s <see cref="int"/>. The real type cannot be
+    /// constructed — it exposes no public constructor.
+    /// </summary>
+    private sealed class MySqlException : ExternalException
+    {
+        public MySqlException()
+        {
+        }
+
+        public MySqlException(string message) : base(message)
+        {
+        }
+
+        public MySqlException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public MySqlException(string message, int errorCode) : base(message, errorCode)
+        {
+        }
+
+        public MySqlException(string message, MySqlErrorCode errorCode) : base(message) => ErrorCode = errorCode;
+
+        public new MySqlErrorCode ErrorCode { get; }
+    }
+
+    #endregion
+}

--- a/Trellis.EntityFrameworkCore/tests/DbExceptionClassifierProviderContractTests.cs
+++ b/Trellis.EntityFrameworkCore/tests/DbExceptionClassifierProviderContractTests.cs
@@ -133,6 +133,46 @@ public class DbExceptionClassifierProviderContractTests
         tableName.Should().Be("public.users");
     }
 
+    [Fact]
+    public void ExtractConstraintDetail_RealPostgresException_ReadsTypedConstraintName()
+    {
+        var ex = new DbUpdateException("save failed", NewPostgresException("23505"));
+
+        DbExceptionClassifier.ExtractConstraintDetail(ex).Should().Be("Constraint: ix_users_email");
+    }
+
+    #endregion
+
+    #region Provider-named exceptions missing the expected property must fall through, not throw
+
+    // The classifier reads error codes reflectively, so a driver that drops or renames a property
+    // must degrade to message matching rather than throw out of the caller's catch block.
+
+    [Fact]
+    public void IsDuplicateKey_SqlExceptionWithoutNumber_FallsBackToMessageMatching()
+    {
+        var ex = new DbUpdateException("save failed", new SqlException("Cannot insert duplicate key row."));
+
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeTrue(
+            "the generic 'duplicate key' fallback still applies when Number is absent");
+    }
+
+    [Fact]
+    public void IsDuplicateKey_SqlExceptionWithoutNumberOrRecognisableMessage_ReturnsFalse()
+    {
+        var ex = new DbUpdateException("save failed", new SqlException("Timeout expired."));
+
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDuplicateKey_MySqlExceptionWithoutNumberOrErrorCode_ReturnsFalse()
+    {
+        var ex = new DbUpdateException("save failed", new WithoutErrorCode.MySqlException("Timeout expired."));
+
+        DbExceptionClassifier.IsDuplicateKey(ex).Should().BeFalse();
+    }
+
     #endregion
 
     #region Real SQLite violations — provoked through EF Core, then classified
@@ -288,6 +328,48 @@ public class DbExceptionClassifierProviderContractTests
         public int Id { get; set; }
 
         public int UserId { get; set; }
+    }
+
+    /// <summary>
+    /// Named <c>SqlException</c> but with no <c>Number</c> property, standing in for a driver that
+    /// dropped or renamed it. The real <c>Microsoft.Data.SqlClient.SqlException</c> exposes no
+    /// public constructor, so its shape is pinned by contract test instead.
+    /// </summary>
+    private sealed class SqlException : Exception
+    {
+        public SqlException()
+        {
+        }
+
+        public SqlException(string message) : base(message)
+        {
+        }
+
+        public SqlException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Container giving a second CLR type the name <c>MySqlException</c> — this one exposing
+    /// neither <c>Number</c> nor <c>ErrorCode</c>, so both reflective lookups miss.
+    /// </summary>
+    private static class WithoutErrorCode
+    {
+        internal sealed class MySqlException : Exception
+        {
+            public MySqlException()
+            {
+            }
+
+            public MySqlException(string message) : base(message)
+            {
+            }
+
+            public MySqlException(string message, Exception innerException) : base(message, innerException)
+            {
+            }
+        }
     }
 
     private enum MySqlErrorCode

--- a/Trellis.EntityFrameworkCore/tests/Trellis.EntityFrameworkCore.Tests.csproj
+++ b/Trellis.EntityFrameworkCore/tests/Trellis.EntityFrameworkCore.Tests.csproj
@@ -16,6 +16,9 @@
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+	  <!-- Test-only: real provider exception types for the classifier contract tests. -->
+	  <PackageReference Include="Npgsql" />
+	  <PackageReference Include="MySqlConnector" />
 	</ItemGroup>
 
 </Project>

--- a/docs/docfx_project/api_reference/trellis-api-efcore.md
+++ b/docs/docfx_project/api_reference/trellis-api-efcore.md
@@ -454,6 +454,19 @@ public static class DbExceptionClassifier
 | `public static string? ExtractConstraintDetail(DbUpdateException ex)` | `string?` | Returns a logging-oriented detail string such as the PostgreSQL constraint name or the provider message. |
 | `public static (string? ConstraintName, string? TableName) ExtractConstraintIdentity(DbUpdateException ex)` | `(string?, string?)` | Returns the constraint name and the qualified table the violated constraint belongs to, parsed from the inner provider exception. Typed extraction first for PostgreSQL (`Npgsql.PostgresException.ConstraintName` / `TableName` / `SchemaName` via reflection so the package stays provider-agnostic; output is `"schema.table"` when both are present), then message-based parsing for SQL Server 2627 / 2601 / FK 547 (both `FOREIGN KEY` and parent-side `REFERENCE` constraint forms), SQLite `UNIQUE constraint failed: <Table>.<Column>` / `PRIMARY KEY` (constraint name is `null` because SQLite does not name the constraint), and MySQL `Duplicate entry '...' for key '<table>.<key>'`. Returns `(null, null)` on any unexpected exception so telemetry extraction never breaks the caller. Used by `SaveChangesResultAsync`, `SaveChangesWithRetryAsync`, and `TryInsertUniqueAsync` to populate `Error.Conflict.ConstraintName` / `ConstraintTableName`. |
 
+> **Provider drift is guarded by tests, not by types.** Matching exceptions by name keeps the
+> package free of driver dependencies, but it fails open: a provider that renames its exception
+> type would silently turn a duplicate-key violation into an unhandled `DbUpdateException`.
+> `DbExceptionClassifierProviderContractTests` references the real drivers (test-only) and pins
+> the type names and the properties read by reflection, so a rename breaks the build instead.
+> PostgreSQL and SQLite are additionally classified end to end against real exception instances.
+>
+> Properties are resolved by walking the type hierarchy most-derived first rather than by name
+> alone, because a driver may shadow a base property with a different type — `MySqlConnector`'s
+> `MySqlException` re-declares `ErrorCode` as an enum over `ExternalException.ErrorCode`, and a
+> plain name lookup raises `AmbiguousMatchException`. These helpers run inside `catch` blocks, so
+> an escaping reflection failure would convert a `409 Conflict` into a `500`.
+
 ### `TrellisPersistenceMappingException`
 
 ```csharp


### PR DESCRIPTION
Closes backlog item 5.

## The defect

`DbExceptionClassifier` matches provider exceptions by `inner.GetType().Name` and reads error codes by reflection, deliberately, so `Trellis.EntityFrameworkCore` takes no dependency on any driver. The trade-off is documented and reasonable, but it **fails open**: a provider that renamed its exception type would turn a duplicate-key violation into an unhandled `DbUpdateException`, and `SaveChangesResultAsync` would surface **500 instead of 409**.

Nothing caught that. `DbExceptionClassifierTests` declares its own fakes named after the providers:

```csharp
private class SqlException : Exception { public int Number { get; } ... }
"SqliteException" => new SqliteException(innerException.Message),
```

so it asserts the classifier matches strings **the tests themselves supply**. Every one of them stays green through any rename.

## The guard

`DbExceptionClassifierProviderContractTests` references the real drivers and pins the type names plus every property read by reflection, so drift breaks the build on package upgrade rather than in production.

| Provider | Coverage | Why |
| --- | --- | --- |
| PostgreSQL | Real `PostgresException` constructed and classified (23505 / 23503), typed identity extraction asserted | public constructor available |
| SQLite | **Real** unique and FK violations provoked through EF Core against an in-memory database | no server needed; the driver's own message is parsed |
| SQL Server | Type name + `Number` pinned | `SqlException` has no public constructor |
| MySQL/MariaDB | Type name + `Number` pinned, plus the `ErrorCode` shadowing shape | `MySqlException` has no public constructor |

Npgsql and MySqlConnector are **test-only**. Verified rather than assumed — the packed `.nupkg` was inspected and carries neither.

The FK tests also assert the violation is **not** classified as a duplicate, because `SaveChangesResultAsync` checks `IsDuplicateKey` first, so a false positive there maps an FK violation to 409.

## Latent bug the guards exposed

`MySqlConnector.MySqlException` re-declares `ErrorCode` as an enum shadowing `ExternalException`'s `int`, so:

```
Type.GetProperty("ErrorCode") -> AmbiguousMatchException
```

It is unreachable today only because `Number` is found first. But the `ErrorCode` path exists precisely for drivers that do not surface `Number`, and the surrounding `catch` covers only `FormatException` / `InvalidCastException` / `OverflowException`. Reaching it throws out of `IsDuplicateKey` — which runs **inside a catch block** — converting a 409 into a 500.

All reflection lookups now resolve through `FindProperty`, walking the hierarchy most-derived-first with `BindingFlags.DeclaredOnly`. Both regression tests were verified failing before the fix and passing after.

## Validation

- `dotnet build` / `dotnet test Trellis.slnx -c Release` — pass, 0 warnings
- `docs\lint-api-reference.ps1` — exit 0
- completeness + documented-symbol audits — exit 0
- shipped `Trellis.EntityFrameworkCore` nupkg dependency list inspected — no driver packages
- `gpt-5.5` code review — no findings