### PR TITLE
build: pin the packaging metadata that every package was repeating

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,8 +248,12 @@ jobs:
     - name: Build docs
       run: docfx docs/docfx_project/docfx.json
   
+    # Runs on pull requests too, not just pushes to main. Package validation - including the
+    # API-compatibility check against the last published release - executes during pack, so
+    # gating this on the push would mean a breaking change first surfaced after merge, or at
+    # publish time. Only the artifact upload stays push-only.
     - name: Pack
-      if: ${{ success() && !github.base_ref }}
+      if: ${{ success() }}
       run: dotnet pack --no-build --verbosity normal -c Release -o artifacts/
         
     - name: Upload artifacts

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,15 @@
     <RepositoryUrl>https://github.com/xavierjohn/Trellis.git</RepositoryUrl>
     <PackageProjectUrl>https://xavierjohn.github.io/Trellis/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!--
+      NUGET_README.md, not README.md. Each package carries both: README.md documents the
+      package for someone reading the repository, NUGET_README.md is the trimmed listing
+      copy nuget.org renders. Every package sets this identically, so it belongs here - and
+      declaring the default as README.md while all 23 overrode it meant a new package that
+      forgot to override would fail pack with NU5039, because README.md is never packed.
+    -->
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
   </PropertyGroup>
   
   <PropertyGroup Label="Build">
@@ -78,6 +86,22 @@
     <!-- Detect breaking changes in library APIs -->
     <EnablePackageValidation>true</EnablePackageValidation>
 
+    <!--
+      Compare against the last published release rather than only across frameworks. Without a
+      baseline, EnablePackageValidation checks internal consistency and silently says nothing
+      about compatibility with what consumers already have installed - which is the question
+      worth asking before a push to nuget.org.
+
+      Breaking changes are permitted in this framework; the gate exists to make them
+      deliberate, not to forbid them. When one is intended, record it in the owning package's
+      CompatibilitySuppressions.xml (rebuild with /p:ApiCompatGenerateSuppressionFile=true)
+      so the break is reviewable in the diff instead of invisible.
+
+      Bump this in the same commit that publishes a release. Leaving it behind means comparing
+      against an ever-older surface and re-reporting breaks that were already accepted.
+    -->
+    <PackageValidationBaselineVersion>3.0.0-alpha.455</PackageValidationBaselineVersion>
+
     <!-- Release hygiene (ga-07) -->
     <!-- DotNet.ReproducibleBuilds bundles Microsoft.SourceLink.GitHub and sets
          Deterministic, ContinuousIntegrationBuild (under CI), EmbedUntrackedSources.
@@ -101,6 +125,17 @@
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'false' ">
     <None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="\" />
+
+    <!--
+      Packages live at Trellis.<Name>/src, so the listing README sits one level up. Guarded by
+      Exists rather than by a packability check: Examples and generator projects sit at other
+      depths and simply have no such file, while a real package missing one still fails pack
+      loudly through NU5039 rather than shipping an empty listing page.
+    -->
+    <None Include="$(MSBuildProjectDirectory)\..\NUGET_README.md"
+          Condition=" Exists('$(MSBuildProjectDirectory)\..\NUGET_README.md') "
+          Pack="true"
+          PackagePath="\" />
   </ItemGroup>
 
   <ImportGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/Trellis.Analyzers/src/Trellis.Analyzers.csproj
+++ b/Trellis.Analyzers/src/Trellis.Analyzers.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
-  <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
   <Description>Roslyn analyzers for Trellis library. Enforces proper Result and Maybe handling patterns at compile time.</Description>
   <PackageTags>trellis;roslyn;analyzers;functional;ddd;result;maybe;railway-oriented-programming</PackageTags>
   <TrellisApiRefName>analyzers</TrellisApiRefName>
@@ -38,7 +37,6 @@
   <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->
   <ItemGroup>
     <None Include="$(TargetPath)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <!--

--- a/Trellis.Asp.ApiVersioning/src/Trellis.Asp.ApiVersioning.csproj
+++ b/Trellis.Asp.ApiVersioning/src/Trellis.Asp.ApiVersioning.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>asp-apiversioning</TrellisApiRefName>
     <Description>API-versioning helpers for Trellis.Asp. Adds a WithVersionedRoute() extension on HttpResponseOptionsBuilder that auto-injects the api-version route value into Location headers, so responses round-trip the requested version under query/header API versioning. Chain after CreatedAtRoute(...), CreatedAtAction(...), or WithLocation(...). Skips injection for [ApiVersionNeutral] endpoints, URL-segment-versioned routes, and endpoints with no ApiVersionMetadata (composes cleanly in unversioned and mixed-versioned hosts).</Description>
     <PackageTags>trellis;api-versioning;asp;versioning;result;railway-oriented;functional-programming</PackageTags>
@@ -8,7 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />

--- a/Trellis.Asp.Idempotency.Cosmos/src/Trellis.Asp.Idempotency.Cosmos.csproj
+++ b/Trellis.Asp.Idempotency.Cosmos/src/Trellis.Asp.Idempotency.Cosmos.csproj
@@ -1,13 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>asp-idempotency-cosmos</TrellisApiRefName>
     <Description>Cosmos DB-backed IIdempotencyStore for Trellis.Asp. Safe across instances and process restarts: reservations are claimed with an atomic CreateItem (409 on duplicate id) and every subsequent mutation is an ETag-conditional replace or delete, so Session consistency cannot cause a double execution. Enforces TTL and reservation-timeout expiry in-process rather than trusting Cosmos DB's best-effort background sweep. Verified by the Trellis.Testing.Idempotency conformance suite.</Description>
     <PackageTags>trellis;idempotency;cosmosdb;azure;asp;http;idempotency-key;distributed;result;railway-oriented</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />

--- a/Trellis.Asp/src/Trellis.Asp.csproj
+++ b/Trellis.Asp/src/Trellis.Asp.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>ASP.NET Core integration for Trellis. Result-to-HTTP response mapping, scalar value validation, JSON converters (with bundled AOT source generator), and ASP.NET actor providers (Claims, Entra, Easy Auth, Development) for Trellis.Authorization.</Description>
     <PackageTags>trellis;aspnetcore;mvc;minimal-api;web-api;railway-oriented;result;http;error-handling;authorization;actor;entra;claims;easy-auth</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -11,7 +10,6 @@
     <InternalsVisibleTo Include="Trellis.Asp.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
   </ItemGroup>

--- a/Trellis.Authorization/src/Trellis.Authorization.csproj
+++ b/Trellis.Authorization/src/Trellis.Authorization.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Lightweight authorization primitives for Trellis. Provides Actor, IActorProvider, IAuthorize, IAuthorizeResource of TResource, IResourceLoader, and ResourceLoaderById types that integrate with the Trellis Result type system. No dependency on any mediator or web framework.</Description>
     <PackageTags>trellis;authorization;actor;permissions;result;railway-oriented;functional-programming</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -39,7 +38,6 @@
     <Compile Remove="Generated/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />

--- a/Trellis.Core/src/Trellis.Core.csproj
+++ b/Trellis.Core/src/Trellis.Core.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>
       Railway Oriented Programming is a coding concept that involves using a library's built-in functions to control program execution flow based on success or error track.
       By doing so, functional code can be written that allows for chaining of functions without the need for error checking.
@@ -13,7 +12,6 @@
     <TrellisShipsApiReferenceSet>true</TrellisShipsApiReferenceSet>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Trellis.Primitives.Tests" />

--- a/Trellis.EntityFrameworkCore.Inbox/src/Trellis.EntityFrameworkCore.Inbox.csproj
+++ b/Trellis.EntityFrameworkCore.Inbox/src/Trellis.EntityFrameworkCore.Inbox.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Transactional inbox for Trellis — the consume-side complement to the outbox. Makes integration-event consumption idempotent: redeliveries of the same message are deduplicated by message id within the consumer's unit of work, so a handler's side effects commit exactly once. EF Core reference store.</Description>
     <PackageTags>trellis;inbox;efcore;integration-events;idempotency;ddd;reliability;messaging</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -12,7 +11,6 @@
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\src\Trellis.EntityFrameworkCore.csproj" />

--- a/Trellis.EntityFrameworkCore.Outbox/src/Trellis.EntityFrameworkCore.Outbox.csproj
+++ b/Trellis.EntityFrameworkCore.Outbox/src/Trellis.EntityFrameworkCore.Outbox.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Transactional outbox for Trellis. Atomically captures aggregate domain events to an EF Core table in the same transaction as the aggregate change, then relays them to Trellis domain-event handlers — durable, at-least-once, in-process dispatch.</Description>
     <PackageTags>trellis;outbox;efcore;domain-events;ddd;reliability;messaging;railway-oriented</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -15,7 +14,6 @@
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.EntityFrameworkCore\src\Trellis.EntityFrameworkCore.csproj" />

--- a/Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj
+++ b/Trellis.EntityFrameworkCore/src/Trellis.EntityFrameworkCore.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>EF Core integration for Trellis. Convention-based value converter registration for Trellis primitives, Result-returning SaveChanges wrappers, Maybe/Result query extensions, and provider-agnostic database exception classification.</Description>
     <PackageTags>trellis;efcore;entity-framework-core;value-converters;railway-oriented;result;maybe;ddd;domain-driven-design</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -18,7 +17,6 @@
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Authorization\src\Trellis.Authorization.csproj" />

--- a/Trellis.FluentValidation/src/Trellis.FluentValidation.csproj
+++ b/Trellis.FluentValidation/src/Trellis.FluentValidation.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Convert fluent validation errors to Trellis Validation errors.</Description>
     <PackageTags>trellis;validation;fluentvalidation;railway-oriented;result;error-handling;ddd</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -8,7 +7,6 @@
     <TrellisApiRefName>fluentvalidation</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" />

--- a/Trellis.Http.Abstractions/src/Trellis.Http.Abstractions.csproj
+++ b/Trellis.Http.Abstractions/src/Trellis.Http.Abstractions.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>http-abstractions</TrellisApiRefName>
     <Description>Transport-aware error types and conditional-request helpers shared by Trellis.Asp (server) and Trellis.Http (client). Hosts the HttpError closed union, ETag/precondition vocabulary, authentication challenges, retry advice, and representation metadata.</Description>
     <PackageTags>trellis;http;abstractions;errors;etag;rfc-9110;rfc-9457;result;railway-oriented</PackageTags>
@@ -8,7 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />

--- a/Trellis.Http/src/Trellis.Http.csproj
+++ b/Trellis.Http/src/Trellis.Http.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>HTTP client extensions for Railway Oriented Programming. Provides fluent extension methods to handle HttpResponseMessage with Result and Maybe monads, including error handling for specific status codes and JSON deserialization.</Description>
     <PackageTags>trellis;http;httpclient;railway-oriented;result;maybe;functional-programming;error-handling;json</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -8,7 +7,6 @@
     <TrellisApiRefName>http</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />

--- a/Trellis.Mediator.FluentValidation/src/Trellis.Mediator.FluentValidation.csproj
+++ b/Trellis.Mediator.FluentValidation/src/Trellis.Mediator.FluentValidation.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Mediator pipeline adapter that plugs FluentValidation validators into the Trellis Mediator validation stage. Open-generic IMessageValidator&lt;TMessage&gt; that resolves every IValidator&lt;TMessage&gt; registered in DI and aggregates failures into a single Error.InvalidInput response.</Description>
     <PackageTags>trellis;mediator;validation;fluentvalidation;pipeline;cqrs;railway-oriented;result;ddd</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -8,7 +7,6 @@
     <TrellisApiRefName>mediator-fluentvalidation</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" />

--- a/Trellis.Mediator/src/Trellis.Mediator.csproj
+++ b/Trellis.Mediator/src/Trellis.Mediator.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Result-aware pipeline behaviors for martinothamar/Mediator. Provides validation, authorization, logging, tracing, and exception handling behaviors that understand Trellis Result types and short-circuit correctly.</Description>
     <PackageTags>trellis;mediator;cqrs;pipeline;result;railway-oriented;validation;authorization;functional-programming</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -8,7 +7,6 @@
     <TrellisApiRefName>mediator</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Authorization\src\Trellis.Authorization.csproj" />

--- a/Trellis.Messaging.AzureServiceBus/src/Trellis.Messaging.AzureServiceBus.csproj
+++ b/Trellis.Messaging.AzureServiceBus/src/Trellis.Messaging.AzureServiceBus.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Azure Service Bus transport for Trellis — the wire between the transactional outbox and the deduplicating inbox. Publishes integration events with the outbox row id as the Service Bus MessageId so redeliveries stay idempotent end to end, and consumes them back into the inbox dispatcher.</Description>
     <PackageTags>trellis;azure-service-bus;messaging;integration-events;outbox;inbox;idempotency;ddd;reliability</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -13,7 +12,6 @@
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />

--- a/Trellis.Persistence.Abstractions/src/Trellis.Persistence.Abstractions.csproj
+++ b/Trellis.Persistence.Abstractions/src/Trellis.Persistence.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>persistence-abstractions</TrellisApiRefName>
     <Description>Store-agnostic persistence contracts for Trellis: the unit-of-work commit boundary and the idempotent-consumer inbox store SPIs (dedup record and resume checkpoint). Implement these over EF Core, Dapper, ADO, Cosmos DB, or any store — they depend only on Trellis.Core.</Description>
     <PackageTags>trellis;persistence;abstractions;unit-of-work;inbox;idempotency;spi;result</PackageTags>
@@ -9,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Trellis.Primitives/src/Trellis.Primitives.csproj
+++ b/Trellis.Primitives/src/Trellis.Primitives.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>
       Infrastructure and ready-to-use implementations for primitive value objects in Domain-Driven Design. Includes base classes (RequiredString, RequiredGuid) with source generation, plus EmailAddress with RFC 5322 validation. Eliminates primitive obsession with strongly-typed domain primitives.
     </Description>
@@ -10,7 +9,6 @@
     <TrellisApiRefName>primitives</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Core\src\Trellis.Core.csproj" />

--- a/Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj
+++ b/Trellis.ServiceDefaults/src/Trellis.ServiceDefaults.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Opinionated service composition defaults for Trellis web services. Provides a tiered builder that wires ASP integration, Mediator behaviors, FluentValidation, resource authorization, actor providers, and EF Core Unit of Work in canonical order.</Description>
     <PackageTags>trellis;service-defaults;composition;aspnetcore;cqrs;mediator;entity-framework-core;fluentvalidation</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -11,7 +10,6 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Trellis.Asp\src\Trellis.Asp.csproj" />

--- a/Trellis.StateMachine/src/Trellis.StateMachine.csproj
+++ b/Trellis.StateMachine/src/Trellis.StateMachine.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <Description>Wraps the Stateless library's Fire() method to return Result instead of throwing on invalid transitions, converting known invalid-transition exceptions into failure results for Railway Oriented Programming.</Description>
     <PackageTags>trellis;stateless;state-machine;railway-oriented;result;functional-programming;error-handling</PackageTags>
     <IsAotCompatible>true</IsAotCompatible>
@@ -8,7 +7,6 @@
     <TrellisApiRefName>statemachine</TrellisApiRefName>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Stateless" />

--- a/Trellis.Testing.AspNetCore/src/Trellis.Testing.AspNetCore.csproj
+++ b/Trellis.Testing.AspNetCore/src/Trellis.Testing.AspNetCore.csproj
@@ -14,7 +14,6 @@
     <PackageId>Trellis.Testing.AspNetCore</PackageId>
     <Description>ASP.NET Core integration test utilities for Trellis - WebApplicationFactory helpers, DI service replacement, fake time providers, and MSAL token acquisition</Description>
     <PackageTags>trellis;functional-programming;testing;aspnetcore;integration-testing;webapplicationfactory;ddd;railway-oriented-programming</PackageTags>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>testing-aspnetcore</TrellisApiRefName>
   </PropertyGroup>
 
@@ -32,7 +31,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Trellis.Testing.Idempotency/src/Trellis.Testing.Idempotency.csproj
+++ b/Trellis.Testing.Idempotency/src/Trellis.Testing.Idempotency.csproj
@@ -23,7 +23,6 @@
     <PackageId>Trellis.Testing.Idempotency</PackageId>
     <Description>Executable conformance suite for Trellis IIdempotencyStore implementations - inherit one class to prove a Redis, Cosmos DB, EF Core, or bespoke store satisfies the reserve, replay, takeover, and abandon contract</Description>
     <PackageTags>trellis;testing;idempotency;conformance;contract-tests;aspnetcore;redis;cosmosdb;http</PackageTags>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>testing-idempotency</TrellisApiRefName>
   </PropertyGroup>
 
@@ -37,7 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Trellis.Testing.Worker/src/Trellis.Testing.Worker.csproj
+++ b/Trellis.Testing.Worker/src/Trellis.Testing.Worker.csproj
@@ -14,7 +14,6 @@
     <PackageId>Trellis.Testing.Worker</PackageId>
     <Description>Integration-test harness for BackgroundService workers built on Trellis - prewired IHost, FakeTimeProvider, TestActorProvider, domain-event capture, and tick-completion primitives</Description>
     <PackageTags>trellis;functional-programming;testing;backgroundservice;worker;integration-testing;hosting;domain-events;ddd</PackageTags>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>testing-worker</TrellisApiRefName>
   </PropertyGroup>
 
@@ -31,7 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Trellis.Testing/src/Trellis.Testing.csproj
+++ b/Trellis.Testing/src/Trellis.Testing.csproj
@@ -14,7 +14,6 @@
     <PackageId>Trellis.Testing</PackageId>
     <Description>FluentAssertions extensions and test doubles for Trellis - assert Result, Maybe, and Error types with readable fluent syntax</Description>
     <PackageTags>trellis;functional-programming;testing;assertions;fluent-assertions;ddd;railway-oriented-programming;result;maybe;test-utilities</PackageTags>
-    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <TrellisApiRefName>testing-reference</TrellisApiRefName>
   </PropertyGroup>
 
@@ -28,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../NUGET_README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Two publishing gaps found while checking whether the framework was ready to push to nuget.org. Neither blocked a release; both made the next one riskier than it needed to be.

## `PackageReadmeFile` default was dead, and a trap

`Directory.Build.props` defaulted it to `README.md`, while all 23 packages overrode it to `NUGET_README.md` — each pairing that override with its own copy of the `<None Include>`. The two files are different documents: `README.md` is repository-facing, `NUGET_README.md` is the trimmed listing copy nuget.org renders.

So the default was not merely unused. A new package that inherited it would fail `pack` with **NU5039**, because `README.md` is never packed. Flipping the default alone would not have fixed that — the `<None Include>` is per-project too, so a new package would still need to know the incantation.

Both now live in `Directory.Build.props`, guarded by `Exists` so projects at other depths (Examples, generators) are unaffected while a real package missing its README still fails loudly. 46 lines of duplication removed.

## `EnablePackageValidation` had no baseline

It was on, which checks a package's internal consistency and says **nothing** about compatibility with what consumers already have installed — the only question worth asking before a push. Baseline pinned to the last published release, `3.0.0-alpha.455`, after confirming all 23 packages exist at that version.

Breaking changes remain permitted here; the gate makes them deliberate rather than forbidding them. Intentional breaks are recorded in `CompatibilitySuppressions.xml` via `/p:ApiCompatGenerateSuppressionFile=true`, so they are reviewable in the diff instead of invisible.

## Pack now runs on pull requests

Package validation executes **during pack**, and pack was gated on `!github.base_ref` — pushes to `main` only. The gate above would therefore have first fired *after* merge, or at publish time: the two most expensive moments to learn about a breaking change. Artifact upload stays push-only.

## Validation

A clean pack proves nothing on its own here — "no warnings" is indistinguishable from "validation never ran". Both controls were run:

- A bogus `PackageValidationBaselineVersion` fails to resolve (NU1102), proving the property is honoured.
- Demoting a public type to `internal` is caught as **CP0001** against the real published `alpha.455` package, proving breaks are actually detected.

That makes the clean pack meaningful: it establishes there are **no API breaks** between `alpha.455` and now.

Also verified: 23/23 packages pack with 0 errors and 0 NU warnings, and every one still contains `NUGET_README.md` and `icon.png`. Full solution build 0/0, test suite green, doc lint clean.
