### PR TITLE
Correct the asset-suppression note in the API-reference targets

### DIFF
--- a/build/Trellis.ApiReference.Payload.targets
+++ b/build/Trellis.ApiReference.Payload.targets
@@ -46,10 +46,13 @@
   <!--
     This file declares payload but carries no copy logic, so it is inert unless Trellis.Core's
     Trellis.ApiReference.targets is also imported. That import can be suppressed without any
-    error - ExcludeAssets="build" or a PrivateAssets set covering build on the Trellis.Core
-    reference - and the result would be a silent no-op: items declared, nothing consuming them,
-    no documentation delivered, build green. Warn instead, since a satellite author debugging
-    "my reference never lands" has nothing else to go on.
+    error - ExcludeAssets="buildTransitive" or "all" on the Trellis.Core reference - and the
+    result would be a silent no-op: items declared, nothing consuming them, no documentation
+    delivered, build green. Note that the copy logic is packed under BOTH build\ and
+    buildTransitive\, so the NuGet default of making `build` private (which surfaces as
+    exclude="Build,Analyzers" on the packed dependency) does NOT suppress it - buildTransitive
+    is a distinct asset group and still flows to transitive consumers. Warn instead, since a
+    satellite author debugging "my reference never lands" has nothing else to go on.
 
     Warning rather than error: excluding build assets is a legitimate consumer choice, and the
     opt-out below is the supported way to turn the whole mechanism off deliberately.
@@ -57,6 +60,6 @@
   <Target Name="_WarnTrellisApiReferenceCopyLogicMissing"
           BeforeTargets="Build"
           Condition="'@(TrellisApiReference)' != '' AND '$(TrellisApiReferenceCopyLogicPresent)' != 'true' AND '$(TrellisDisableApiReferenceSync)' != 'true' AND '$(DesignTimeBuild)' != 'true' AND '$(BuildingForLiveUnitTesting)' != 'true'">
-    <Warning Text="Trellis API reference payload was declared but the copy logic is missing, so no documentation will be delivered to .github/. The copy logic lives in Trellis.ApiReference.targets, which ships with Trellis.Core. Either reference Trellis.Core with its build assets intact (check ExcludeAssets/PrivateAssets), or - if the package declaring this payload has no Trellis.Core dependency at all - that package must pack Trellis.ApiReference.targets alongside its payload. Set TrellisDisableApiReferenceSync=true to silence this deliberately." />
+    <Warning Text="Trellis API reference payload was declared but the copy logic is missing, so no documentation will be delivered to .github/. The copy logic lives in Trellis.ApiReference.targets, which ships with Trellis.Core. Either reference Trellis.Core with its buildTransitive assets intact (check ExcludeAssets/PrivateAssets for buildTransitive or all), or - if the package declaring this payload has no Trellis.Core dependency at all - that package must pack Trellis.ApiReference.targets alongside its payload. Set TrellisDisableApiReferenceSync=true to silence this deliberately." />
   </Target>
 </Project>

--- a/build/Trellis.ApiReference.targets
+++ b/build/Trellis.ApiReference.targets
@@ -27,11 +27,14 @@
   -->
   <!--
     Marker for satellite packages: build/Trellis.ApiReference.Payload.targets declares payload
-    items but carries no copy logic, and relies on this file arriving with Trellis.Core. If Core's
-    build assets are suppressed (ExcludeAssets="build", PrivateAssets covering build, and so on)
-    the items would be declared with nothing to consume them and the docs would silently fail to
-    appear. Payload.targets warns on that, and needs this property to tell it apart from a healthy
-    build.
+    items but carries no copy logic, and relies on this file arriving with Trellis.Core. This
+    file is packed under BOTH build\ and buildTransitive\, so the NuGet default of making
+    `build` private - which surfaces as exclude="Build,Analyzers" on the packed dependency -
+    does NOT suppress it: buildTransitive is a distinct asset group and still flows to
+    transitive consumers. Suppressing it takes ExcludeAssets="buildTransitive" or "all" on the
+    Trellis.Core reference. In that case the items would be declared with nothing to consume
+    them and the docs would silently fail to appear. Payload.targets warns on that, and needs
+    this property to tell it apart from a healthy build.
   -->
   <PropertyGroup>
     <TrellisApiReferenceCopyLogicPresent>true</TrellisApiReferenceCopyLogicPresent>


### PR DESCRIPTION
## What

Corrects a factually wrong explanatory comment in `build/Trellis.ApiReference.targets` and `build/Trellis.ApiReference.Payload.targets`. **Comments only — no behaviour change.**

## Why it matters

Both files said the API-reference copy logic could be suppressed with:

> `ExcludeAssets="build"` or a `PrivateAssets` set covering `build`

That is wrong in the dangerous direction: it describes the **default** configuration as a failure mode, so anyone debugging doc delivery would suspect the one thing that is actually fine.

The copy logic is packed under **both** `build\` and `buildTransitive\`. NuGet makes `build` private by default, which surfaces as `exclude="Build,Analyzers"` on the packed dependency — but `buildTransitive` is a distinct asset group that the default does **not** cover, so it still flows to transitive consumers. Actually suppressing the mechanism takes `ExcludeAssets="buildTransitive"` or `"all"`.

## Evidence

Found while porting this mechanism into `xavierjohn/Trellis.Microservices`, and confirmed by A/B test rather than by reading:

- A consumer referencing only a payload-only package received the full first-party doc set (30 files) **with** the dependency carrying `exclude="Build,Analyzers"`.
- The delivered set was identical **with and without** `PrivateAssets="none"` on the intermediate `ProjectReference` — proving that workaround was a no-op and that `buildTransitive` flows regardless. (That experiment was reverted downstream as a result.)

Scenario 5 of `build/test-apireference-payload.ps1` — *"the first-party set arrived via a transitive Trellis.Core"* — already covers this path. The full probe passes, all 5 scenarios.

## Note

`Trellis.ApiReference.targets` is copied verbatim into downstream repos, so the same correction is being applied there in lockstep; the two copies remain byte-identical apart from a BOM.