### PR TITLE
fix: pack API reference docs at a clean trellis/ path on every platform

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -124,7 +124,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'false' ">
-    <None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="/" />
 
     <!--
       Packages live at Trellis.<Name>/src, so the listing README sits one level up. Guarded by
@@ -135,7 +135,7 @@
     <None Include="$(MSBuildProjectDirectory)\..\NUGET_README.md"
           Condition=" Exists('$(MSBuildProjectDirectory)\..\NUGET_README.md') "
           Pack="true"
-          PackagePath="\" />
+          PackagePath="/" />
   </ItemGroup>
 
   <ImportGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -19,11 +19,19 @@
     embedding a copy would recreate exactly the staleness described above. They declare
     their payload with build/Trellis.ApiReference.Payload.targets and rely on the copy
     logic shipped here, so the ~200-line directory walk lives in one place.
+
+    PackagePath uses forward slashes deliberately. On Windows a trailing backslash in
+    PackagePath="trellis\" is recognized as a directory marker and the doc lands at
+    trellis/<name>.md. On Linux the backslash is not a separator: it normalizes to
+    "trellis/" and NuGet then appends its own, so the doc lands at the malformed
+    "trellis//<name>.md". That still satisfies a trellis/*.md glob and still delivers,
+    which is why the defect survived a casual check and reached published packages.
+    Scenario 6 of build/test-apireference-payload.ps1 holds this line.
   -->
   <ItemGroup Condition="'$(TrellisShipsApiReferenceSet)' == 'true'">
     <None Include="$(MSBuildThisFileDirectory)docs\docfx_project\api_reference\*.md"
           Exclude="$(MSBuildThisFileDirectory)docs\docfx_project\api_reference\completeness-report.md"
-          Pack="true" PackagePath="trellis\" />
+          Pack="true" PackagePath="trellis/" />
   </ItemGroup>
 
   <!--
@@ -34,14 +42,14 @@
   -->
   <ItemGroup Condition="'$(TrellisShipsOwnApiReference)' == 'true' AND '$(TrellisApiRefName)' != ''">
     <None Include="$(MSBuildThisFileDirectory)docs\docfx_project\api_reference\trellis-api-$(TrellisApiRefName).md"
-          Pack="true" PackagePath="trellis\" />
+          Pack="true" PackagePath="trellis/" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TrellisShipsApiReferenceSet)' == 'true' OR '$(TrellisShipsOwnApiReference)' == 'true'">
     <None Include="$(MSBuildThisFileDirectory)build\Trellis.ApiReference.targets"
-          Pack="true" PackagePath="build\$(PackageId).targets" />
+          Pack="true" PackagePath="build/$(PackageId).targets" />
     <None Include="$(MSBuildThisFileDirectory)build\Trellis.ApiReference.targets"
-          Pack="true" PackagePath="buildTransitive\$(PackageId).targets" />
+          Pack="true" PackagePath="buildTransitive/$(PackageId).targets" />
   </ItemGroup>
 
 

--- a/build/test-apireference-payload.ps1
+++ b/build/test-apireference-payload.ps1
@@ -16,6 +16,7 @@
       3. Fallback creates .github        - no .github inside the repo means one is created at root.
       4. TrellisApiReferenceRoot         - explicit override wins over the walk.
       5. TrellisDisableApiReferenceSync  - opts out entirely.
+      6. Packed layout                   - docs land at a clean trellis/<name>.md on every platform.
 #>
 [CmdletBinding()]
 param(
@@ -124,9 +125,9 @@ function New-SatellitePackage {
     <PackageReference Include="Trellis.Core" Version="$CoreVersion" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="trellis/$DocName" Pack="true" PackagePath="trellis\" />
-    <None Include="Payload.targets" Pack="true" PackagePath="build\Trellis.SatelliteProbe.targets" />
-    <None Include="Payload.targets" Pack="true" PackagePath="buildTransitive\Trellis.SatelliteProbe.targets" />
+    <None Include="trellis/$DocName" Pack="true" PackagePath="trellis/" />
+    <None Include="Payload.targets" Pack="true" PackagePath="build/Trellis.SatelliteProbe.targets" />
+    <None Include="Payload.targets" Pack="true" PackagePath="buildTransitive/Trellis.SatelliteProbe.targets" />
   </ItemGroup>
 </Project>
 "@ | Set-Content -Path (Join-Path $Path 'Satellite.csproj') -Encoding utf8
@@ -305,6 +306,66 @@ try {
         -Condition ($s5Docs -contains $satelliteDoc)
     Assert-Condition -Scenario 'satellite' -Because 'the first-party set arrived via a transitive Trellis.Core' `
         -Condition ($s5Docs -contains 'trellis-api-efcore-outbox.md')
+
+    # ------------------------------------------------------------- Scenario 6: packed layout
+    # A trailing backslash in PackagePath="trellis\" is a directory marker on Windows, so the doc
+    # lands at trellis/<name>.md. On Linux the backslash is not a separator: it normalizes to
+    # "trellis/" and NuGet appends its own, producing the malformed "trellis//<name>.md". That
+    # still satisfies a trellis/*.md glob and still delivers, which is why every scenario above
+    # stays green either way and the defect reached published packages unnoticed.
+    #
+    # Two assertions, because neither alone is sufficient. The packed-entry check is the real
+    # behaviour but can only go red on Linux, so on a developer's Windows machine it is blind.
+    # The declaration check is platform-independent and is what actually holds the line locally.
+    Write-Host "`nScenario 6 - packed layout is clean on every platform"
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
+    try {
+        $packedDocs = @($archive.Entries | ForEach-Object { $_.FullName } | Where-Object { $_ -like '*trellis-api-*.md' })
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $malformed = @($packedDocs | Where-Object { $_ -notmatch '^trellis/[^/]+\.md$' })
+    Assert-Condition -Scenario 'layout' -Because 'every packed doc sits at exactly trellis/<name>.md' `
+        -Condition ($packedDocs.Count -gt 0 -and $malformed.Count -eq 0)
+    if ($malformed.Count -gt 0) {
+        Write-Host "        malformed entries: $($malformed -join ', ')" -ForegroundColor Red
+    }
+
+    # Parse the XML rather than scanning text. A line-based regex cannot see the single-quoted
+    # attribute form (PackagePath='trellis\') or the <PackagePath>trellis\</PackagePath> metadata
+    # element, and it would flag the comments in these files that quote the malformed value on
+    # purpose. XDocument handles all three correctly and gives line numbers via IXmlLineInfo.
+    #
+    # Property indirection - PackagePath="$(SomeVar)" where SomeVar holds a backslash - is not
+    # statically visible here; the packed-entry assertion above is what covers that case.
+    $declarations = @(
+        Get-ChildItem -Path $repoRoot -Recurse -File -Include '*.csproj', '*.props', '*.targets' |
+            Where-Object { $_.FullName -notmatch '[\\/](bin|obj)[\\/]' } |
+            ForEach-Object {
+                $file = $_
+                $document = [System.Xml.Linq.XDocument]::Load($file.FullName, [System.Xml.Linq.LoadOptions]::SetLineInfo)
+                $relative = $file.FullName.Substring($repoRoot.Path.Length + 1)
+
+                $nodes = @()
+                $nodes += @($document.Descendants() | Where-Object { $_.Name.LocalName -eq 'PackagePath' })
+                $nodes += @($document.Descendants().Attributes() | Where-Object { $_.Name.LocalName -eq 'PackagePath' })
+
+                foreach ($node in $nodes) {
+                    if ($node.Value -like '*\*') {
+                        "${relative}:$(([System.Xml.IXmlLineInfo]$node).LineNumber) -> PackagePath=$($node.Value)"
+                    }
+                }
+            }
+    )
+    Assert-Condition -Scenario 'layout' -Because 'no PackagePath contains a backslash' `
+        -Condition ($declarations.Count -eq 0)
+    if ($declarations.Count -gt 0) {
+        Write-Host "        backslash PackagePath at: $($declarations -join ', ')" -ForegroundColor Red
+    }
 }
 finally {
     $env:NUGET_PACKAGES = $script:originalNuGetPackages


### PR DESCRIPTION
`PackagePath` separators are platform-dependent in a way that hides the defect on Windows.

A trailing backslash in `PackagePath="trellis\"` is recognized as a **directory marker** on Windows, so the doc packs to `trellis/<name>.md`. On Linux the backslash is **not** a separator: it normalizes to `trellis/` and NuGet then appends its own, so the doc packs to the malformed `trellis//<name>.md`.

That malformed path still satisfies the `trellis/*.md` glob the copy logic uses, so documentation is still delivered and every functional test stays green. Nothing asserted the exact entry path, so the defect reached published packages.

Confirmed from nuget.org's own bytes:

| Package | Packed path |
| --- | --- |
| `Trellis.Core` 3.0.0-alpha.458 | `trellis//trellis-api-*.md` (all 27) |
| `Trellis.Microservices.Abstractions` 0.1.0-alpha.72 | `trellis//trellis-api-*.md` |
| `Trellis.ResourceNaming.Abstractions` 0.1.0-preview.12 | `trellis/trellis-api-resourcenaming.md` |

ResourceNaming is the control: it already uses forward slashes and packs cleanly from the same Linux CI.

## The fix

Converts every `PackagePath` in the repository to forward slashes, including the root marker `PackagePath="\"` used for `icon.png` and `NUGET_README.md`. That root form is **not** actually broken today — verified from published bytes that both land at the package root — but a single rule ("no backslashes in `PackagePath`") is easier to hold than "no trailing backslash, except the root one", and it matches the sibling `Trellis.ResourceNaming` repo.

## The guard

Adds **Scenario 6** to `build/test-apireference-payload.ps1`, with two assertions because neither alone is sufficient:

1. **Every packed doc sits at exactly `trellis/<name>.md`.** The real behaviour — but it can only fail on Linux, so it is blind on a developer's Windows machine.
2. **No `PackagePath` contains a backslash.** Platform-independent, so this is what actually holds the line locally.

The declaration check **parses the XML** rather than scanning text. A line-based regex missed two of three planted violations — the single-quoted attribute form `PackagePath='trellis\'` and the `<PackagePath>trellis\</PackagePath>` metadata element — and it would also have flagged the comments that quote the malformed value on purpose to explain the defect. `XDocument` handles all of these and supplies line numbers through `IXmlLineInfo`.

Property indirection (`PackagePath="$(SomeVar)"` where the variable holds a backslash) is not statically visible; assertion 1 covers that case on Linux.

## Validation

- Declaration check goes **red** on the unfixed tree (4 sites) and green after
- Catches planted single-quoted and metadata-element violations at the correct line numbers; correctly ignores prose inside `<!-- -->`
- Packed output re-verified: `NUGET_README.md` and `icon.png` still at package root, `build/`, `buildTransitive/`, `trellis/` all correct, no double slashes or backslashes
- All 6 probe scenarios pass
- `dotnet build Trellis.slnx -c Release` — 0 errors

## Note

This changes packed output, so the fix reaches nuget.org only on the next publish. Already-published packages keep `trellis//`, which is harmless since delivery works either way.

A companion PR applies the same fix and guard to `Trellis.Microservices`.