### PR TITLE
chore: drop the shebang from test-apireference-payload.ps1

### DIFF
--- a/build/test-apireference-payload.ps1
+++ b/build/test-apireference-payload.ps1
@@ -1,5 +1,4 @@
-﻿#!/usr/bin/env pwsh
-<#
+﻿<#
 .SYNOPSIS
     Probes the API-reference doc delivery mechanism end to end: pack a real package, restore it
     into a scratch consumer outside this repository, build, and assert what lands in .github/.


### PR DESCRIPTION
Follow-up to #713, which merged before this cleanup could be added to it.

`build/test-apireference-payload.ps1` is UTF-8 with BOM per `.github/copilot-instructions.md`, so Linux's `binfmt_script` handler never sees `#!` as the literal first two bytes and the shebang cannot work on Linux or macOS. It implied the script was directly executable when it is not.

CI invokes it through pwsh, so nothing depended on it. Dropping the shebang rather than the BOM keeps the repository convention, and matches `docs/lint-api-reference.ps1` and `docs/audit-stale-docs.ps1`, which are BOM-encoded with no shebang. The comment-based help immediately below still documents the script.

Raised in review on xavierjohn/Trellis.Microservices#57 and fixed there in the same way.

An audit of every `.ps1` in the three related repositories found:

| File | BOM | Shebang |
| --- | --- | --- |
| `Trellis` `build/test-apireference-payload.ps1` | yes | yes -> **fixed here** |
| `Trellis` `docs/audit-doc-freshness.ps1` | yes | yes -> pre-existing, left alone |
| `Trellis.Microservices` `build/test-package-layout.ps1` | yes | yes -> fixed in that repo |
| `Trellis.ResourceNaming` `build/test-apireference-packaging.ps1` | no | yes -> already valid |

`audit-doc-freshness.ps1` is untouched by this change, so I have left it as a separate cleanup rather than widening the diff.

Validation: the probe passes all 6 scenarios locally, and `Get-Help` still resolves the synopsis, confirming the comment-based help was not disturbed.