### PR TITLE
feat: let a declaration site override its validation reason code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,74 @@ vocabulary, and renaming them would change dispatch, not just presentation.
 **The vocabulary freezes on release.** Adding a code later is additive and safe; narrowing an existing one
 degrades through namespace fallback rather than breaking a catalog entry a client already recognises.
 
+### Added — naming a failure in the application's own vocabulary
+
+The frozen vocabulary above is the framework's, and freezing it constrains *Trellis*, not the application. An
+application whose clients already speak a catalog of its own should not have to choose between Trellis's names
+and its own, so this release adds two ways to override a reason code at the declaration site. Neither is
+encouraged or discouraged: no analyzer pressures either choice, and the framework code stays the default.
+
+**Constraint attributes carry a `Code`.** `[Range]`, `[StringLength]`, `[NotDefault]`, `[Positive]`,
+`[NonNegative]`, `[Negative]` and `[NonPositive]` each take an optional `Code` that replaces the framework
+reason code on the resulting `FieldViolation`:
+
+```csharp
+[StringLength(8, MinimumLength = 3, Code = "account.reference.length")]
+public partial class AccountReference : RequiredString<AccountReference>;
+```
+
+`[Trim]` gets none, because trimming normalizes and cannot fail. The four sign attributes share `[Range]`'s
+slot, since they synthesize into the same range emission. Two consequences are stated rather than solved:
+`[Range].Code` renames **both** directional failures, and the null check is never overridable — it belongs to no
+attribute and always reports `value.not-null`. An empty or whitespace `Code` is the new generator error
+**TRLS060**, because a blank code names nothing and would reach the wire where a client expects a catalog key.
+
+**`ValidateAdditional` gained a four-argument overload** that can name its own failure instead of reporting
+`error.unspecified`:
+
+```csharp
+static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode);
+```
+
+The generator emits whichever declaration you implemented, so existing three-argument implementations compile
+and behave exactly as before. Leaving `errorCode` unset falls back to `error.unspecified`. Declaring both
+overloads is **TRLS061** — the generator emits one defining declaration, so the other implementation would fail
+with a compiler error that names no Trellis concept.
+
+### Added — `ValidationArgsOptions`, the opt-in for validator args Trellis cannot classify
+
+`ValidationArgsProjection` publishes machine-readable operands only for validators whose placeholders Trellis
+can vouch for, which means a rule Trellis did not write — a `Must()` calling
+`context.MessageFormatter.AppendArgument(...)`, or any validator behind a custom `WithErrorCode` — emitted no
+args at all. `ValidationArgsOptions.AllowArgs(errorCode, placeholderNames)` supplies the knowledge Trellis
+lacks:
+
+```csharp
+services.Configure<ValidationArgsOptions>(options => options.AllowArgs("MinimumAge", "MinAge"));
+```
+
+`AddTrellisFluentValidation()` now calls `AddOptions<ValidationArgsOptions>()`, so the Mediator adapter always
+resolves the configured instance; the standalone `ToResult` / `ValidateToResult` / `ValidateToResultAsync`
+helpers have no container to read from and take the same object through an optional `argsOptions` parameter.
+
+An explicit opt-in satisfies the **template** half of the containment gate without consulting the template — the
+template check defends against a placeholder Trellis *guessed* was safe, and a custom validator has no
+language-manager entry for it to consult, so leaving it in force would make the opt-in inert. **The message half
+still holds**, so an opted-in arg still cannot carry anything the client's own message did not. The opt-in only
+ever widens, and `PropertyValue` / `PropertyPath` can never be re-admitted: `AllowArgs` throws rather than
+silently dropping them.
+
+Generated `[StringLength]` violations now also carry `totalLength` alongside `minLength` / `maxLength`, matching
+what the FluentValidation adapter already emitted for the same failure. Omitting it was a producer disagreement,
+which is precisely what the vocabulary exists to remove.
+
+### Changed — `ValidateToResultAsync` parameter order
+
+`ValidationArgsOptions? argsOptions` was inserted **before** `CancellationToken cancellationToken`, because
+CA1068 requires the cancellation token to be last. A call site that passed the token positionally as the fourth
+argument no longer compiles; name it (`cancellationToken:`) to fix.
+
+
 ### Added — `Trellis.Messaging.AzureServiceBus`, the wire between the outbox and the inbox
 
 Trellis shipped both ends of reliable cross-service messaging — a transactional outbox that stages integration

--- a/Examples/CookbookSnippets/Recipe01_CrudAggregate.cs
+++ b/Examples/CookbookSnippets/Recipe01_CrudAggregate.cs
@@ -53,9 +53,9 @@ public sealed class Order : Aggregate<OrderId>
     // Combine aggregates per-field errors into a single Error.InvalidInput; Map
     // constructs the aggregate from the tuple of validated non-null values.
     public static Result<Order> TryCreate(OrderId? id, Money? total, ActorId? ownerId) =>
-        id.ToResult(Error.InvalidInput.ForField("id", "validation.error", "Order id is required."))
-            .Combine(total.ToResult(Error.InvalidInput.ForField("total", "validation.error", "Total is required.")))
-            .Combine(ownerId.ToResult(Error.InvalidInput.ForField("ownerId", "validation.error", "Owner id is required.")))
+        id.ToResult(Error.InvalidInput.ForField("id", ValidationCodes.ValueNotNull, "Order id is required."))
+            .Combine(total.ToResult(Error.InvalidInput.ForField("total", ValidationCodes.ValueNotNull, "Total is required.")))
+            .Combine(ownerId.ToResult(Error.InvalidInput.ForField("ownerId", ValidationCodes.ValueNotNull, "Owner id is required.")))
             .Map((id, total, ownerId) => new Order(id) { Total = total, Status = OrderStatus.Draft, OwnerId = ownerId });
 
     // Exercises the protected `DomainEvents` member inherited from Aggregate<TId>.

--- a/Examples/CookbookSnippets/Recipe13_OwnedValueObject.cs
+++ b/Examples/CookbookSnippets/Recipe13_OwnedValueObject.cs
@@ -82,9 +82,9 @@ public sealed partial class Customer : Aggregate<CustomerId>
     }
 
     public static Result<Customer> TryCreate(CustomerId? id, string? name, ShippingAddress? shipping) =>
-        id.ToResult(Error.InvalidInput.ForField("id", "validation.error", "Customer id is required."))
-            .Combine(name.EnsureNotNullOrWhiteSpace(Error.InvalidInput.ForField("name", "required", "Name is required.")))
-            .Combine(shipping.ToResult(Error.InvalidInput.ForField("shipping", "validation.error", "Shipping address is required.")))
+        id.ToResult(Error.InvalidInput.ForField("id", ValidationCodes.ValueNotNull, "Customer id is required."))
+            .Combine(name.EnsureNotNullOrWhiteSpace(Error.InvalidInput.ForField("name", ValidationCodes.ValueNotEmpty, "Name is required.")))
+            .Combine(shipping.ToResult(Error.InvalidInput.ForField("shipping", ValidationCodes.ValueNotNull, "Shipping address is required.")))
             .Map((id, name, shipping) => new Customer(id, name, shipping));
 }
 

--- a/Examples/CookbookSnippets/Recipe16_UnitOfWork.cs
+++ b/Examples/CookbookSnippets/Recipe16_UnitOfWork.cs
@@ -27,7 +27,7 @@ public sealed class Order : Aggregate<OrderId>
     private Order(OrderId id) : base(id) { }
 
     public static Result<Order> TryCreate(Money? total) =>
-        total.ToResult(Error.InvalidInput.ForField("total", "validation.error", "Total is required."))
+        total.ToResult(Error.InvalidInput.ForField("total", ValidationCodes.ValueNotNull, "Total is required."))
             .Map(t => new Order(OrderId.NewUniqueV4()) { Total = t });
 }
 

--- a/Examples/CookbookSnippets/Recipe17_DomainEvents.cs
+++ b/Examples/CookbookSnippets/Recipe17_DomainEvents.cs
@@ -39,8 +39,8 @@ public sealed class Order : Aggregate<OrderId>
     private Order(OrderId id) : base(id) { }
 
     public static Result<Order> TryCreate(OrderId? id, Money? total) =>
-        id.ToResult(Error.InvalidInput.ForField("id", "validation.error", "Order id is required."))
-            .Combine(total.ToResult(Error.InvalidInput.ForField("total", "validation.error", "Total is required.")))
+        id.ToResult(Error.InvalidInput.ForField("id", ValidationCodes.ValueNotNull, "Order id is required."))
+            .Combine(total.ToResult(Error.InvalidInput.ForField("total", ValidationCodes.ValueNotNull, "Total is required.")))
             .Map((id, total) => new Order(id) { Total = total });
 
     public Result<Order> Submit(TimeProvider clock)

--- a/Examples/EfCoreExample/Entities/Order.cs
+++ b/Examples/EfCoreExample/Entities/Order.cs
@@ -40,7 +40,7 @@ public class Order : Aggregate<OrderId>
     /// </summary>
     public static Result<Order> TryCreate(CustomerId customerId) =>
         customerId.ToResult()
-            .Ensure(id => id != null, Error.InvalidInput.ForField(nameof(customerId), "validation.error", "Customer ID is required"))
+            .Ensure(id => id != null, Error.InvalidInput.ForField(nameof(customerId), ValidationCodes.ValueNotNull, "Customer ID is required"))
             .Map(_ => new Order(customerId));
 
     /// <summary>
@@ -51,7 +51,7 @@ public class Order : Aggregate<OrderId>
         this.ToResult()
             // RequiredEnum provides the CanModify property
             .Ensure(_ => State.CanModify, Error.InvalidInput.ForRule("order.not-modifiable", $"Cannot modify order in '{State}' state"))
-            .Ensure(_ => quantity > 0, Error.InvalidInput.ForField(nameof(quantity), "validation.error", "Quantity must be positive"))
+            .Ensure(_ => quantity > 0, Error.InvalidInput.ForField(nameof(quantity), ValidationCodes.ValueGreaterThan, "Quantity must be positive"))
             .Tap(_ => _lines.Add(new OrderLine(Id, product, quantity)));
 
     /// <summary>

--- a/Examples/EfCoreExample/Entities/Product.cs
+++ b/Examples/EfCoreExample/Entities/Product.cs
@@ -27,8 +27,8 @@ public class Product : Entity<ProductId>
     /// </summary>
     public static Result<Product> TryCreate(string? name, decimal price, int stockQuantity) =>
         ProductName.TryCreate(name, nameof(name))
-            .Ensure(_ => price > 0, Error.InvalidInput.ForField(nameof(price), "validation.error", "Price must be greater than zero"))
-            .Ensure(_ => stockQuantity >= 0, Error.InvalidInput.ForField(nameof(stockQuantity), "validation.error", "Stock cannot be negative"))
+            .Ensure(_ => price > 0, Error.InvalidInput.ForField(nameof(price), ValidationCodes.ValueGreaterThan, "Price must be greater than zero"))
+            .Ensure(_ => stockQuantity >= 0, Error.InvalidInput.ForField(nameof(stockQuantity), ValidationCodes.ValueGreaterThanOrEqual, "Stock cannot be negative"))
             .Map(productName => new Product(
                 ProductId.NewUniqueV4(),
                 productName,
@@ -40,7 +40,7 @@ public class Product : Entity<ProductId>
     /// </summary>
     public Result<Product> ReduceStock(int quantity) =>
         this.ToResult()
-            .Ensure(_ => quantity > 0, Error.InvalidInput.ForField(nameof(quantity), "validation.error", "Quantity must be positive"))
-            .Ensure(_ => StockQuantity >= quantity, Error.InvalidInput.ForField(nameof(quantity), "validation.error", $"Insufficient stock. Available: {StockQuantity}"))
+            .Ensure(_ => quantity > 0, Error.InvalidInput.ForField(nameof(quantity), ValidationCodes.ValueGreaterThan, "Quantity must be positive"))
+            .Ensure(_ => StockQuantity >= quantity, Error.InvalidInput.ForField(nameof(quantity), "product.insufficient-stock", $"Insufficient stock. Available: {StockQuantity}"))
             .Tap(_ => StockQuantity -= quantity);
 }

--- a/Examples/EfCoreExample/Enums/OrderState.cs
+++ b/Examples/EfCoreExample/Enums/OrderState.cs
@@ -48,7 +48,7 @@ public partial class OrderState : RequiredEnum<OrderState>
 
         return Result.Fail<OrderState>(Error.InvalidInput.ForField(
             "state",
-            "validation.error",
+            "order.invalid-transition",
             $"Cannot transition from '{this}' to '{newState}'. Allowed transitions: {string.Join(", ", AllowedTransitions)}"));
     }
 }

--- a/Examples/TestingPatterns/DomainDrivenDesignSamplesTests.cs
+++ b/Examples/TestingPatterns/DomainDrivenDesignSamplesTests.cs
@@ -21,7 +21,7 @@ public class DomainDrivenDesignSamplesTests
 
         public static Result<CustomerId> TryCreate(Guid value, string? fieldName = null) =>
             value == Guid.Empty
-                ? Result.Fail<CustomerId>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "customerId"), "validation.error") { Detail = "Customer ID cannot be empty" })))
+                ? Result.Fail<CustomerId>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "customerId"), ValidationCodes.ValueNotDefault) { Detail = "Customer ID cannot be empty" })))
                 : Result.Ok(new CustomerId(value));
 
         public static Result<CustomerId> TryCreate(string? value, string? fieldName = null) =>
@@ -41,7 +41,7 @@ public class DomainDrivenDesignSamplesTests
 
         public static Result<OrderId> TryCreate(Guid value, string? fieldName = null) =>
             value == Guid.Empty
-                ? Result.Fail<OrderId>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "orderId"), "validation.error") { Detail = "Order ID cannot be empty" })))
+                ? Result.Fail<OrderId>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "orderId"), ValidationCodes.ValueNotDefault) { Detail = "Order ID cannot be empty" })))
                 : Result.Ok(new OrderId(value));
 
         public static Result<OrderId> TryCreate(string? value, string? fieldName = null) =>
@@ -58,8 +58,8 @@ public class DomainDrivenDesignSamplesTests
         private ProductId(string value) : base(value) { }
 
         public static Result<ProductId> TryCreate(string? value, string? fieldName = null) =>
-            value.ToResult(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "productId"), "validation.error") { Detail = "Product ID cannot be empty" })))
-                .Ensure(v => !string.IsNullOrWhiteSpace(v), new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "productId"), "validation.error") { Detail = "Product ID cannot be empty" })))
+            value.ToResult(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "productId"), ValidationCodes.ValueNotNull) { Detail = "Product ID cannot be empty" })))
+                .Ensure(v => !string.IsNullOrWhiteSpace(v), new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "productId"), ValidationCodes.ValueNotEmpty) { Detail = "Product ID cannot be empty" })))
                 .Map(v => new ProductId(v));
     }
 
@@ -69,9 +69,9 @@ public class DomainDrivenDesignSamplesTests
         private EmailAddress(string value) : base(value) { }
 
         public static Result<EmailAddress> TryCreate(string? value, string? fieldName = null) =>
-            value.ToResult(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "email"), "validation.error") { Detail = "Email cannot be empty" })))
-                .Ensure(v => !string.IsNullOrWhiteSpace(v), new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "email"), "validation.error") { Detail = "Email cannot be empty" })))
-                .Ensure(v => v.Contains('@'), new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "email"), "validation.error") { Detail = "Email must contain @" })))
+            value.ToResult(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "email"), ValidationCodes.ValueNotNull) { Detail = "Email cannot be empty" })))
+                .Ensure(v => !string.IsNullOrWhiteSpace(v), new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "email"), ValidationCodes.ValueNotEmpty) { Detail = "Email cannot be empty" })))
+                .Ensure(v => v.Contains('@'), new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(fieldName ?? "email"), ValidationCodes.StringEmail) { Detail = "Email must contain @" })))
                 .Map(v => new EmailAddress(v));
     }
 
@@ -243,15 +243,15 @@ public class DomainDrivenDesignSamplesTests
             string country) =>
             (street, city, state, postalCode, country).ToResult()
                 .Ensure(x => !string.IsNullOrWhiteSpace(x.street),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(street)), "validation.error") { Detail = "Street is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(street)), ValidationCodes.ValueNotEmpty) { Detail = "Street is required" })))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x.city),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(city)), "validation.error") { Detail = "City is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(city)), ValidationCodes.ValueNotEmpty) { Detail = "City is required" })))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x.state),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(state)), "validation.error") { Detail = "State is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(state)), ValidationCodes.ValueNotEmpty) { Detail = "State is required" })))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x.postalCode),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(postalCode)), "validation.error") { Detail = "Postal code is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(postalCode)), ValidationCodes.ValueNotEmpty) { Detail = "Postal code is required" })))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x.country),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(country)), "validation.error") { Detail = "Country is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(country)), ValidationCodes.ValueNotEmpty) { Detail = "Country is required" })))
                 .Map(x => new Address(x.street, x.city, x.state, x.postalCode, x.country));
 
         protected override void GetEqualityComponents(ref EqualityComponents components)
@@ -323,9 +323,9 @@ public class DomainDrivenDesignSamplesTests
             var field = fieldName ?? "temperature";
             return value.ToResult()
                 .Ensure(v => v >= -273.15m,
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = "Temperature cannot be below absolute zero" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual) { Detail = "Temperature cannot be below absolute zero" })))
                 .Ensure(v => v <= 1_000_000m,
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), "validation.error") { Detail = "Temperature exceeds physical limits" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual) { Detail = "Temperature exceeds physical limits" })))
                 .Map(v => new Temperature(v));
         }
 
@@ -437,11 +437,11 @@ public class DomainDrivenDesignSamplesTests
         public static Result<Money> TryCreate(decimal amount, string currency = "USD") =>
             (amount, currency).ToResult()
                 .Ensure(x => x.amount >= 0,
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(amount)), "validation.error") { Detail = "Amount cannot be negative" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(amount)), ValidationCodes.ValueGreaterThanOrEqual) { Detail = "Amount cannot be negative" })))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x.currency),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(currency)), "validation.error") { Detail = "Currency is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(currency)), ValidationCodes.ValueNotEmpty) { Detail = "Currency is required" })))
                 .Ensure(x => x.currency.Length == 3,
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(currency)), "validation.error") { Detail = "Currency must be 3-letter ISO code" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(currency)), ValidationCodes.StringExactLength) { Detail = "Currency must be 3-letter ISO code" })))
                 .Map(x => new Money(x.amount, x.currency.ToUpperInvariant()));
 
         public static Money Create(decimal amount, string currency = "USD")
@@ -660,9 +660,9 @@ public class DomainDrivenDesignSamplesTests
                 .Ensure(_ => Status == OrderStatus.Draft,
                        new Error.InvalidInput(EquatableArray<FieldViolation>.Empty) { Detail = "Can only add items to draft orders" })
                 .Ensure(_ => quantity > 0,
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(quantity)), "validation.error") { Detail = "Quantity must be positive" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(quantity)), ValidationCodes.ValueGreaterThan) { Detail = "Quantity must be positive" })))
                 .Ensure(_ => quantity <= 1000,
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(quantity)), "validation.error") { Detail = "Quantity cannot exceed 1000" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(quantity)), ValidationCodes.ValueLessThanOrEqual) { Detail = "Quantity cannot exceed 1000" })))
                 .Tap(_ =>
                 {
                     var existingLine = _lines.FirstOrDefault(l => l.ProductId == productId);
@@ -725,7 +725,7 @@ public class DomainDrivenDesignSamplesTests
                 .Ensure(_ => Status is OrderStatus.Draft or OrderStatus.Submitted,
                        new Error.InvalidInput(EquatableArray<FieldViolation>.Empty) { Detail = "Can only cancel draft or submitted orders" })
                 .Ensure(_ => !string.IsNullOrWhiteSpace(reason),
-                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(reason)), "validation.error") { Detail = "Cancellation reason is required" })))
+                       new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(reason)), ValidationCodes.ValueNotEmpty) { Detail = "Cancellation reason is required" })))
                 .Tap(_ =>
                 {
                     Status = OrderStatus.Cancelled;

--- a/Examples/TestingPatterns/FluentValidationSamplesTests.cs
+++ b/Examples/TestingPatterns/FluentValidationSamplesTests.cs
@@ -26,9 +26,9 @@ public class FluentValidationSamplesTests
         public static Result<EmailAddress> TryCreate(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.EmailAddress>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Email cannot be empty" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.EmailAddress>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueNotEmpty) { Detail = "Email cannot be empty" })));
             if (!value.Contains('@'))
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.EmailAddress>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Email must contain @" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.EmailAddress>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.StringEmail) { Detail = "Email must contain @" })));
             return Result.Ok(new EmailAddress(value));
         }
     }
@@ -41,9 +41,9 @@ public class FluentValidationSamplesTests
         public static Result<Username> TryCreate(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Username>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Username cannot be empty" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Username>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueNotEmpty) { Detail = "Username cannot be empty" })));
             if (value.Length is < 3 or > 20)
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Username>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Username must be between 3 and 20 characters" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Username>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.StringLength) { Detail = "Username must be between 3 and 20 characters" })));
             return Result.Ok(new Username(value));
         }
     }
@@ -56,7 +56,7 @@ public class FluentValidationSamplesTests
         public static Result<PhoneNumber> TryCreate(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.PhoneNumber>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Phone number cannot be empty" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.PhoneNumber>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueNotEmpty) { Detail = "Phone number cannot be empty" })));
             return Result.Ok(new PhoneNumber(value));
         }
     }
@@ -300,7 +300,7 @@ public class FluentValidationSamplesTests
         public static Result<ProductId> TryCreate(string? value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.ProductId>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Product ID cannot be empty" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.ProductId>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueNotEmpty) { Detail = "Product ID cannot be empty" })));
             return Result.Ok(new ProductId(value));
         }
     }
@@ -313,9 +313,9 @@ public class FluentValidationSamplesTests
         public static Result<Quantity> TryCreate(int value)
         {
             if (value <= 0)
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Quantity>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Quantity must be positive" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Quantity>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueGreaterThan) { Detail = "Quantity must be positive" })));
             if (value > 1000)
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Quantity>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Quantity cannot exceed 1000" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Quantity>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueLessThanOrEqual) { Detail = "Quantity cannot exceed 1000" })));
             return Result.Ok(new Quantity(value));
         }
     }
@@ -328,7 +328,7 @@ public class FluentValidationSamplesTests
         public static Result<Price> TryCreate(decimal value)
         {
             if (value <= 0)
-                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Price>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), "validation.error") { Detail = "Price must be positive" })));
+                return Result.Fail<TestingPatterns.FluentValidationSamplesTests.Price>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(nameof(value)), ValidationCodes.ValueGreaterThan) { Detail = "Price must be positive" })));
             return Result.Ok(new Price(value));
         }
     }

--- a/MIGRATION_v3.md
+++ b/MIGRATION_v3.md
@@ -1043,6 +1043,8 @@ public sealed partial class CommentBody : RequiredString<CommentBody>;
 | TRLS045 | Error | Numeric convenience attribute combined with explicit `[Range]` |
 | TRLS057 | Error | `[Trim]` on a Required base other than `RequiredString` |
 | TRLS058 | Error | `[NotDefault]` on `RequiredBool` or `RequiredEnum` (no default sentinel to reject) |
+| TRLS060 | Error | A constraint attribute's `Code` override is empty or whitespace |
+| TRLS061 | Error | Both `ValidateAdditional` overloads declared on one value object |
 
 ---
 

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -15,7 +15,7 @@
 /// </code>
 /// <para>
 /// IDs in the <c>TRLS001</c>–<c>TRLS023</c> and <c>TRLS054</c>–<c>TRLS055</c> ranges are emitted by the
-/// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS045</c> and <c>TRLS056</c>–<c>TRLS058</c>
+/// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS045</c>, <c>TRLS056</c>–<c>TRLS058</c> and <c>TRLS060</c>–<c>TRLS061</c>
 /// ranges are emitted by the bundled source generators
 /// (<c>Trellis.Core.Generator</c>, <c>Trellis.EntityFrameworkCore.Generator</c>,
 /// and <c>Trellis.AspSourceGenerator</c>).
@@ -161,4 +161,10 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS058 — <c>[NotDefault]</c> applied to a sentinel-less Required base (<c>RequiredBool</c> or <c>RequiredEnum</c>), which has no default value to reject.</summary>
     public const string NotDefaultOnSentinellessBase = "TRLS058";
+
+    /// <summary>TRLS060 — a constraint attribute's <c>Code</c> override is empty or whitespace, which would put a blank reason code on the wire where a client expects a catalog key.</summary>
+    public const string EmptyReasonCodeOverride = "TRLS060";
+
+    /// <summary>TRLS061 — both <c>ValidateAdditional</c> overloads are declared on one value object; the generator emits a defining declaration for only one of them.</summary>
+    public const string ValidateAdditionalOverloadConflict = "TRLS061";
 }

--- a/Trellis.Core/generator/AnalyzerReleases.Unshipped.md
+++ b/Trellis.Core/generator/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,7 @@
 Rule ID  | Category | Severity | Notes
 ---------|----------|----------|------------------------------------------------------------------------
 TRLS056  | Trellis  | Error    | RequiredPartialClassGenerator: Generated member conflicts with user declaration.
+TRLS057  | Trellis  | Error    | RequiredPartialClassGenerator: [Trim] on a Required base other than RequiredString.
+TRLS058  | Trellis  | Error    | RequiredPartialClassGenerator: [NotDefault] on a sentinel-less Required base.
+TRLS060  | Trellis  | Error    | RequiredPartialClassGenerator: Reason-code override is empty or whitespace.
+TRLS061  | Trellis  | Error    | RequiredPartialClassGenerator: Both ValidateAdditional overloads declared.

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -2025,9 +2025,16 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
     /// The extra parameter on the emitted declaration, the extra argument on the emitted call, the
     /// declaration of the code local, and the expression that supplies the violation's reason code.
     /// </returns>
+    /// <remarks>
+    /// The blank check is the runtime sibling of TRLS060. An attribute's <c>Code</c> is a literal an
+    /// analyzer can read, so a blank one fails the build; a code assigned inside
+    /// <c>ValidateAdditional</c> is only known when the value is rejected, so the guard has to live
+    /// in the emitted code. Both exist to keep an empty string off the wire, where it would read as
+    /// a reason rather than as the absence of one.
+    /// </remarks>
     private static (string Param, string Arg, string Init, string Code) ValidateAdditionalShape(RequiredPartialClassInfo g) =>
         g.ValidateAdditionalHasCode
-            ? (", ref string? errorCode", ", ref additionalCode", " string? additionalCode = null;", "additionalCode ?? ValidationCodes.Unspecified")
+            ? (", ref string? errorCode", ", ref additionalCode", " string? additionalCode = null;", "(string.IsNullOrWhiteSpace(additionalCode) ? ValidationCodes.Unspecified : additionalCode!)")
             : ("", "", "", "ValidationCodes.Unspecified");
 
     private static string GenerateDateTimeMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -144,6 +144,18 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
     /// <c>Trellis.TrellisDiagnosticIds</c> in <c>Trellis.Analyzers</c> for the
     /// consumer-facing equivalents.
     /// </summary>
+    /// <summary>
+    /// Chooses between an application-supplied reason code and the framework default, returning the
+    /// C# expression to emit.
+    /// </summary>
+    /// <remarks>
+    /// The default is emitted as a reference to <c>ValidationCodes</c> rather than as its literal
+    /// value, so a rename of the constant stays a compile error in generated code rather than a
+    /// silently divergent string. An override is emitted as a verbatim-safe literal.
+    /// </remarks>
+    private static string CodeOrDefault(string? overrideCode, string defaultExpression) =>
+        overrideCode is null ? defaultExpression : SymbolDisplay.FormatLiteral(overrideCode, quote: true);
+
     private static class Ids
     {
         public const string UnsupportedRequiredBaseType = "TRLS031";
@@ -156,6 +168,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         public const string GeneratedMemberCollision = "TRLS056";
         public const string TrimOnNonStringBase = "TRLS057";
         public const string NotDefaultOnSentinellessBase = "TRLS058";
+        public const string EmptyReasonCodeOverride = "TRLS060";
+        public const string ValidateAdditionalOverloadConflict = "TRLS061";
     }
 
     /// <summary>
@@ -676,20 +690,22 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
     private static string GenerateGuidMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotDefault");
         var emptyDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be Guid.Empty.""";
         var emptyCheck = !g.HasNotDefault
             ? ""
             : $@"
             if (value == Guid.Empty)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {emptyDetail} }})));";
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {emptyDetail} }})));";
         var emptyNullableEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(x => x != Guid.Empty, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {emptyDetail} }})))";
+                .Ensure(x => x != Guid.Empty, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {emptyDetail} }})))";
         var emptyParsedEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(_ => parsedGuid != Guid.Empty, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {emptyDetail} }})))";
+                .Ensure(_ => parsedGuid != Guid.Empty, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {emptyDetail} }})))";
 
         return $@"
 
@@ -700,7 +716,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated Guid value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(Guid value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(Guid value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a new instance with a unique Version 4 (random) GUID.
@@ -743,10 +759,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{emptyCheck}
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -758,10 +774,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){emptyNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(guid => new {g.ClassName}(guid));
         }}
@@ -777,10 +793,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => Guid.TryParse(x, out parsedGuid), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatGuid) {{ Detail = ""Guid should contain 32 digits with 4 dashes (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"" }}))){emptyParsedEnsure};
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedGuid, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedGuid, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(guid => new {g.ClassName}(parsedGuid));
         }}
@@ -834,6 +850,53 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
     {
         var ok = true;
         var isNumericBase = g.ClassBase is "RequiredInt" or "RequiredLong" or "RequiredDecimal";
+
+        // An override names the failure in the application's own terms, so Trellis imposes no shape
+        // rule on it — but an empty or whitespace code names nothing at all, and would put a blank
+        // string on the wire where a client expects a catalog key. That is always a typo.
+        foreach (var (code, attribute) in new[]
+        {
+            (g.LengthCode, "[StringLength]"),
+            (g.RangeCode, "[Range]"),
+            (g.NotDefaultCode, "[NotDefault]"),
+        })
+        {
+            if (code is null || !string.IsNullOrWhiteSpace(code))
+                continue;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: Ids.EmptyReasonCodeOverride,
+                    title: "Reason-code override is empty",
+                    messageFormat: "Class '{0}' sets {1} Code to an empty or whitespace string. Give the failure a name, or omit Code to keep the framework default.",
+                    category: "Trellis",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description: "An application may override a framework reason code with a name of its own, but an empty code names nothing and would reach the wire where a client expects a catalog key.",
+                    helpLinkUri: HelpLinkBase),
+                location: null,
+                g.ClassName,
+                attribute));
+            ok = false;
+        }
+
+        if (g.DeclaredBothValidateAdditional)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                new DiagnosticDescriptor(
+                    id: Ids.ValidateAdditionalOverloadConflict,
+                    title: "Both ValidateAdditional overloads declared",
+                    messageFormat: "Class '{0}' declares both ValidateAdditional overloads. Keep one: the three-argument overload reports error.unspecified, the four-argument overload can set a reason code.",
+                    category: "Trellis",
+                    DiagnosticSeverity.Error,
+                    isEnabledByDefault: true,
+                    description: "The generator emits one defining declaration for ValidateAdditional, so the other implementation would fail to compile with an error that names no Trellis concept.",
+                    helpLinkUri: HelpLinkBase),
+                location: null,
+                g.ClassName));
+            ok = false;
+        }
+
         var numericConvenienceCount = (g.HasPositive ? 1 : 0)
             + (g.HasNonNegative ? 1 : 0)
             + (g.HasNegative ? 1 : 0)
@@ -942,6 +1005,12 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
     private static string? GenerateStringMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        // A [NotDefault] string fails as "present but blank", which is value.not-empty, not the
+        // value.not-default that [NotDefault] means on Guid and the numeric primitives.
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotEmpty");
+        var minLengthCode = CodeOrDefault(g.LengthCode, "ValidationCodes.StringMinLength");
+        var maxLengthCode = CodeOrDefault(g.LengthCode, "ValidationCodes.StringMaxLength");
         // Validate [StringLength] constraints are consistent
         if (g.MinLength.HasValue && g.MaxLength.HasValue && g.MinLength.Value > g.MaxLength.Value)
         {
@@ -967,14 +1036,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {
             lengthChecks += $@"
     if (normalized.Length < {g.MinLength.Value})
-        return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.StringMinLength, ValidationArgs.Of(""minLength"", {g.MinLength.Value})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {g.MinLength.Value} {"character" + (g.MinLength.Value == 1 ? "" : "s")}."" }})));";
+        return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {minLengthCode}, ValidationArgs.Of(""minLength"", {g.MinLength.Value}, ""totalLength"", normalized.Length)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {g.MinLength.Value} {"character" + (g.MinLength.Value == 1 ? "" : "s")}."" }})));";
         }
 
         if (g.MaxLength.HasValue)
         {
             lengthChecks += $@"
     if (normalized.Length > {g.MaxLength.Value})
-        return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.StringMaxLength, ValidationArgs.Of(""maxLength"", {g.MaxLength.Value})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be {g.MaxLength.Value} {"character" + (g.MaxLength.Value == 1 ? "" : "s")} or fewer."" }})));";
+        return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {maxLengthCode}, ValidationArgs.Of(""maxLength"", {g.MaxLength.Value}, ""totalLength"", normalized.Length)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be {g.MaxLength.Value} {"character" + (g.MaxLength.Value == 1 ? "" : "s")} or fewer."" }})));";
         }
 
         // String validation pipeline, lenient-by-default:
@@ -990,7 +1059,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         var emptyStep = g.HasNotDefault
             ? $@"
     if (normalized.Length == 0)
-        return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));"
+        return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));"
             : "";
 
         return $@"
@@ -1002,7 +1071,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated string value (trimmed when [Trim] is applied).</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a string.
@@ -1018,10 +1087,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             if (value is null)
                 return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be null."" }})));
             {trimStep}{emptyStep}{lengthChecks}
-            string? additionalError = null;
-            ValidateAdditional(normalized, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(normalized, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(normalized));
         }}
 
@@ -1043,6 +1112,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
     private static string? GenerateIntMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotDefault");
+        var rangeMinCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueGreaterThanOrEqual");
+        var rangeMaxCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueLessThanOrEqual");
         var result = "";
         var hasRange = g.RangeMin.HasValue && g.RangeMax.HasValue;
         var rangeMin = g.RangeMin.GetValueOrDefault();
@@ -1053,15 +1126,15 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             ? ""
             : $@"
             if (value == 0)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})));";
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})));";
         var notDefaultNullableEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(x => x != 0, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(x => x != 0, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
         var notDefaultParsedEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(_ => parsedInt != 0, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(_ => parsedInt != 0, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
 
         // Validate [Range] constraints are consistent
         if (hasRange && rangeMin > rangeMax)
@@ -1093,7 +1166,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated integer value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(int value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(int value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from an integer.
@@ -1107,13 +1180,13 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {rangeMin})
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})));
             if (value > {rangeMax})
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1123,14 +1196,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
-                .Ensure(x => x >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(x => x <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                .Ensure(x => x >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
+                .Ensure(x => x <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1144,14 +1217,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatInteger) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid integer."" }}))){notDefaultParsedEnsure}
-                .Ensure(_ => parsedInt >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                .Ensure(_ => parsedInt >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
+                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedInt, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedInt, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedInt));
         }}";
@@ -1168,7 +1241,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated integer value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(int value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(int value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from an integer.
@@ -1181,10 +1254,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1196,10 +1269,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1215,10 +1288,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatInteger) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid integer."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedInt, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedInt, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedInt));
         }}";
@@ -1286,6 +1359,12 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
     private static string? GenerateDecimalMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotDefault");
+        var rangeMinCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueGreaterThanOrEqual");
+        var rangeMaxCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueLessThanOrEqual");
+        var rangeAboveCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueGreaterThan");
+        var rangeBelowCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueLessThan");
         var result = "";
         var hasRange = g.RangeDoubleMin.HasValue && g.RangeDoubleMax.HasValue;
         // Use double values for fractional ranges, fall back to int values
@@ -1298,15 +1377,15 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             ? ""
             : $@"
             if (value == 0m)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})));";
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})));";
         var notDefaultNullableEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(x => x != 0m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(x => x != 0m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
         var notDefaultParsedEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(_ => parsedDecimal != 0m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(_ => parsedDecimal != 0m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
 
         // Convenience sign-check attributes ([Positive] / [NonNegative] / [Negative] /
         // [NonPositive]) are emitted as direct sign comparisons rather than as Range bounds
@@ -1365,7 +1444,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated decimal value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(decimal value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(decimal value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a decimal.
@@ -1379,13 +1458,13 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {minStr}m)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})));
             if (value > {maxStr}m)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1395,14 +1474,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
-                .Ensure(x => x >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(x => x <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                .Ensure(x => x >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
+                .Ensure(x => x <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1416,14 +1495,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatDecimal) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid decimal."" }}))){notDefaultParsedEnsure}
-                .Ensure(_ => parsedDecimal >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                .Ensure(_ => parsedDecimal >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
+                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedDecimal, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedDecimal, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedDecimal));
         }}";
@@ -1440,7 +1519,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated decimal value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(decimal value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(decimal value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a decimal.
@@ -1453,10 +1532,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}{signCheck.ifCheck}
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1468,10 +1547,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}{signCheck.nullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1487,10 +1566,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatDecimal) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid decimal."" }}))){notDefaultParsedEnsure}{signCheck.parsedEnsure};
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedDecimal, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedDecimal, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedDecimal));
         }}";
@@ -1567,10 +1646,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         string compareOp;
         string message;
         string code;
-        if (g.HasPositive) { compareOp = "<= 0m"; message = $"{g.ClassName.SplitPascalCase()} must be positive."; code = "ValidationCodes.ValueGreaterThan"; }
-        else if (g.HasNonNegative) { compareOp = "< 0m"; message = $"{g.ClassName.SplitPascalCase()} must be zero or positive."; code = "ValidationCodes.ValueGreaterThanOrEqual"; }
-        else if (g.HasNegative) { compareOp = ">= 0m"; message = $"{g.ClassName.SplitPascalCase()} must be negative."; code = "ValidationCodes.ValueLessThan"; }
-        else /* HasNonPositive */ { compareOp = "> 0m"; message = $"{g.ClassName.SplitPascalCase()} must be zero or negative."; code = "ValidationCodes.ValueLessThanOrEqual"; }
+        if (g.HasPositive) { compareOp = "<= 0m"; message = $"{g.ClassName.SplitPascalCase()} must be positive."; code = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueGreaterThan"); }
+        else if (g.HasNonNegative) { compareOp = "< 0m"; message = $"{g.ClassName.SplitPascalCase()} must be zero or positive."; code = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueGreaterThanOrEqual"); }
+        else if (g.HasNegative) { compareOp = ">= 0m"; message = $"{g.ClassName.SplitPascalCase()} must be negative."; code = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueLessThan"); }
+        else /* HasNonPositive */ { compareOp = "> 0m"; message = $"{g.ClassName.SplitPascalCase()} must be zero or negative."; code = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueLessThanOrEqual"); }
 
         var detail = $@"""{message}""";
 
@@ -1594,6 +1673,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
     private static string? GenerateLongMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotDefault");
+        var rangeMinCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueGreaterThanOrEqual");
+        var rangeMaxCode = CodeOrDefault(g.RangeCode, "ValidationCodes.ValueLessThanOrEqual");
         var result = "";
         var hasRange = g.RangeLongMin.HasValue && g.RangeLongMax.HasValue;
         var rangeLongMin = g.RangeLongMin.GetValueOrDefault();
@@ -1604,15 +1687,15 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             ? ""
             : $@"
             if (value == 0L)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})));";
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})));";
         var notDefaultNullableEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(x => x != 0L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(x => x != 0L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
         var notDefaultParsedEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(_ => parsedLong != 0L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(_ => parsedLong != 0L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
 
         // Validate [Range] constraints are consistent
         if (hasRange && rangeLongMin > rangeLongMax)
@@ -1644,7 +1727,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated long value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(long value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(long value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a long.
@@ -1658,13 +1741,13 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {rangeLongMin}L)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})));
             if (value > {rangeLongMax}L)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1674,14 +1757,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
-                .Ensure(x => x >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                .Ensure(x => x >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
+                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1695,14 +1778,14 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatInteger) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid long."" }}))){notDefaultParsedEnsure}
-                .Ensure(_ => parsedLong >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueGreaterThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueLessThanOrEqual, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                .Ensure(_ => parsedLong >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
+                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedLong, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedLong, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedLong));
         }}";
@@ -1719,7 +1802,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated long value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(long value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(long value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a long.
@@ -1732,10 +1815,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1747,10 +1830,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1766,10 +1849,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatInteger) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid long."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedLong, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedLong, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedLong));
         }}";
@@ -1835,7 +1918,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         return result;
     }
 
-    private static string GenerateBoolMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions) =>
+    private static string GenerateBoolMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
+    {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        return
         $@"
 
         /// <summary>
@@ -1845,7 +1931,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated boolean value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(bool value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(bool value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a boolean.
@@ -1858,10 +1944,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1873,10 +1959,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})));
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -1892,10 +1978,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => bool.TryParse(x, out parsedBool), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatBoolean) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid boolean (true or false)."" }})));
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedBool, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedBool, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedBool));
         }}
@@ -1929,23 +2015,39 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 onSuccess: created => created,
                 onFailure: error => throw new InvalidOperationException($""Failed to create {g.ClassName}: {{error.GetDisplayMessage()}}""));
         }}";
+    }
+
+    /// <summary>
+    /// Builds the four emission fragments that adapt the generated <c>ValidateAdditional</c> call to
+    /// whichever overload the application implemented.
+    /// </summary>
+    /// <returns>
+    /// The extra parameter on the emitted declaration, the extra argument on the emitted call, the
+    /// declaration of the code local, and the expression that supplies the violation's reason code.
+    /// </returns>
+    private static (string Param, string Arg, string Init, string Code) ValidateAdditionalShape(RequiredPartialClassInfo g) =>
+        g.ValidateAdditionalHasCode
+            ? (", ref string? errorCode", ", ref additionalCode", " string? additionalCode = null;", "additionalCode ?? ValidationCodes.Unspecified")
+            : ("", "", "", "ValidationCodes.Unspecified");
 
     private static string GenerateDateTimeMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotDefault");
         var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be DateTime.MinValue.""";
         var notDefaultCheck = !g.HasNotDefault
             ? ""
             : $@"
             if (value == default(DateTime))
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})));";
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})));";
         var notDefaultNullableEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(x => x != default(DateTime), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(x => x != default(DateTime), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
         var notDefaultParsedEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(_ => parsedDateTime != default(DateTime), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(_ => parsedDateTime != default(DateTime), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
 
         return $@"
 
@@ -1956,7 +2058,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated DateTime value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(DateTime value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(DateTime value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a DateTime.
@@ -1969,10 +2071,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultCheck}
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -1984,10 +2086,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -2003,10 +2105,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => DateTime.TryParse(x, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out parsedDateTime), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatDateTime) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid date/time."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedDateTime, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedDateTime, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedDateTime));
         }}
@@ -2057,20 +2159,22 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
 
     private static string GenerateDateTimeOffsetMethods(RequiredPartialClassInfo g, SourceProductionContext context, HashSet<string> reportedCollisions)
     {
+        var (vaParam, vaArg, vaInit, vaCode) = ValidateAdditionalShape(g);
+        var notDefaultCode = CodeOrDefault(g.NotDefaultCode, "ValidationCodes.ValueNotDefault");
         var notDefaultDetail = $@"""{g.ClassName.SplitPascalCase()} cannot be DateTimeOffset.MinValue.""";
         var notDefaultCheck = !g.HasNotDefault
             ? ""
             : $@"
             if (value == default(DateTimeOffset))
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})));";
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})));";
         var notDefaultNullableEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(x => x != default(DateTimeOffset), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(x => x != default(DateTimeOffset), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
         var notDefaultParsedEnsure = !g.HasNotDefault
             ? ""
             : $@"
-                .Ensure(_ => parsedDateTimeOffset != default(DateTimeOffset), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotDefault) {{ Detail = {notDefaultDetail} }})))";
+                .Ensure(_ => parsedDateTimeOffset != default(DateTimeOffset), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {notDefaultCode}) {{ Detail = {notDefaultDetail} }})))";
 
         return $@"
 
@@ -2081,7 +2185,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         /// <param name=""value"">The validated DateTimeOffset value.</param>
         /// <param name=""fieldName"">The normalized field name for error messages.</param>
         /// <param name=""errorMessage"">Set to a non-null string to reject the value.</param>
-        static partial void ValidateAdditional(DateTimeOffset value, string fieldName, ref string? errorMessage);
+        static partial void ValidateAdditional(DateTimeOffset value, string fieldName, ref string? errorMessage{vaParam});
 
         /// <summary>
         /// Creates a validated instance from a DateTimeOffset.
@@ -2094,10 +2198,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         {{
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultCheck}
-            string? additionalError = null;
-            ValidateAdditional(value, field, ref additionalError);
+            string? additionalError = null;{vaInit}
+            ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             return Result.Ok(new {g.ClassName}(value));
         }}
 
@@ -2109,10 +2213,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure};
             if (validated.TryGetValue(out var value))
             {{
-                string? additionalError = null;
-                ValidateAdditional(value, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(value, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(val => new {g.ClassName}(val));
         }}
@@ -2128,10 +2232,10 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .Ensure(x => DateTimeOffset.TryParse(x, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out parsedDateTimeOffset), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatDateTime) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid date/time with offset."" }}))){notDefaultParsedEnsure};
             if (validated.IsSuccess)
             {{
-                string? additionalError = null;
-                ValidateAdditional(parsedDateTimeOffset, field, ref additionalError);
+                string? additionalError = null;{vaInit}
+                ValidateAdditional(parsedDateTimeOffset, field, ref additionalError{vaArg});
                 if (additionalError is not null)
-                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.Unspecified) {{ Detail = additionalError }})));
+                    return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {vaCode}) {{ Detail = additionalError }})));
             }}
             return validated.Map(_ => new {g.ClassName}(parsedDateTimeOffset));
         }}
@@ -2229,10 +2333,15 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var typePath = BuildTypePath(@namespace, classSymbol);
             var userDeclaredMembers = GetUserDeclaredMembers(classSymbol, cancellationToken);
             var hasUserJsonConverter = HasJsonConverterAttribute(classSymbol);
+            var validateAdditionalHasCode =
+                DetectValidateAdditionalArity(classSymbol, cancellationToken, out var declaredBothValidateAdditional) ?? false;
 
             // Read [StringLength] attribute for RequiredString types
             int? maxLength = null;
             int? minLength = null;
+            string? lengthCode = null;
+            string? rangeCode = null;
+            string? notDefaultCode = null;
             if (@base == "RequiredString")
             {
                 foreach (var attr in classSymbol.GetAttributes())
@@ -2249,6 +2358,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                         {
                             if (named.Key == "MinimumLength" && named.Value.Value is int min && min > 0)
                                 minLength = min;
+                            else if (named.Key == "Code" && named.Value.Value is string code)
+                                lengthCode = code;
                         }
                     }
                 }
@@ -2268,6 +2379,12 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                     if (attr.AttributeClass?.Name == "RangeAttribute"
                         && attr.AttributeClass.ContainingNamespace?.ToDisplayString() == "Trellis")
                     {
+                        foreach (var named in attr.NamedArguments)
+                        {
+                            if (named.Key == "Code" && named.Value.Value is string code)
+                                rangeCode = code;
+                        }
+
                         if (attr.ConstructorArguments.Length >= 2)
                         {
                             var arg0 = attr.ConstructorArguments[0].Value;
@@ -2312,25 +2429,41 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             {
                 if (attr.AttributeClass?.ContainingNamespace?.ToDisplayString() != "Trellis")
                     continue;
+
+                // The four sign-convenience attributes synthesize into the same range emission, so
+                // their Code lands on RangeCode; each produces exactly one failure, so there is no
+                // ambiguity about which failure it names.
+                string? attributeCode = null;
+                foreach (var named in attr.NamedArguments)
+                {
+                    if (named.Key == "Code" && named.Value.Value is string code)
+                        attributeCode = code;
+                }
+
                 switch (attr.AttributeClass?.Name)
                 {
                     case "NotDefaultAttribute":
                         hasNotDefault = true;
+                        notDefaultCode = attributeCode;
                         break;
                     case "TrimAttribute":
                         hasTrim = true;
                         break;
                     case "PositiveAttribute":
                         hasPositive = true;
+                        rangeCode ??= attributeCode;
                         break;
                     case "NonNegativeAttribute":
                         hasNonNegative = true;
+                        rangeCode ??= attributeCode;
                         break;
                     case "NegativeAttribute":
                         hasNegative = true;
+                        rangeCode ??= attributeCode;
                         break;
                     case "NonPositiveAttribute":
                         hasNonPositive = true;
+                        rangeCode ??= attributeCode;
                         break;
                 }
             }
@@ -2361,6 +2494,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 hasPositive, hasNonNegative, hasNegative, hasNonPositive,
                 hasExplicitRange,
                 hasUserJsonConverter,
+                lengthCode, rangeCode, notDefaultCode,
+                validateAdditionalHasCode, declaredBothValidateAdditional,
                 userDeclaredMembers));
         }
 
@@ -2508,6 +2643,39 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Determines which <c>ValidateAdditional</c> overload the application implemented, so the
+    /// generator emits the matching declaration and call.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> when the application declared neither, which is legal and the
+    /// common case. Declaring both is reported as <c>TRLS061</c> by the caller: the generator can
+    /// only emit one defining declaration, so the other implementation would fail to compile with an
+    /// error that names no Trellis concept.
+    /// </remarks>
+    private static bool? DetectValidateAdditionalArity(
+        INamedTypeSymbol classSymbol,
+        CancellationToken cancellationToken,
+        out bool declaredBoth)
+    {
+        var hasThreeArg = false;
+        var hasFourArg = false;
+
+        foreach (var member in classSymbol.GetMembers("ValidateAdditional"))
+        {
+            if (member is not IMethodSymbol method || !IsPartialValidateAdditional(method, cancellationToken))
+                continue;
+
+            if (method.Parameters.Length == 4)
+                hasFourArg = true;
+            else if (method.Parameters.Length == 3)
+                hasThreeArg = true;
+        }
+
+        declaredBoth = hasThreeArg && hasFourArg;
+        return hasFourArg || hasThreeArg ? hasFourArg : null;
     }
 
     private static Location? FirstSourceLocation(ISymbol symbol) =>

--- a/Trellis.Core/generator/RequiredPartialClassInfo.cs
+++ b/Trellis.Core/generator/RequiredPartialClassInfo.cs
@@ -270,6 +270,47 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     /// <c>JsonSerializerContext</c>) must declare it in original source, and Trellis then has to
     /// step aside to avoid CS0579.
     /// </remarks>
+    /// <summary>
+    /// Gets the application-supplied reason code that replaces the framework default on every
+    /// failure the type's <c>[StringLength]</c> produces, or <see langword="null"/> to keep it.
+    /// </summary>
+    public readonly string? LengthCode;
+
+    /// <summary>
+    /// Gets the application-supplied reason code that replaces the framework default on every
+    /// range failure, or <see langword="null"/> to keep it.
+    /// </summary>
+    /// <remarks>
+    /// Sourced from <c>[Range].Code</c>, or from whichever numeric convenience attribute
+    /// (<c>[Positive]</c> and friends) synthesized the range, since those each produce exactly one
+    /// failure and synthesize into the same emission.
+    /// </remarks>
+    public readonly string? RangeCode;
+
+    /// <summary>
+    /// Gets the application-supplied reason code that replaces the framework default on the
+    /// <c>[NotDefault]</c> sentinel rejection, or <see langword="null"/> to keep it.
+    /// </summary>
+    public readonly string? NotDefaultCode;
+
+    /// <summary>
+    /// Gets whether the application declared the four-argument <c>ValidateAdditional</c> overload,
+    /// which can set a reason code, rather than the three-argument one, which cannot.
+    /// </summary>
+    /// <remarks>
+    /// The generator emits whichever declaration the application implemented. An existing
+    /// three-argument implementation therefore keeps compiling and keeps reporting
+    /// <c>error.unspecified</c>, which is what it means today.
+    /// </remarks>
+    public readonly bool ValidateAdditionalHasCode;
+
+    /// <summary>
+    /// Gets whether the application declared both <c>ValidateAdditional</c> overloads, which the
+    /// generator cannot satisfy: it emits one defining declaration, so the other implementation
+    /// would fail with a compiler error naming no Trellis concept.
+    /// </summary>
+    public readonly bool DeclaredBothValidateAdditional;
+
     public readonly bool HasUserJsonConverter;
 
     public readonly GeneratedMemberDeclaration[] UserDeclaredMembers;
@@ -299,6 +340,11 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
     /// <param name="hasNonPositive">True when the target carries <c>[NonPositive]</c>.</param>
     /// <param name="hasExplicitRange">True when the target had an explicit <c>[Range]</c> before convenience-attribute synthesis.</param>
     /// <param name="hasUserJsonConverter">True when the user's own declaration already carries <c>[JsonConverter]</c>.</param>
+    /// <param name="lengthCode">Optional reason-code override from <c>[StringLength].Code</c>.</param>
+    /// <param name="rangeCode">Optional reason-code override from <c>[Range].Code</c> or a numeric convenience attribute.</param>
+    /// <param name="notDefaultCode">Optional reason-code override from <c>[NotDefault].Code</c>.</param>
+    /// <param name="validateAdditionalHasCode">True when the application declared the four-argument <c>ValidateAdditional</c>.</param>
+    /// <param name="declaredBothValidateAdditional">True when the application declared both <c>ValidateAdditional</c> overloads.</param>
     /// <param name="userDeclaredMembers">Members declared by the user that may collide with generated members.</param>
     public RequiredPartialClassInfo(
         string nameSpace,
@@ -323,6 +369,11 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
         bool hasNonPositive = false,
         bool hasExplicitRange = false,
         bool hasUserJsonConverter = false,
+        string? lengthCode = null,
+        string? rangeCode = null,
+        string? notDefaultCode = null,
+        bool validateAdditionalHasCode = false,
+        bool declaredBothValidateAdditional = false,
         GeneratedMemberDeclaration[]? userDeclaredMembers = null)
     {
         NameSpace = nameSpace;
@@ -347,6 +398,11 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
         HasNonPositive = hasNonPositive;
         HasExplicitRange = hasExplicitRange;
         HasUserJsonConverter = hasUserJsonConverter;
+        LengthCode = lengthCode;
+        RangeCode = rangeCode;
+        NotDefaultCode = notDefaultCode;
+        ValidateAdditionalHasCode = validateAdditionalHasCode;
+        DeclaredBothValidateAdditional = declaredBothValidateAdditional;
         UserDeclaredMembers = userDeclaredMembers ?? [];
     }
 
@@ -375,6 +431,11 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
             && HasNonPositive == other.HasNonPositive
             && HasExplicitRange == other.HasExplicitRange
             && HasUserJsonConverter == other.HasUserJsonConverter
+            && LengthCode == other.LengthCode
+            && RangeCode == other.RangeCode
+            && NotDefaultCode == other.NotDefaultCode
+            && ValidateAdditionalHasCode == other.ValidateAdditionalHasCode
+            && DeclaredBothValidateAdditional == other.DeclaredBothValidateAdditional
             && TypePath == other.TypePath
             && NestingParents.SequenceEqual(other.NestingParents)
             && UserDeclaredMembers.SequenceEqual(other.UserDeclaredMembers);
@@ -407,6 +468,11 @@ internal class RequiredPartialClassInfo : IEquatable<RequiredPartialClassInfo>
             hash = (hash * 31) + HasNonPositive.GetHashCode();
             hash = (hash * 31) + HasExplicitRange.GetHashCode();
             hash = (hash * 31) + HasUserJsonConverter.GetHashCode();
+            hash = (hash * 31) + (LengthCode?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (RangeCode?.GetHashCode() ?? 0);
+            hash = (hash * 31) + (NotDefaultCode?.GetHashCode() ?? 0);
+            hash = (hash * 31) + ValidateAdditionalHasCode.GetHashCode();
+            hash = (hash * 31) + DeclaredBothValidateAdditional.GetHashCode();
             hash = (hash * 31) + StringComparer.Ordinal.GetHashCode(TypePath);
             foreach (var member in UserDeclaredMembers)
                 hash = (hash * 31) + member.GetHashCode();

--- a/Trellis.Core/src/Primitives/NegativeAttribute.cs
+++ b/Trellis.Core/src/Primitives/NegativeAttribute.cs
@@ -27,4 +27,19 @@ using System;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 public sealed class NegativeAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.Core/src/Primitives/NonNegativeAttribute.cs
+++ b/Trellis.Core/src/Primitives/NonNegativeAttribute.cs
@@ -26,4 +26,19 @@ using System;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 public sealed class NonNegativeAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.Core/src/Primitives/NonPositiveAttribute.cs
+++ b/Trellis.Core/src/Primitives/NonPositiveAttribute.cs
@@ -26,4 +26,19 @@ using System;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 public sealed class NonPositiveAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.Core/src/Primitives/NotDefaultAttribute.cs
+++ b/Trellis.Core/src/Primitives/NotDefaultAttribute.cs
@@ -27,4 +27,19 @@ using System;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 public sealed class NotDefaultAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.Core/src/Primitives/PositiveAttribute.cs
+++ b/Trellis.Core/src/Primitives/PositiveAttribute.cs
@@ -28,4 +28,19 @@ using System;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 public sealed class PositiveAttribute : Attribute
 {
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.Core/src/Primitives/RangeAttribute.cs
+++ b/Trellis.Core/src/Primitives/RangeAttribute.cs
@@ -48,4 +48,20 @@ public sealed class RangeAttribute : Attribute
     /// C# does not allow decimal in attribute constructors, so double is used.
     /// </summary>
     public RangeAttribute(double minimum, double maximum) { }
+
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.Core/src/Primitives/StringLengthAttribute.cs
+++ b/Trellis.Core/src/Primitives/StringLengthAttribute.cs
@@ -81,4 +81,20 @@ public sealed class StringLengthAttribute : Attribute
 
         MaximumLength = maximumLength;
     }
+
+    /// <summary>
+    /// Gets or sets an application-defined reason code that replaces the framework default on every
+    /// failure this attribute produces.
+    /// </summary>
+    /// <value>
+    /// A non-empty code, or <see langword="null"/> to keep the framework default. Setting it to an
+    /// empty or whitespace string is a generator error (<c>TRLS060</c>).
+    /// </value>
+    /// <remarks>
+    /// The framework vocabulary is frozen so that one client catalog entry works across every Trellis
+    /// service. An application that owns both ends of its own contract — it wrote the declaration and
+    /// it writes the catalog key — may name the failure in its own terms instead, and nothing it does
+    /// here can invalidate another party's catalog. An override carries no warning and no penalty.
+    /// </remarks>
+    public string? Code { get; set; }
 }

--- a/Trellis.FluentValidation/src/CompatibilitySuppressions.xml
+++ b/Trellis.FluentValidation/src/CompatibilitySuppressions.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.FluentValidation.FluentValidationResultExtensions.ToResult``1(FluentValidation.Results.ValidationResult,``0,System.String)</Target>
+    <Left>lib/net10.0/Trellis.FluentValidation.dll</Left>
+    <Right>lib/net10.0/Trellis.FluentValidation.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.FluentValidation.FluentValidationResultExtensions.ValidateToResult``1(FluentValidation.IValidator{``0},``0,System.String,System.String)</Target>
+    <Left>lib/net10.0/Trellis.FluentValidation.dll</Left>
+    <Right>lib/net10.0/Trellis.FluentValidation.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.FluentValidation.FluentValidationResultExtensions.ValidateToResultAsync``1(FluentValidation.IValidator{``0},``0,System.String,System.String,System.Threading.CancellationToken)</Target>
+    <Left>lib/net10.0/Trellis.FluentValidation.dll</Left>
+    <Right>lib/net10.0/Trellis.FluentValidation.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/Trellis.FluentValidation/src/FluentValidationResultExtensions.cs
+++ b/Trellis.FluentValidation/src/FluentValidationResultExtensions.cs
@@ -195,10 +195,15 @@ public static class FluentValidationResultExtensions
     /// The caller argument expression for <paramref name="value"/>. Used as the field name when
     /// FluentValidation reports a root-level failure with no property name.
     /// </param>
+    /// <param name="argsOptions">
+    /// Widens the validation-arg allowlist beyond the framework default. Supplied explicitly here
+    /// because these helpers have no container to read <c>IOptions</c> from.
+    /// </param>
     public static Result<T> ToResult<T>(
         this ValidationResult validationResult,
         T value,
-        [CallerArgumentExpression(nameof(value))] string paramName = "value")
+        [CallerArgumentExpression(nameof(value))] string paramName = "value",
+        ValidationArgsOptions? argsOptions = null)
     {
         ArgumentNullException.ThrowIfNull(validationResult);
 
@@ -211,7 +216,7 @@ public static class FluentValidationResultExtensions
                 var rawName = string.IsNullOrWhiteSpace(e.PropertyName) ? paramName : e.PropertyName;
                 var pointerPath = JsonPointerNormalizer.ToJsonPointer(rawName);
                 var reasonCode = ValidationCodeProjection.Project(e.ErrorCode, e.AttemptedValue);
-                return new FieldViolation(new InputPointer(pointerPath), reasonCode, ValidationArgsProjection.Project(e)) { Detail = e.ErrorMessage };
+                return new FieldViolation(new InputPointer(pointerPath), reasonCode, ValidationArgsProjection.Project(e, argsOptions)) { Detail = e.ErrorMessage };
             })
             .ToArray();
 
@@ -300,11 +305,16 @@ public static class FluentValidationResultExtensions
     /// // Validator.Validate() is never called
     /// </code>
     /// </example>
+    /// <param name="argsOptions">
+    /// Widens the validation-arg allowlist beyond the framework default. Supplied explicitly here
+    /// because these helpers have no container to read <c>IOptions</c> from.
+    /// </param>
     public static Result<T> ValidateToResult<T>(
         this IValidator<T> validator,
         T value,
         [CallerArgumentExpression(nameof(value))] string paramName = "value",
-        string? message = null)
+        string? message = null,
+        ValidationArgsOptions? argsOptions = null)
     {
         ArgumentNullException.ThrowIfNull(validator);
 
@@ -312,10 +322,10 @@ public static class FluentValidationResultExtensions
         {
             var nullFailure = new ValidationFailure(paramName, message ?? $"'{paramName}' must not be empty.") { ErrorCode = "NotNullValidator" };
             var nullResult = new ValidationResult([nullFailure]);
-            return nullResult.ToResult(value!, paramName);
+            return nullResult.ToResult(value!, paramName, argsOptions);
         }
 
-        return validator.Validate(value).ToResult(value, paramName);
+        return validator.Validate(value).ToResult(value, paramName, argsOptions);
     }
 
     /// <summary>
@@ -426,11 +436,16 @@ public static class FluentValidationResultExtensions
     /// );
     /// </code>
     /// </example>
+    /// <param name="argsOptions">
+    /// Widens the validation-arg allowlist beyond the framework default. Supplied explicitly here
+    /// because these helpers have no container to read <c>IOptions</c> from.
+    /// </param>
     public static async Task<Result<T>> ValidateToResultAsync<T>(
         this IValidator<T> validator,
         T value,
         [CallerArgumentExpression(nameof(value))] string paramName = "value",
         string? message = null,
+        ValidationArgsOptions? argsOptions = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(validator);
@@ -445,10 +460,10 @@ public static class FluentValidationResultExtensions
         {
             var nullFailure = new ValidationFailure(paramName, message ?? $"'{paramName}' must not be empty.") { ErrorCode = "NotNullValidator" };
             var nullResult = new ValidationResult([nullFailure]);
-            return nullResult.ToResult(value!, paramName);
+            return nullResult.ToResult(value!, paramName, argsOptions);
         }
 
         var result = await validator.ValidateAsync(value, cancellationToken).ConfigureAwait(false);
-        return result.ToResult(value, paramName);
+        return result.ToResult(value, paramName, argsOptions);
     }
 }

--- a/Trellis.FluentValidation/src/ValidationArgsOptions.cs
+++ b/Trellis.FluentValidation/src/ValidationArgsOptions.cs
@@ -41,20 +41,37 @@ using System.Collections.Generic;
 public sealed class ValidationArgsOptions
 {
     /// <summary>
-    /// Placeholders no opt-in can re-admit.
+    /// Placeholders no opt-in can re-admit, each with the reason it is denied.
     /// </summary>
-    private static readonly HashSet<string> NeverAllowed = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly Dictionary<string, string> NeverAllowed = new(StringComparer.OrdinalIgnoreCase)
     {
-        "PropertyValue",
-        "PropertyPath",
+        ["PropertyValue"] = "it carries the submitted input verbatim, which is a disclosure and PII hazard. Report the value's location instead, which the violation already does.",
+        ["PropertyPath"] = "it carries the traversal path the violation's own location already reports. Read the violation's pointer instead.",
     };
 
     private readonly Dictionary<string, HashSet<string>> additional = new(StringComparer.Ordinal);
 
+    private readonly bool isShared;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationArgsOptions"/> class.
+    /// </summary>
+    public ValidationArgsOptions()
+    {
+    }
+
+    private ValidationArgsOptions(bool isShared) => this.isShared = isShared;
+
     /// <summary>
     /// The configuration used when an application registered none.
     /// </summary>
-    public static ValidationArgsOptions Default { get; } = new();
+    /// <remarks>
+    /// This instance is shared process-wide, so it rejects <see cref="AllowArgs"/>. Widening it
+    /// would silently widen every validation call in the process, including those in unrelated
+    /// scopes and on other threads — a global effect from what reads like a local one. Configure
+    /// through the options system instead, which hands out an instance of your own.
+    /// </remarks>
+    public static ValidationArgsOptions Default { get; } = new(isShared: true);
 
     /// <summary>
     /// Allows the named placeholders to be emitted for failures carrying
@@ -73,8 +90,17 @@ public sealed class ValidationArgsOptions
     /// Thrown when <paramref name="errorCode"/> is blank, or when <paramref name="placeholderNames"/>
     /// names a placeholder that can never be allowed.
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when called on <see cref="Default"/>, which is shared process-wide.
+    /// </exception>
     public ValidationArgsOptions AllowArgs(string errorCode, params string[] placeholderNames)
     {
+        if (isShared)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(ValidationArgsOptions)}.{nameof(Default)} is shared across the process and cannot be widened. Register your own through services.Configure<{nameof(ValidationArgsOptions)}>(...) so the change is scoped to the application that made it.");
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(errorCode);
         ArgumentNullException.ThrowIfNull(placeholderNames);
 
@@ -85,10 +111,10 @@ public sealed class ValidationArgsOptions
             // Failing loudly beats silently dropping the name: an application that asked for
             // PropertyValue has misunderstood what args are for, and a silent drop would leave it
             // waiting for an arg that is never coming.
-            if (NeverAllowed.Contains(name))
+            if (NeverAllowed.TryGetValue(name, out var reason))
             {
                 throw new ArgumentException(
-                    $"'{name}' can never be emitted as a validation arg because it carries the submitted input. Report the value's location instead, which the violation already does.",
+                    $"'{name}' can never be emitted as a validation arg because {reason}",
                     nameof(placeholderNames));
             }
 

--- a/Trellis.FluentValidation/src/ValidationArgsOptions.cs
+++ b/Trellis.FluentValidation/src/ValidationArgsOptions.cs
@@ -1,0 +1,118 @@
+﻿namespace Trellis.FluentValidation;
+
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Widens the per-validator allowlist that <see cref="ValidationArgsProjection"/> applies, so an
+/// application can publish a machine-readable operand Trellis withholds by default.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The default allowlist is deliberately narrow: it carries only the operands whose meaning Trellis
+/// can vouch for across every validator that populates them. FluentValidation populates
+/// placeholders its message never uses and populates them with sentinels, so a blanket
+/// pass-through would put <c>maxLength: -1</c> on the wire for a <c>MinimumLength</c> failure.
+/// Widening is therefore a per-validator decision the application makes with knowledge Trellis does
+/// not have.
+/// </para>
+/// <para>
+/// <b>This only ever widens.</b> There is no method to remove an entry, because the default set is
+/// the conservative one — a remove operation would only ever narrow a client contract that
+/// something already depends on, and an application that wants fewer args can stop reading them.
+/// </para>
+/// <para>
+/// <b>Widening does not bypass the safety gates.</b> An opted-in placeholder still passes through
+/// the containment gate, the bound, and the control-character escaping in
+/// <see cref="ValidationArgsProjection"/>. It cannot re-admit <c>PropertyValue</c> or
+/// <c>PropertyPath</c>: the first carries the user's submitted input verbatim, which is a
+/// disclosure and PII hazard no opt-in should be able to switch on, and the second carries the
+/// traversal path that the violation's own location already reports.
+/// </para>
+/// <para>
+/// Register through the options system so both the standalone helpers and the Mediator pipeline
+/// adapter see the same configuration:
+/// </para>
+/// <code>
+/// services.Configure&lt;ValidationArgsOptions&gt;(options =&gt;
+///     options.AllowArgs("PredicateValidator", "MinAge"));
+/// </code>
+/// </remarks>
+public sealed class ValidationArgsOptions
+{
+    /// <summary>
+    /// Placeholders no opt-in can re-admit.
+    /// </summary>
+    private static readonly HashSet<string> NeverAllowed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "PropertyValue",
+        "PropertyPath",
+    };
+
+    private readonly Dictionary<string, HashSet<string>> additional = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The configuration used when an application registered none.
+    /// </summary>
+    public static ValidationArgsOptions Default { get; } = new();
+
+    /// <summary>
+    /// Allows the named placeholders to be emitted for failures carrying
+    /// <paramref name="errorCode"/>.
+    /// </summary>
+    /// <param name="errorCode">
+    /// FluentValidation's error code for the validator, such as <c>"PredicateValidator"</c> or a
+    /// code the application set with <c>WithErrorCode</c>.
+    /// </param>
+    /// <param name="placeholderNames">
+    /// The placeholder names as FluentValidation spells them, in <c>PascalCase</c>. They reach the
+    /// wire in <c>camelCase</c>, matching every other arg.
+    /// </param>
+    /// <returns>The same instance, so calls can be chained.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="errorCode"/> is blank, or when <paramref name="placeholderNames"/>
+    /// names a placeholder that can never be allowed.
+    /// </exception>
+    public ValidationArgsOptions AllowArgs(string errorCode, params string[] placeholderNames)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorCode);
+        ArgumentNullException.ThrowIfNull(placeholderNames);
+
+        foreach (var name in placeholderNames)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+            // Failing loudly beats silently dropping the name: an application that asked for
+            // PropertyValue has misunderstood what args are for, and a silent drop would leave it
+            // waiting for an arg that is never coming.
+            if (NeverAllowed.Contains(name))
+            {
+                throw new ArgumentException(
+                    $"'{name}' can never be emitted as a validation arg because it carries the submitted input. Report the value's location instead, which the violation already does.",
+                    nameof(placeholderNames));
+            }
+
+            if (!additional.TryGetValue(errorCode, out var names))
+            {
+                names = new HashSet<string>(StringComparer.Ordinal);
+                additional[errorCode] = names;
+            }
+
+            names.Add(name);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Gets the placeholders the application added for an error code, or an empty set.
+    /// </summary>
+    internal IReadOnlyCollection<string> AdditionalFor(string errorCode) =>
+        additional.TryGetValue(errorCode, out var names) ? names : [];
+
+    /// <summary>
+    /// Gets whether the application widened any error code, letting the projection keep its fast
+    /// path when nothing was configured.
+    /// </summary>
+    internal bool IsEmpty => additional.Count == 0;
+}

--- a/Trellis.FluentValidation/src/ValidationArgsProjection.cs
+++ b/Trellis.FluentValidation/src/ValidationArgsProjection.cs
@@ -83,15 +83,57 @@ public static class ValidationArgsProjection
     private const int MaxStringLength = 64;
 
     /// <summary>
+    /// Combines the framework allowlist with the application's widening for one error code.
+    /// </summary>
+    /// <remarks>
+    /// An application may widen an error code the framework does not allowlist at all, which is the
+    /// point: <c>PredicateValidator</c> has no default entry because Trellis cannot know what a
+    /// <c>Must()</c> rule's placeholders mean, and the application does.
+    /// </remarks>
+    private static (IReadOnlyCollection<string> Names, HashSet<string>? OptedIn) ResolveAllowed(
+        string errorCode,
+        ValidationArgsOptions? options)
+    {
+        IReadOnlyCollection<string> defaults = Allowed.TryGetValue(errorCode, out var known) ? known : [];
+        if (options is null || options.IsEmpty)
+            return (defaults, null);
+
+        var extra = options.AdditionalFor(errorCode);
+        if (extra.Count == 0)
+            return (defaults, null);
+
+        var combined = new HashSet<string>(defaults, StringComparer.Ordinal);
+        var optedIn = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var name in extra)
+        {
+            combined.Add(name);
+            optedIn.Add(name);
+        }
+
+        return (combined, optedIn);
+    }
+
+    /// <summary>
     /// Builds the args for a failure, or <see langword="null"/> when none survive.
     /// </summary>
-    public static ImmutableDictionary<string, string>? Project(ValidationFailure failure)
+    /// <param name="failure">The FluentValidation failure to project.</param>
+    /// <param name="options">
+    /// The application's widening of the default allowlist, or <see langword="null"/> to apply the
+    /// framework default alone.
+    /// </param>
+    public static ImmutableDictionary<string, string>? Project(
+        ValidationFailure failure,
+        ValidationArgsOptions? options = null)
     {
         var placeholders = failure.FormattedMessagePlaceholderValues;
         if (placeholders is null || placeholders.Count == 0)
             return null;
 
-        if (string.IsNullOrEmpty(failure.ErrorCode) || !Allowed.TryGetValue(failure.ErrorCode, out var allowed))
+        if (string.IsNullOrEmpty(failure.ErrorCode))
+            return null;
+
+        var (allowed, optedIn) = ResolveAllowed(failure.ErrorCode, options);
+        if (allowed.Count == 0)
             return null;
 
         var template = ResolveTemplate(failure.ErrorCode);
@@ -106,7 +148,7 @@ public static class ValidationArgsProjection
                 continue;
 
             var rendered = Convert.ToString(raw, CultureInfo.CurrentCulture);
-            if (!ShouldEmit(rendered, template, name, failure.ErrorMessage))
+            if (!ShouldEmit(rendered, template, name, failure.ErrorMessage, optedIn?.Contains(name) == true))
                 continue;
 
             var encoded = Encode(raw);
@@ -150,10 +192,19 @@ public static class ValidationArgsProjection
     /// message contains. What Trellis puts on the wire is a different string — see
     /// <see cref="IsReconciled"/>, which closes the gap the two representations open.
     /// </para>
+    /// <para>
+    /// An explicit opt-in through <see cref="ValidationArgsOptions"/> satisfies the template half
+    /// without consulting the template. The template check defends against a placeholder Trellis
+    /// <em>guessed</em> was safe, which is why coincidence can fool it; an application naming its
+    /// own validator's placeholder is not guessing, and a custom validator has no entry in the
+    /// language manager for the check to consult in the first place — so leaving it in force would
+    /// make the opt-in inert, which is the same as not shipping it. The message half still holds,
+    /// so an opted-in arg still cannot carry anything the client's own message did not.
+    /// </para>
     /// </remarks>
-    private static bool ShouldEmit(string? rendered, string template, string name, string message)
+    private static bool ShouldEmit(string? rendered, string template, string name, string message, bool optedIn)
     {
-        if (!TemplateNamesPlaceholder(template, name))
+        if (!optedIn && !TemplateNamesPlaceholder(template, name))
             return false;
 
         return !string.IsNullOrEmpty(rendered)

--- a/Trellis.FluentValidation/tests/FluentTests.cs
+++ b/Trellis.FluentValidation/tests/FluentTests.cs
@@ -233,7 +233,7 @@ public class FluentTests
         };
 
         // Act
-        var result = await validator.ValidateToResultAsync(myValue, "CustomParam", "Custom error message", TestContext.Current.CancellationToken);
+        var result = await validator.ValidateToResultAsync(myValue, "CustomParam", "Custom error message", cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         result.Should().BeFailureOfType<Error.InvalidInput>()

--- a/Trellis.FluentValidation/tests/ValidationArgsOptionsTests.cs
+++ b/Trellis.FluentValidation/tests/ValidationArgsOptionsTests.cs
@@ -102,12 +102,34 @@ public class ValidationArgsOptionsTests
     [InlineData("PropertyValue")]
     [InlineData("PropertyPath")]
     [InlineData("propertyvalue")]
-    public void AllowArgs_refuses_the_placeholders_that_carry_submitted_input(string name)
+    [InlineData("propertypath")]
+    public void AllowArgs_refuses_the_permanently_denied_placeholders(string name)
     {
         var act = () => new ValidationArgsOptions().AllowArgs("GreaterThanValidator", name);
 
-        act.Should().Throw<ArgumentException>().WithMessage("*submitted input*");
+        act.Should().Throw<ArgumentException>().WithMessage($"*'{name}'*");
     }
+
+    [Fact]
+    public void AllowArgs_says_PropertyValue_is_denied_for_disclosure() =>
+        new Func<object>(() => new ValidationArgsOptions().AllowArgs("GreaterThanValidator", "PropertyValue"))
+            .Should().Throw<ArgumentException>().WithMessage("*submitted input*");
+
+    [Fact]
+    public void AllowArgs_says_PropertyPath_is_denied_for_redundancy() =>
+        new Func<object>(() => new ValidationArgsOptions().AllowArgs("GreaterThanValidator", "PropertyPath"))
+            .Should().Throw<ArgumentException>().WithMessage("*already reports*",
+                "PropertyPath is withheld because the violation's location carries it, not because it discloses input");
+
+    [Fact]
+    public void AllowArgs_refuses_to_widen_the_shared_default() =>
+        new Func<object>(() => ValidationArgsOptions.Default.AllowArgs("GreaterThanValidator", "ComparisonValue"))
+            .Should().Throw<InvalidOperationException>().WithMessage("*shared*",
+                "widening the process-wide instance would be a global effect from what reads like a local one");
+
+    [Fact]
+    public void The_shared_default_widens_nothing() =>
+        ValidationArgsOptions.Default.IsEmpty.Should().BeTrue();
 
     [Fact]
     public void AllowArgs_rejects_a_blank_error_code() =>

--- a/Trellis.FluentValidation/tests/ValidationArgsOptionsTests.cs
+++ b/Trellis.FluentValidation/tests/ValidationArgsOptionsTests.cs
@@ -1,0 +1,136 @@
+﻿namespace Trellis.FluentValidation.Tests;
+
+using global::FluentValidation;
+using Trellis;
+using Trellis.FluentValidation;
+
+/// <summary>
+/// Pins the opt-in that widens the validation-arg allowlist: it must reach the wire, it must not
+/// bypass the disclosure gates, and it must refuse the placeholders that carry submitted input.
+/// </summary>
+public class ValidationArgsOptionsTests
+{
+    private sealed record Subject(string A = "", int N = 0);
+
+    private static FieldViolation Violate(
+        Action<InlineValidator<Subject>> configure,
+        Subject subject,
+        ValidationArgsOptions? options)
+    {
+        var validator = new InlineValidator<Subject>();
+        configure(validator);
+        var result = validator.Validate(subject).ToResult(subject, argsOptions: options);
+        result.IsFailure.Should().BeTrue();
+        return ((Error.InvalidInput)result.Error!).Fields[0];
+    }
+
+    [Fact]
+    public void An_unallowlisted_validator_emits_no_args_by_default()
+    {
+        var violation = Violate(MinimumAgeRule, new Subject(N: 12), options: null);
+
+        violation.Args.Should().BeNull();
+    }
+
+    [Fact]
+    public void AllowArgs_admits_a_placeholder_the_framework_withholds()
+    {
+        var options = new ValidationArgsOptions().AllowArgs("MinimumAge", "MinAge");
+
+        var violation = Violate(MinimumAgeRule, new Subject(N: 12), options);
+
+        violation.Args!["minAge"].Should().Be("18");
+    }
+
+    [Fact]
+    public void An_opted_in_arg_still_cannot_carry_what_the_message_does_not()
+    {
+        var options = new ValidationArgsOptions().AllowArgs("MinimumAge", "MinAge");
+
+        var violation = Violate(
+            v => MinimumAgeRule(v, "too young"),
+            new Subject(N: 12),
+            options);
+
+        violation.Args.Should().BeNull(
+            "the message no longer contains the bound, so publishing it would be a new disclosure");
+    }
+
+    private static void MinimumAgeRule(InlineValidator<Subject> validator) =>
+        MinimumAgeRule(validator, "Must be at least {MinAge}.");
+
+    private static void MinimumAgeRule(InlineValidator<Subject> validator, string message) =>
+        validator.RuleFor(x => x.N)
+            .Must((_, value, context) =>
+            {
+                context.MessageFormatter.AppendArgument("MinAge", 18);
+                return value >= 18;
+            })
+            .WithErrorCode("MinimumAge")
+            .WithMessage(message);
+
+    [Fact]
+    public void Widening_cannot_reintroduce_a_denied_placeholder()
+    {
+        var options = new ValidationArgsOptions().AllowArgs("GreaterThanValidator", "PropertyName");
+
+        var violation = Violate(
+            v => v.RuleFor(x => x.N).GreaterThan(5),
+            new Subject(N: 1),
+            options);
+
+        violation.Args!["comparisonValue"].Should().Be("5");
+        violation.Args.Should().NotContainKey("propertyName",
+            "PropertyName is on the universal denylist, so widening cannot reintroduce it");
+    }
+
+    [Fact]
+    public void Widening_does_not_bypass_the_containment_gate()
+    {
+        var options = new ValidationArgsOptions().AllowArgs("GreaterThanValidator", "ComparisonValue");
+
+        var violation = Violate(
+            v => v.RuleFor(x => x.N).GreaterThan(5).WithMessage("out of range"),
+            new Subject(N: 1),
+            options);
+
+        violation.Args.Should().BeNull(
+            "an application that took the bound out of its message must not have it put back by an opt-in");
+    }
+
+    [Theory]
+    [InlineData("PropertyValue")]
+    [InlineData("PropertyPath")]
+    [InlineData("propertyvalue")]
+    public void AllowArgs_refuses_the_placeholders_that_carry_submitted_input(string name)
+    {
+        var act = () => new ValidationArgsOptions().AllowArgs("GreaterThanValidator", name);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*submitted input*");
+    }
+
+    [Fact]
+    public void AllowArgs_rejects_a_blank_error_code() =>
+        new Func<object>(() => new ValidationArgsOptions().AllowArgs("  ", "MaxLength"))
+            .Should().Throw<ArgumentException>();
+
+    [Fact]
+    public void AllowArgs_is_chainable_and_accumulates()
+    {
+        var options = new ValidationArgsOptions()
+            .AllowArgs("GreaterThanValidator", "ComparisonValue")
+            .AllowArgs("GreaterThanValidator", "ComparisonProperty");
+
+        var violation = Violate(v => v.RuleFor(x => x.N).GreaterThan(5), new Subject(N: 1), options);
+
+        violation.Args!["comparisonValue"].Should().Be("5");
+    }
+
+    [Fact]
+    public void The_default_instance_widens_nothing()
+    {
+        var violation = Violate(MinimumAgeRule, new Subject(N: 12), ValidationArgsOptions.Default);
+
+        violation.Args.Should().BeNull();
+    }
+}

--- a/Trellis.Mediator.FluentValidation/src/FluentValidationMessageValidatorAdapter.cs
+++ b/Trellis.Mediator.FluentValidation/src/FluentValidationMessageValidatorAdapter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using global::FluentValidation;
+using Microsoft.Extensions.Options;
 using Trellis;
 using Trellis.FluentValidation;
 using Trellis.Mediator;
@@ -37,6 +38,7 @@ public sealed class FluentValidationMessageValidatorAdapter<TMessage>
     where TMessage : global::Mediator.IMessage
 {
     private readonly IEnumerable<IValidator<TMessage>> _validators;
+    private readonly ValidationArgsOptions _argsOptions;
 
     /// <summary>
     /// Initializes a new instance of <see cref="FluentValidationMessageValidatorAdapter{TMessage}"/>.
@@ -47,9 +49,39 @@ public sealed class FluentValidationMessageValidatorAdapter<TMessage>
     /// </param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="validators"/> is null.</exception>
     public FluentValidationMessageValidatorAdapter(IEnumerable<IValidator<TMessage>> validators)
+        : this(validators, ValidationArgsOptions.Default)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FluentValidationMessageValidatorAdapter{TMessage}"/>
+    /// with an application-configured validation-arg allowlist.
+    /// </summary>
+    /// <param name="validators">
+    /// The injected sequence of <see cref="IValidator{T}"/> implementations to run against each
+    /// message.
+    /// </param>
+    /// <param name="argsOptions">
+    /// The application's widening of the default arg allowlist. Supplied by the options system, so
+    /// the pipeline adapter and the standalone <c>ToResult</c> helpers project identically.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="validators"/> or <paramref name="argsOptions"/> is null.
+    /// </exception>
+    public FluentValidationMessageValidatorAdapter(
+        IEnumerable<IValidator<TMessage>> validators,
+        IOptions<ValidationArgsOptions> argsOptions)
+        : this(validators, (argsOptions ?? throw new ArgumentNullException(nameof(argsOptions))).Value)
+    {
+    }
+
+    private FluentValidationMessageValidatorAdapter(
+        IEnumerable<IValidator<TMessage>> validators,
+        ValidationArgsOptions argsOptions)
     {
         ArgumentNullException.ThrowIfNull(validators);
         _validators = validators;
+        _argsOptions = argsOptions;
     }
 
     /// <inheritdoc />
@@ -76,7 +108,7 @@ public sealed class FluentValidationMessageValidatorAdapter<TMessage>
                     : failure.PropertyName;
                 var pointerPath = JsonPointerNormalizer.ToJsonPointer(rawName);
                 var reasonCode = ValidationCodeProjection.Project(failure.ErrorCode, failure.AttemptedValue);
-                violations.Add(new FieldViolation(new InputPointer(pointerPath), reasonCode, ValidationArgsProjection.Project(failure))
+                violations.Add(new FieldViolation(new InputPointer(pointerPath), reasonCode, ValidationArgsProjection.Project(failure, _argsOptions))
                 {
                     Detail = failure.ErrorMessage,
                 });

--- a/Trellis.Mediator.FluentValidation/src/FluentValidationServiceCollectionExtensions.cs
+++ b/Trellis.Mediator.FluentValidation/src/FluentValidationServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using global::FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Trellis.FluentValidation;
 using Trellis.Mediator;
 
 /// <summary>
@@ -53,6 +54,13 @@ public static partial class FluentValidationServiceCollectionExtensions
     public static IServiceCollection AddTrellisFluentValidation(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // The adapter's greediest constructor takes IOptions<ValidationArgsOptions>, so the options
+        // machinery must be present even when the application configured nothing; otherwise DI
+        // silently falls back to the narrower constructor and any Configure<ValidationArgsOptions>
+        // registered later would be ignored.
+        services.AddOptions<ValidationArgsOptions>();
+
         // Idempotent: calling AddTrellisFluentValidation() multiple times (directly or via the
         // scanning overload) must not register the open-generic adapter more than once. Without
         // this guard, DI would resolve multiple IMessageValidator<TMessage> instances and the

--- a/Trellis.Mediator.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
+++ b/Trellis.Mediator.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
@@ -5,6 +5,7 @@ using global::Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Trellis;
 using Trellis.Mediator;
+using Trellis.FluentValidation;
 using Trellis.Mediator.FluentValidation;
 using Trellis.Testing;
 
@@ -39,6 +40,63 @@ public class FluentValidationMessageValidatorAdapterTests
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("validators");
+    }
+
+    [Fact]
+    public void Constructor_throws_ArgumentNullException_when_argsOptions_is_null()
+    {
+        var act = () => new FluentValidationMessageValidatorAdapter<CreateUserCommand>([], null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("argsOptions");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_honours_the_configured_args_allowlist()
+    {
+        var adapter = ResolveAdapter(options => options.AllowArgs("MinimumNameLength", "MinNameLength"));
+
+        var result = await adapter.ValidateAsync(new CreateUserCommand("Al", "alice@example.com"), CancellationToken.None);
+
+        var violation = ((Error.InvalidInput)result.Error!).Fields[0];
+        violation.Args!["minNameLength"].Should().Be("3",
+            "the adapter must read the same options the standalone helpers take as a parameter");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_emits_no_args_for_a_custom_validator_by_default()
+    {
+        var adapter = ResolveAdapter(configure: null);
+
+        var result = await adapter.ValidateAsync(new CreateUserCommand("Al", "alice@example.com"), CancellationToken.None);
+
+        ((Error.InvalidInput)result.Error!).Fields[0].Args.Should().BeNull();
+    }
+
+    private static IMessageValidator<CreateUserCommand> ResolveAdapter(Action<ValidationArgsOptions>? configure)
+    {
+        var services = new ServiceCollection();
+        services.AddTrellisFluentValidation();
+        services.AddScoped<IValidator<CreateUserCommand>, MinimumNameLengthValidator>();
+        if (configure is not null)
+            services.Configure(configure);
+
+        return services.BuildServiceProvider()
+            .CreateScope()
+            .ServiceProvider
+            .GetRequiredService<IMessageValidator<CreateUserCommand>>();
+    }
+
+    private sealed class MinimumNameLengthValidator : AbstractValidator<CreateUserCommand>
+    {
+        public MinimumNameLengthValidator() =>
+            RuleFor(x => x.Name)
+                .Must((_, value, context) =>
+                {
+                    context.MessageFormatter.AppendArgument("MinNameLength", 3);
+                    return value.Length >= 3;
+                })
+                .WithErrorCode("MinimumNameLength")
+                .WithMessage("Name must be at least {MinNameLength} characters.");
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/ReasonCodeOverrideTests.cs
+++ b/Trellis.Primitives/tests/ReasonCodeOverrideTests.cs
@@ -1,0 +1,176 @@
+﻿namespace Trellis.Primitives.Tests;
+
+using Trellis.Testing;
+
+// --- Test value objects exercising the reason-code override surface ---
+
+/// <summary>
+/// A length-constrained string whose length failures speak the application's vocabulary rather than
+/// the framework's.
+/// </summary>
+[StringLength(8, MinimumLength = 3, Code = "account.reference.length")]
+public partial class AccountReference : RequiredString<AccountReference> { }
+
+/// <summary>
+/// A string whose blank rejection is renamed, proving <c>[NotDefault].Code</c> reaches the
+/// present-but-blank failure on <c>RequiredString</c>.
+/// </summary>
+[NotDefault(Code = "account.reference.missing")]
+public partial class NamedReference : RequiredString<NamedReference> { }
+
+/// <summary>
+/// A code carrying characters that are not literal-safe. Nothing about the wire vocabulary invites
+/// a quote, a backslash, or a newline in a reason code, but the generator inlines the override into
+/// generated source, so an unescaped one would emit source that does not compile. Pinning the odd
+/// value here keeps that escaping honest.
+/// </summary>
+[NotDefault(Code = "weird\\code\"with\r\nnewline\tand\ttabs")]
+public partial class AwkwardlyNamedCode : RequiredString<AwkwardlyNamedCode> { }
+
+/// <summary>
+/// A ranged int whose two directional failures collapse onto one application code, which is the
+/// documented consequence of a single <c>Code</c> on <c>[Range]</c>.
+/// </summary>
+[Range(1, 10, Code = "cart.quantity.out-of-range")]
+public partial class CartQuantity : RequiredInt<CartQuantity> { }
+
+/// <summary>
+/// A sign-convenience attribute carrying an override, proving the convenience attributes share the
+/// range slot rather than owning one of their own.
+/// </summary>
+[Positive(Code = "invoice.amount.not-positive")]
+public partial class InvoiceAmount : RequiredDecimal<InvoiceAmount> { }
+
+/// <summary>
+/// A Guid whose default-value rejection is renamed.
+/// </summary>
+[NotDefault(Code = "tenant.id.missing")]
+public partial class TenantId : RequiredGuid<TenantId> { }
+
+/// <summary>
+/// A value object using the four-argument <c>ValidateAdditional</c>, which can name its own failure
+/// instead of falling back to <c>error.unspecified</c>.
+/// </summary>
+public partial class ReservationCode : RequiredString<ReservationCode>
+{
+    static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode)
+    {
+        if (value.StartsWith("RES-", StringComparison.Ordinal))
+            return;
+
+        errorMessage = "Reservation Code must start with RES-.";
+        errorCode = "reservation.code.malformed";
+    }
+}
+
+/// <summary>
+/// The four-argument overload leaving <c>errorCode</c> unset, which must still produce a violation
+/// and must fall back to the framework's unspecified code.
+/// </summary>
+public partial class LegacyReservationCode : RequiredString<LegacyReservationCode>
+{
+    static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode)
+    {
+        if (value.Length < 4)
+            errorMessage = "Legacy Reservation Code is too short.";
+    }
+}
+
+public class ReasonCodeOverrideTests
+{
+    private static FieldViolation FirstViolation(Error error) =>
+        ((Error.InvalidInput)error).Fields[0];
+
+    [Fact]
+    public void StringLength_Code_override_replaces_both_length_codes()
+    {
+        FirstViolation(AccountReference.TryCreate("ab").UnwrapError()).ReasonCode
+            .Should().Be("account.reference.length");
+        FirstViolation(AccountReference.TryCreate("abcdefghi").UnwrapError()).ReasonCode
+            .Should().Be("account.reference.length");
+    }
+
+    [Fact]
+    public void StringLength_violation_carries_the_rejected_length_as_totalLength()
+    {
+        var violation = FirstViolation(AccountReference.TryCreate("ab").UnwrapError());
+
+        violation.Args.Should().Contain("minLength", "3");
+        violation.Args.Should().Contain("totalLength", "2");
+    }
+
+    [Fact]
+    public void StringLength_maximum_violation_carries_totalLength()
+    {
+        var violation = FirstViolation(AccountReference.TryCreate("abcdefghi").UnwrapError());
+
+        violation.Args.Should().Contain("maxLength", "8");
+        violation.Args.Should().Contain("totalLength", "9");
+    }
+
+    [Fact]
+    public void NotDefault_Code_override_renames_the_blank_string_rejection() =>
+        FirstViolation(NamedReference.TryCreate("").UnwrapError()).ReasonCode
+            .Should().Be("account.reference.missing");
+
+    [Fact]
+    public void A_Code_containing_characters_that_are_not_literal_safe_round_trips_intact() =>
+        FirstViolation(AwkwardlyNamedCode.TryCreate("").UnwrapError()).ReasonCode
+            .Should().Be("weird\\code\"with\r\nnewline\tand\ttabs");
+
+    [Fact]
+    public void NotDefault_default_on_a_string_stays_the_present_but_blank_code() =>
+        FirstViolation(NotDefaultRequiredString.TryCreate("").UnwrapError()).ReasonCode
+            .Should().Be(ValidationCodes.ValueNotEmpty);
+
+    [Fact]
+    public void Range_Code_override_collapses_both_directional_codes()
+    {
+        FirstViolation(CartQuantity.TryCreate(0).UnwrapError()).ReasonCode
+            .Should().Be("cart.quantity.out-of-range");
+        FirstViolation(CartQuantity.TryCreate(11).UnwrapError()).ReasonCode
+            .Should().Be("cart.quantity.out-of-range");
+    }
+
+    [Fact]
+    public void Sign_convenience_attribute_Code_override_reaches_the_range_failure() =>
+        FirstViolation(InvoiceAmount.TryCreate(0m).UnwrapError()).ReasonCode
+            .Should().Be("invoice.amount.not-positive");
+
+    [Fact]
+    public void NotDefault_Code_override_renames_the_empty_guid_rejection() =>
+        FirstViolation(TenantId.TryCreate(Guid.Empty).UnwrapError()).ReasonCode
+            .Should().Be("tenant.id.missing");
+
+    [Fact]
+    public void The_null_rejection_is_never_overridable() =>
+        FirstViolation(NamedReference.TryCreate(null!).UnwrapError()).ReasonCode
+            .Should().Be(ValidationCodes.ValueNotNull);
+
+    [Fact]
+    public void ValidateAdditional_can_set_the_reason_code()
+    {
+        var violation = FirstViolation(ReservationCode.TryCreate("XYZ-1").UnwrapError());
+
+        violation.ReasonCode.Should().Be("reservation.code.malformed");
+        violation.Detail.Should().Be("Reservation Code must start with RES-.");
+    }
+
+    [Fact]
+    public void ValidateAdditional_leaving_the_code_unset_falls_back_to_unspecified() =>
+        FirstViolation(LegacyReservationCode.TryCreate("abc").UnwrapError()).ReasonCode
+            .Should().Be(ValidationCodes.Unspecified);
+
+    [Fact]
+    public void ValidateAdditional_still_reports_error_unspecified_for_the_three_argument_overload() =>
+        FirstViolation(Sku.TryCreate("BAD").UnwrapError()).ReasonCode
+            .Should().Be(ValidationCodes.Unspecified);
+
+    [Fact]
+    public void An_override_leaves_the_success_path_untouched()
+    {
+        AccountReference.TryCreate("abcd").Unwrap().Value.Should().Be("abcd");
+        CartQuantity.TryCreate(5).Unwrap().Value.Should().Be(5);
+        ReservationCode.TryCreate("RES-1").Unwrap().Value.Should().Be("RES-1");
+    }
+}

--- a/Trellis.Primitives/tests/ReasonCodeOverrideTests.cs
+++ b/Trellis.Primitives/tests/ReasonCodeOverrideTests.cs
@@ -76,6 +76,25 @@ public partial class LegacyReservationCode : RequiredString<LegacyReservationCod
     }
 }
 
+/// <summary>
+/// The four-argument overload assigning a blank code. TRLS060 catches a blank <c>Code</c> on an
+/// attribute because that is a literal an analyzer can read, but a code assigned here is only known
+/// once the value is rejected, so the generated code has to fall back at runtime. Either way an
+/// empty string must never reach the wire, where it would read as a reason rather than as the
+/// absence of one.
+/// </summary>
+public partial class BlankCodedReservation : RequiredString<BlankCodedReservation>
+{
+    static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode)
+    {
+        if (value.Length >= 4)
+            return;
+
+        errorMessage = "Blank Coded Reservation is too short.";
+        errorCode = "   ";
+    }
+}
+
 public class ReasonCodeOverrideTests
 {
     private static FieldViolation FirstViolation(Error error) =>
@@ -160,6 +179,12 @@ public class ReasonCodeOverrideTests
     public void ValidateAdditional_leaving_the_code_unset_falls_back_to_unspecified() =>
         FirstViolation(LegacyReservationCode.TryCreate("abc").UnwrapError()).ReasonCode
             .Should().Be(ValidationCodes.Unspecified);
+
+    [Fact]
+    public void ValidateAdditional_setting_a_blank_code_falls_back_to_unspecified() =>
+        FirstViolation(BlankCodedReservation.TryCreate("abc").UnwrapError()).ReasonCode
+            .Should().Be(ValidationCodes.Unspecified,
+                "a blank code on the wire reads as a reason rather than as the absence of one");
 
     [Fact]
     public void ValidateAdditional_still_reports_error_unspecified_for_the_three_argument_overload() =>

--- a/Trellis.Primitives/tests/RequiredPartialClassGeneratorDiagnosticsTests.cs
+++ b/Trellis.Primitives/tests/RequiredPartialClassGeneratorDiagnosticsTests.cs
@@ -325,8 +325,7 @@ public class RequiredPartialClassGeneratorDiagnosticsTests
     }
 
     [Fact]
-    public void TrimAndNotDefaultOnRequiredString_ReportsNoPlacementDiagnostic()
-    {
+    public void TrimAndNotDefaultOnRequiredString_ReportsNoPlacementDiagnostic()    {
         var cancellationToken = TestContext.Current.CancellationToken;
 
         const string source = """
@@ -344,6 +343,108 @@ public class RequiredPartialClassGeneratorDiagnosticsTests
 
         diagnostics.Should().NotContain(d => d.Id == "TRLS057");
         diagnostics.Should().NotContain(d => d.Id == "TRLS058");
+    }
+
+    [Theory]
+    [InlineData("[StringLength(5, Code = \"\")]", "RequiredString<Widget>", "[StringLength]")]
+    [InlineData("[StringLength(5, Code = \"   \")]", "RequiredString<Widget>", "[StringLength]")]
+    [InlineData("[Range(1, 5, Code = \"\")]", "RequiredInt<Widget>", "[Range]")]
+    [InlineData("[NotDefault(Code = \"\")]", "RequiredGuid<Widget>", "[NotDefault]")]
+    [InlineData("[Positive(Code = \"\")]", "RequiredInt<Widget>", "[Range]")]
+    public void EmptyReasonCodeOverride_Reports_TRLS060(string attribute, string baseType, string attributeInMessage)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var source = $$"""
+            using Trellis;
+
+            namespace TestNamespace;
+
+            {{attribute}}
+            public partial class Widget : {{baseType}}
+            {
+            }
+            """;
+
+        var diagnostics = RunGeneratorAndGetDiagnostics(source, cancellationToken);
+
+        var diagnostic = diagnostics.Single(d => d.Id == "TRLS060");
+        diagnostic.Severity.Should().Be(DiagnosticSeverity.Error);
+        diagnostic.GetMessage(CultureInfo.InvariantCulture).Should().Contain("Widget");
+        diagnostic.GetMessage(CultureInfo.InvariantCulture).Should().Contain(attributeInMessage);
+    }
+
+    [Fact]
+    public void NonEmptyReasonCodeOverride_ReportsNothing()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string source = """
+            using Trellis;
+
+            namespace TestNamespace;
+
+            [StringLength(5, Code = "widget.name.length")]
+            public partial class Widget : RequiredString<Widget>
+            {
+            }
+            """;
+
+        var diagnostics = RunGeneratorAndGetDiagnostics(source, cancellationToken);
+
+        diagnostics.Should().NotContain(d => d.Id == "TRLS060");
+    }
+
+    [Fact]
+    public void BothValidateAdditionalOverloads_Reports_TRLS061()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string source = """
+            using Trellis;
+
+            namespace TestNamespace;
+
+            public partial class Widget : RequiredString<Widget>
+            {
+                static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage)
+                {
+                }
+
+                static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode)
+                {
+                }
+            }
+            """;
+
+        var diagnostics = RunGeneratorAndGetDiagnostics(source, cancellationToken);
+
+        var diagnostic = diagnostics.Single(d => d.Id == "TRLS061");
+        diagnostic.Severity.Should().Be(DiagnosticSeverity.Error);
+        diagnostic.GetMessage(CultureInfo.InvariantCulture).Should().Contain("Widget");
+    }
+
+    [Fact]
+    public void SingleValidateAdditionalOverload_ReportsNothing()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string source = """
+            using Trellis;
+
+            namespace TestNamespace;
+
+            public partial class Widget : RequiredString<Widget>
+            {
+                static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode)
+                {
+                }
+            }
+            """;
+
+        var diagnostics = RunGeneratorAndGetDiagnostics(source, cancellationToken);
+
+        diagnostics.Should().NotContain(d => d.Id == "TRLS061");
     }
 
     [Fact]

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Analyzers
 namespaces: [Trellis, Trellis.Analyzers]
-types: [TrellisDiagnosticIds, DiagnosticDescriptors, ResultNotHandledAnalyzer, UseBindInsteadOfMapAnalyzer, UnsafeValueAccessAnalyzer, ResultDoubleWrappingAnalyzer, AsyncResultMisuseAnalyzer, MaybeDoubleWrappingAnalyzer, UseResultCombineAnalyzer, AsyncLambdaWithSyncMethodAnalyzer, ThrowInResultChainAnalyzer, UnsafeValueInLinqAnalyzer, CombineLimitAnalyzer, UseSaveChangesResultAnalyzer, HasIndexMaybePropertyAnalyzer, UnsafeResultDeconstructionAnalyzer, DefaultResultOrMaybeAnalyzer, CompositeValueObjectDtoConverterAnalyzer, RedundantEfConfigurationAnalyzer, OwnedEntityInitOnlyPropertyAnalyzer, AddResultGuardCodeFixProvider, UseBindInsteadOfMapCodeFixProvider, UseAsyncMethodVariantCodeFixProvider, UseSaveChangesResultCodeFixProvider, TRLS043, TRLS044, TRLS045, TRLS054, TRLS055, TRLS057, TRLS058]
+types: [TrellisDiagnosticIds, EmptyReasonCodeOverride, ValidateAdditionalOverloadConflict, DiagnosticDescriptors, ResultNotHandledAnalyzer, UseBindInsteadOfMapAnalyzer, UnsafeValueAccessAnalyzer, ResultDoubleWrappingAnalyzer, AsyncResultMisuseAnalyzer, MaybeDoubleWrappingAnalyzer, UseResultCombineAnalyzer, AsyncLambdaWithSyncMethodAnalyzer, ThrowInResultChainAnalyzer, UnsafeValueInLinqAnalyzer, CombineLimitAnalyzer, UseSaveChangesResultAnalyzer, HasIndexMaybePropertyAnalyzer, UnsafeResultDeconstructionAnalyzer, DefaultResultOrMaybeAnalyzer, CompositeValueObjectDtoConverterAnalyzer, RedundantEfConfigurationAnalyzer, OwnedEntityInitOnlyPropertyAnalyzer, AddResultGuardCodeFixProvider, UseBindInsteadOfMapCodeFixProvider, UseAsyncMethodVariantCodeFixProvider, UseSaveChangesResultCodeFixProvider, TRLS043, TRLS044, TRLS045, TRLS054, TRLS055, TRLS057, TRLS058]
 version: v3
 last_verified: 2026-06-17
 audience: [llm]
@@ -100,6 +100,9 @@ In test projects, `TRLS001` and `TRLS015` are the rules most likely to need tuni
 | `TRLS058` | Error | `[NotDefault]` on a sentinel-less Required base | Emitted by `RequiredPartialClassGenerator` when `[NotDefault]` is applied to `RequiredBool` or `RequiredEnum`. Those bases have no meaningful default sentinel to reject (every value is valid), so the attribute is a no-op. Remove the attribute. |
 | `TRLS059` | Warning | `JsonSerializerContext` has `[GenerateScalarValueConverters]` but no `[JsonSerializable]` | Emitted by `ScalarValueJsonConverterGenerator` (Trellis.AspSourceGenerator) when a context marked `[GenerateScalarValueConverters]` declares no `[JsonSerializable]` of its own. System.Text.Json's source generator only observes attributes present in the original compilation, so it skips such a context entirely and never emits the abstract members `JsonSerializerContext` requires — failing the build with two CS0534 errors that give no hint about the cause. Trellis cannot supply the attribute on your behalf, because source generators cannot observe one another's output. Add at least one `[JsonSerializable(typeof(...))]`. |
 
+| `TRLS060` | Error | Reason-code override is empty | Emitted by `RequiredPartialClassGenerator` when `[StringLength]`, `[Range]`, `[NotDefault]`, or one of the sign-convenience attributes sets `Code` to an empty or whitespace string. An application may name a failure in its own terms, but an empty code names nothing and would reach the wire where a client expects a catalog key. Give the failure a name, or omit `Code` to keep the framework default. |
+| `TRLS061` | Error | Both `ValidateAdditional` overloads declared | Emitted by `RequiredPartialClassGenerator` when a value object declares both the three-argument `ValidateAdditional` and the four-argument overload that can set a reason code. The generator emits one defining declaration, so the other implementation would fail with a compiler error that names no Trellis concept. Keep one. |
+
 ## Constants — `TrellisDiagnosticIds`
 
 The public static class `Trellis.TrellisDiagnosticIds` (in the `Trellis.Analyzers` assembly) exposes every diagnostic ID above as a `public const string`. Use it from `[SuppressMessage]` attributes and rule sets to avoid magic strings:
@@ -110,7 +113,7 @@ The public static class `Trellis.TrellisDiagnosticIds` (in the `Trellis.Analyzer
 public string GetCity(Maybe<Address> address) => address.Value.City;
 ```
 
-Generator IDs (`TRLS031`–`TRLS045`, `TRLS056`–`TRLS058`) and the LINQ-analyzer IDs (`TRLS054`–`TRLS055`) are also exposed as constants on the same class so consumers have a single canonical reference for the unified namespace.
+Generator IDs (`TRLS031`–`TRLS045`, `TRLS056`–`TRLS058`, `TRLS060`–`TRLS061`) and the LINQ-analyzer IDs (`TRLS054`–`TRLS055`) are also exposed as constants on the same class so consumers have a single canonical reference for the unified namespace.
 
 ### Constant → diagnostic ID → emitter
 
@@ -155,6 +158,8 @@ Every `public const string` field on `TrellisDiagnosticIds`, the diagnostic ID i
 | `TrimOnNonStringBase` | `TRLS057` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `NotDefaultOnSentinellessBase` | `TRLS058` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `SerializerContextHasNoJsonSerializable` | `TRLS059` | `ScalarValueJsonConverterGenerator` (Trellis.AspSourceGenerator) |
+| `EmptyReasonCodeOverride` | `TRLS060` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
+| `ValidateAdditionalOverloadConflict` | `TRLS061` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 
 ## Descriptors — `DiagnosticDescriptors`
 
@@ -188,7 +193,7 @@ Every descriptor uses the single shared category `Trellis` (defined as `private 
 
 > **Note:** The TRLS013 descriptor was originally exposed as `UnsafeValueInLinq`. The current canonical name is `UnsafeMaybeValueInLinq` (matching the `TrellisDiagnosticIds.UnsafeMaybeValueInLinq` constant); the old name is retained as an `[Obsolete]` alias pointing at the same `DiagnosticDescriptor` instance for backward compatibility. New code should reference `UnsafeMaybeValueInLinq`.
 
-> **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS045` and `TRLS056`–`TRLS058`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
+> **Note:** Generator-emitted diagnostics (`TRLS031`–`TRLS045`, `TRLS056`–`TRLS058` and `TRLS060`–`TRLS061`) are constructed inline by the source generators and are *not* exposed as fields on `DiagnosticDescriptors`. Use the `TrellisDiagnosticIds` constants instead for those IDs.
 
 ```csharp
 // Re-exporting an analyzer rule in a custom analyzer:

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -25,7 +25,7 @@ audience: [llm]
   - [trellis-api-statemachine.md](trellis-api-statemachine.md#use-this-file-when) — `FireResult`, `LazyStateMachine<,>`
   - [trellis-api-testing-reference.md](trellis-api-testing-reference.md#use-this-file-when) — `Should().Be(...)`, `UnwrapError()`
   - [trellis-api-testing-aspnetcore.md](trellis-api-testing-aspnetcore.md#use-this-file-when) — `WebApplicationFactoryExtensions`, `.http` replay helpers
-  - [trellis-api-analyzers.md](trellis-api-analyzers.md#use-this-file-when) — `TRLS001`-`TRLS059`, `TrellisDiagnosticIds`
+  - [trellis-api-analyzers.md](trellis-api-analyzers.md#use-this-file-when) — `TRLS001`-`TRLS061`, `TrellisDiagnosticIds`
 
 ## How to read these recipes
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -654,8 +654,8 @@ Emit these by constant, not by literal — a typo in a literal is a silent wire 
 | `FormatDuration` | `format.duration` | Not parseable as `TimeSpan`. |
 | `FormatConversion` | `format.conversion` | Conversion to the target type failed with no more specific code — including a JSON token of the wrong kind. |
 | `StringLength` | `string.length` | Length outside an allowed range. |
-| `StringMinLength` | `string.min-length` | Shorter than the minimum. Args: `minLength`. |
-| `StringMaxLength` | `string.max-length` | Longer than the maximum. Args: `maxLength`; the FluentValidation adapter adds `totalLength`, which generated primitives do not carry. |
+| `StringMinLength` | `string.min-length` | Shorter than the minimum. Args: `minLength`, `totalLength`. |
+| `StringMaxLength` | `string.max-length` | Longer than the maximum. Args: `maxLength`, `totalLength`. Generated primitives and the FluentValidation adapter agree on both, so a client renders the same message whichever producer noticed. |
 | `StringExactLength` | `string.exact-length` | Not the required exact length. |
 | `StringPattern` | `string.pattern` | Did not match a required regular expression. |
 | `StringEmail` | `string.email` | Not a valid email address. |
@@ -2087,6 +2087,12 @@ Numeric Required bases (`RequiredInt`, `RequiredLong`, `RequiredDecimal`) accept
 
 The lenient defaults also drive the EF Core `TrellisScalarConverter` read path: only `null` triggers `TrellisPersistenceMappingException` during materialization. When `[NotDefault]` is present, persisted sentinel values also throw. Add `[NotDefault]` for columns where the sentinel is never valid persisted domain state.
 
+#### Overriding a constraint's reason code
+
+`RangeAttribute`, `StringLengthAttribute`, `NotDefaultAttribute`, `PositiveAttribute`, `NonNegativeAttribute`, `NegativeAttribute`, and `NonPositiveAttribute` each carry an optional `Code` that replaces the framework reason code on the resulting `FieldViolation`. `TrimAttribute` carries none, because trimming normalizes and cannot fail. The four sign attributes share `RangeAttribute`'s slot, since they synthesize into the same range emission. An empty or whitespace `Code` is `TRLS060`.
+
+The framework vocabulary stays frozen and stays the default; the freeze constrains Trellis, not the application. `ValidateAdditional` also has a four-argument overload — `(T value, string fieldName, ref string? errorMessage, ref string? errorCode)` — that names a custom rule's failure instead of reporting `error.unspecified`; declaring both overloads is `TRLS061`. See [trellis-api-primitives.md](trellis-api-primitives.md#overriding-the-reason-code--code) for the full treatment.
+
 ### `ResultRequiresExplicitHttpMappingConverter`
 
 ```csharp
@@ -2115,7 +2121,7 @@ public sealed class RangeAttribute : Attribute
 
 | Name | Type | Description |
 | --- | --- | --- |
-| — | — | Constructor arguments are consumed by the source generator; no public properties are exposed. |
+| `Code` | `string?` | Replaces the framework reason code on both directional failures. `null` keeps `value.greater-than-or-equal` / `value.less-than-or-equal`. |
 
 | Signature | Returns | Description |
 | --- | --- | --- |
@@ -2134,6 +2140,7 @@ public sealed class StringLengthAttribute : Attribute
 | --- | --- | --- |
 | `MaximumLength` | `int` | Inclusive maximum length. |
 | `MinimumLength` | `int` | Inclusive minimum length; defaults to `0`. |
+| `Code` | `string?` | Replaces the framework reason code on both length failures. `null` keeps `string.min-length` / `string.max-length`. |
 
 | Signature | Returns | Description |
 | --- | --- | --- |
@@ -2151,6 +2158,10 @@ Opt-in attribute consumed by `Trellis.Core.Generator`. When present, the generat
 | Signature | Returns | Description |
 | --- | --- | --- |
 | `public NotDefaultAttribute()` | `NotDefaultAttribute` | Marker only — no constructor arguments. |
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `Code` | `string?` | Replaces the framework reason code on the sentinel rejection. `null` keeps `value.not-default`, or `value.not-empty` on `RequiredString<TSelf>`. |
 
 ### `TrimAttribute`
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.FluentValidation
 namespaces: [Trellis.FluentValidation]
-types: [FluentValidationResultExtensions, JsonPointerNormalizer, ValidationArgsProjection, ValidationCodeProjection]
+types: [FluentValidationResultExtensions, JsonPointerNormalizer, ValidationArgsProjection, ValidationArgsOptions, ValidationCodeProjection]
 version: v3
 last_verified: 2026-06-04
 audience: [llm]
@@ -36,6 +36,7 @@ For wiring FluentValidation validators into the Trellis Mediator validation stag
 | Validate a value outside Mediator | `validator.ValidateToResult(value)` / `ValidateToResultAsync(...)` | [`FluentValidationResultExtensions`](#fluentvalidationresultextensions) |
 | Normalize a FluentValidation property name into a JSON pointer | `JsonPointerNormalizer.ToJsonPointer(propertyName)` | [`JsonPointerNormalizer`](#jsonpointernormalizer) |
 | Wire FluentValidation into the Mediator pipeline | `services.AddTrellisFluentValidation()` from `Trellis.Mediator.FluentValidation` | [trellis-api-mediator-fluentvalidation.md](trellis-api-mediator-fluentvalidation.md#fluentvalidationservicecollectionextensions) |
+| A custom `Must()` rule emits no machine-readable `args` | Opt the placeholder in with `ValidationArgsOptions.AllowArgs(...)` | [`ValidationArgsOptions`](#validationargsoptions) |
 
 ## Common traps
 
@@ -168,7 +169,7 @@ public static class ValidationArgsProjection
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static ImmutableDictionary<string, string>? Project(ValidationFailure failure)` | `ImmutableDictionary<string,string>?` | Projects a failure's `FormattedMessagePlaceholderValues` onto the `Args` carried by `FieldViolation`, applying the allowlist, the containment gate and the encoding rules below. Returns `null` when nothing survives. Both adapters call this — `FluentValidationResultExtensions.ToResult` and, in `Trellis.Mediator.FluentValidation`, `FluentValidationMessageValidatorAdapter`. |
+| `public static ImmutableDictionary<string, string>? Project(ValidationFailure failure, ValidationArgsOptions? options = null)` | `ImmutableDictionary<string,string>?` | Projects a failure's `FormattedMessagePlaceholderValues` onto the `Args` carried by `FieldViolation`, applying the allowlist, the containment gate and the encoding rules below. Returns `null` when nothing survives. Both adapters call this — `FluentValidationResultExtensions.ToResult` and, in `Trellis.Mediator.FluentValidation`, `FluentValidationMessageValidatorAdapter`. |
 
 `Args` is what lets a client render its own localized message instead of displaying the server's English prose. Blanket camelCase pass-through of FluentValidation's placeholders is unsafe on two independent counts, so two controls apply.
 
@@ -223,6 +224,42 @@ The gate compares FluentValidation's **rendered** form, because that is what the
 
 In practice that makes temporal args a standing false negative, since a culture-rendered date and a round-trip one essentially never coincide. That direction is deliberate — a false negative hides a safe arg and stays recoverable through an explicit opt-in, while a false positive discloses and cannot be taken back. Bounding and escaping are reconciled rather than treated as a mismatch: `Sanitize` derives every character it emits from a character of the value the gate already accepted — truncation omits, escaping re-encodes — so it cannot introduce content the message lacked, even though its output is not byte-for-byte present there. Demanding verbatim presence would suppress exactly the long and control-bearing values the bound exists to serve.
 
+### `ValidationArgsOptions`
+
+**Declaration**
+
+```csharp
+public sealed class ValidationArgsOptions
+```
+
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `Default` | `ValidationArgsOptions` | The static configuration used when the application registered none. Widens nothing. |
+
+**Methods**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public ValidationArgsOptions AllowArgs(string errorCode, params string[] placeholderNames)` | `ValidationArgsOptions` | Allows the named placeholders — spelled as FluentValidation spells them, in PascalCase — to be emitted for failures carrying `errorCode`. Returns the same instance so calls chain. Throws `ArgumentException` for a blank error code or name, or for a placeholder that can never be allowed. |
+
+This is the explicit opt-in the two controls above defer to. The default allowlist carries only the operands whose meaning Trellis can vouch for across every validator that populates them, so a rule Trellis did not write — a `Must()` with `context.MessageFormatter.AppendArgument(...)`, or a validator behind a custom `WithErrorCode` — emits no args at all. `AllowArgs` is how the application supplies the knowledge Trellis lacks.
+
+```csharp
+services.Configure<ValidationArgsOptions>(options =>
+    options.AllowArgs("MinimumAge", "MinAge"));
+```
+
+`AddTrellisFluentValidation()` calls `AddOptions<ValidationArgsOptions>()`, so the Mediator pipeline adapter always resolves the configured instance. The standalone `ToResult` / `ValidateToResult` / `ValidateToResultAsync` helpers have no container to read from, so they take the same object through an optional `argsOptions` parameter.
+
+Three properties are worth stating, because each is load-bearing:
+
+- **It only ever widens.** There is no remove operation. The default set is the conservative one, so removing could only narrow a client contract something already depends on — and an application that wants fewer args can stop reading them.
+- **An explicit opt-in satisfies the template half of the containment gate without consulting the template.** The template check defends against a placeholder *Trellis guessed* was safe, which is why coincidence can fool it; an application naming its own validator's placeholder is not guessing, and a custom validator has no language-manager entry for the check to consult. Leaving it in force would make the opt-in inert. **The message half still holds**, so an opted-in arg still cannot carry anything the client's own message did not.
+- **`PropertyValue` and `PropertyPath` can never be re-admitted.** `AllowArgs` throws rather than silently dropping them, because an application that asked for `PropertyValue` has misunderstood what args are for and a silent drop would leave it waiting for an arg that is never coming.
+
+
 ## Extension methods
 
 ### `FluentValidationResultExtensions`
@@ -231,19 +268,22 @@ In practice that makes temporal args a standing false negative, since a culture-
 public static Result<T> ToResult<T>(
     this ValidationResult validationResult,
     T value,
-    [CallerArgumentExpression(nameof(value))] string paramName = "value")
+    [CallerArgumentExpression(nameof(value))] string paramName = "value",
+    ValidationArgsOptions? argsOptions = null)
 
 public static Result<T> ValidateToResult<T>(
     this IValidator<T> validator,
     T value,
     [CallerArgumentExpression(nameof(value))] string paramName = "value",
-    string? message = null)
+    string? message = null,
+    ValidationArgsOptions? argsOptions = null)
 
 public static async Task<Result<T>> ValidateToResultAsync<T>(
     this IValidator<T> validator,
     T value,
     [CallerArgumentExpression(nameof(value))] string paramName = "value",
     string? message = null,
+    ValidationArgsOptions? argsOptions = null,
     CancellationToken cancellationToken = default)
 ```
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -236,13 +236,13 @@ public sealed class ValidationArgsOptions
 
 | Name | Type | Description |
 | --- | --- | --- |
-| `Default` | `ValidationArgsOptions` | The static configuration used when the application registered none. Widens nothing. |
+| `Default` | `ValidationArgsOptions` | The static configuration used when the application registered none. Widens nothing, and rejects `AllowArgs` with `InvalidOperationException` because it is shared process-wide. |
 
 **Methods**
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public ValidationArgsOptions AllowArgs(string errorCode, params string[] placeholderNames)` | `ValidationArgsOptions` | Allows the named placeholders — spelled as FluentValidation spells them, in PascalCase — to be emitted for failures carrying `errorCode`. Returns the same instance so calls chain. Throws `ArgumentException` for a blank error code or name, or for a placeholder that can never be allowed. |
+| `public ValidationArgsOptions AllowArgs(string errorCode, params string[] placeholderNames)` | `ValidationArgsOptions` | Allows the named placeholders — spelled as FluentValidation spells them, in PascalCase — to be emitted for failures carrying `errorCode`. Returns the same instance so calls chain. Throws `ArgumentException` for a blank error code or name, or for a placeholder that can never be allowed, and `InvalidOperationException` when called on `Default`. |
 
 This is the explicit opt-in the two controls above defer to. The default allowlist carries only the operands whose meaning Trellis can vouch for across every validator that populates them, so a rule Trellis did not write — a `Must()` with `context.MessageFormatter.AppendArgument(...)`, or a validator behind a custom `WithErrorCode` — emits no args at all. `AllowArgs` is how the application supplies the knowledge Trellis lacks.
 
@@ -257,7 +257,9 @@ Three properties are worth stating, because each is load-bearing:
 
 - **It only ever widens.** There is no remove operation. The default set is the conservative one, so removing could only narrow a client contract something already depends on — and an application that wants fewer args can stop reading them.
 - **An explicit opt-in satisfies the template half of the containment gate without consulting the template.** The template check defends against a placeholder *Trellis guessed* was safe, which is why coincidence can fool it; an application naming its own validator's placeholder is not guessing, and a custom validator has no language-manager entry for the check to consult. Leaving it in force would make the opt-in inert. **The message half still holds**, so an opted-in arg still cannot carry anything the client's own message did not.
-- **`PropertyValue` and `PropertyPath` can never be re-admitted.** `AllowArgs` throws rather than silently dropping them, because an application that asked for `PropertyValue` has misunderstood what args are for and a silent drop would leave it waiting for an arg that is never coming.
+- **`PropertyValue` and `PropertyPath` can never be re-admitted.** `AllowArgs` throws rather than silently dropping them, because an application that asked for `PropertyValue` has misunderstood what args are for and a silent drop would leave it waiting for an arg that is never coming. The two are denied for different reasons, and the exception says which: `PropertyValue` carries the submitted input verbatim, a disclosure and PII hazard; `PropertyPath` carries the traversal path the violation's own location already reports.
+
+- **`Default` cannot be widened.** It is shared process-wide, so `ValidationArgsOptions.Default.AllowArgs(...)` throws `InvalidOperationException` rather than applying a global effect from what reads like a local one. Register through `services.Configure<ValidationArgsOptions>(...)`, which hands out an instance of your own.
 
 
 ## Extension methods

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -41,6 +41,8 @@ See also: [trellis-api-cookbook.md](trellis-api-cookbook.md#recipe-1--crud-aggre
 | Define a custom SKU/order-id primitive | Use `partial class Sku : RequiredString<Sku>` or `partial class OrderId : RequiredGuid<OrderId>` from `Trellis.Core` | [Core primitive base classes](trellis-api-core.md#primitive-value-object-base-classes) |
 | Opt into strict Required behavior | Use `[NotDefault]` to reject the type's sentinel, `[Trim]` to enable string trimming | [`Required*` defaults and opt-ins](#required-defaults-and-opt-ins) |
 | Add length/range constraints to custom primitives | Use Trellis `[StringLength]` / `[Range]` attributes from `namespace Trellis`, not DataAnnotations | [Core attributes](trellis-api-core.md#primitive-value-object-base-classes) |
+| Report an application's own reason code instead of the framework's | Set `Code` on the constraint attribute | [Overriding the reason code](#overriding-the-reason-code--code) |
+| Name a failure raised by a custom rule rather than reporting `error.unspecified` | Declare the four-argument `ValidateAdditional` | [Naming a failure from `ValidateAdditional`](#naming-a-failure-from-validateadditional) |
 | Add JSON for composite value objects | `CompositeValueObjectJsonConverter<T>` | [`CompositeValueObjectJsonConverter<T>`](#compositevalueobjectjsonconvertert) |
 
 ## Common traps
@@ -113,6 +115,62 @@ Validation order:
 | TRLS045 | Error | Numeric convenience attribute combined with explicit `[Range]` |
 | TRLS057 | Error | `[Trim]` on a Required base other than `RequiredString` |
 | TRLS058 | Error | `[NotDefault]` on `RequiredBool` or `RequiredEnum` (no default sentinel to reject) |
+| TRLS060 | Error | A constraint attribute's `Code` is empty or whitespace |
+| TRLS061 | Error | Both `ValidateAdditional` overloads declared on one value object |
+
+### Overriding the reason code — `Code`
+
+Every constraint attribute that can *fail* carries an optional `Code`, which replaces the framework reason code on the resulting `FieldViolation`:
+
+```csharp
+[StringLength(8, MinimumLength = 3, Code = "account.reference.length")]
+public partial class AccountReference : RequiredString<AccountReference>;
+
+[Range(1, 10, Code = "cart.quantity.out-of-range")]
+public partial class CartQuantity : RequiredInt<CartQuantity>;
+
+[NotDefault(Code = "tenant.id.missing")]
+public partial class TenantId : RequiredGuid<TenantId>;
+```
+
+`RangeAttribute`, `StringLengthAttribute`, `NotDefaultAttribute`, `PositiveAttribute`, `NonNegativeAttribute`, `NegativeAttribute`, and `NonPositiveAttribute` all expose `Code`. `TrimAttribute` does not, because trimming normalizes and cannot fail.
+
+Three consequences are worth stating plainly, because each surprises someone:
+
+- **The framework vocabulary stays frozen and stays the default.** Overriding is not encouraged or discouraged; no analyzer pressures either choice. The freeze constrains *Trellis*, not your application — an application that overrides owns both ends of its own contract.
+- **`[Range].Code` collapses both directions.** One attribute produces two failures — below the minimum and above the maximum — and one `Code` renames both. When a client must tell them apart, keep the framework codes and use `ValidateAdditional` for the case that needs its own name.
+- **The four sign-convenience attributes share the range slot.** `[Positive]`, `[NonNegative]`, `[Negative]`, and `[NonPositive]` synthesize into the same range emission, so their `Code` overrides the same reason code `[Range]` would.
+
+The null check is never overridable: it belongs to no attribute and always reports `value.not-null`.
+
+### Naming a failure from `ValidateAdditional`
+
+`ValidateAdditional` has two shapes, and a value object declares at most one:
+
+```csharp
+// Reports error.unspecified, which is what it has always meant.
+static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage);
+
+// Can name the failure.
+static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode);
+```
+
+The generator emits whichever declaration you implemented, so existing three-argument implementations compile and behave unchanged. In the four-argument form, setting `errorMessage` still decides *whether* the value is rejected; leaving `errorCode` unset falls back to `error.unspecified`. Declaring both overloads is `TRLS061`.
+
+```csharp
+public partial class ReservationCode : RequiredString<ReservationCode>
+{
+    static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode)
+    {
+        if (value.StartsWith("RES-", StringComparison.Ordinal))
+            return;
+
+        errorMessage = "Reservation Code must start with RES-.";
+        errorCode = "reservation.code.malformed";
+    }
+}
+```
+
 
 ## Types
 

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -155,7 +155,7 @@ static partial void ValidateAdditional(string value, string fieldName, ref strin
 static partial void ValidateAdditional(string value, string fieldName, ref string? errorMessage, ref string? errorCode);
 ```
 
-The generator emits whichever declaration you implemented, so existing three-argument implementations compile and behave unchanged. In the four-argument form, setting `errorMessage` still decides *whether* the value is rejected; leaving `errorCode` unset falls back to `error.unspecified`. Declaring both overloads is `TRLS061`.
+The generator emits whichever declaration you implemented, so existing three-argument implementations compile and behave unchanged. In the four-argument form, setting `errorMessage` still decides *whether* the value is rejected; leaving `errorCode` unset — or setting it to a blank string — falls back to `error.unspecified`, because an empty code on the wire reads as a reason rather than as the absence of one. (`TRLS060` catches the same mistake on an attribute's `Code`, where the value is a literal an analyzer can read.) Declaring both overloads is `TRLS061`.
 
 ```csharp
 public partial class ReservationCode : RequiredString<ReservationCode>


### PR DESCRIPTION
## What

PR 3 froze the validation vocabulary so a consumer can switch over reason codes and trust the result. The freeze constrains *Trellis*, not the application — an application that owns both ends of its own contract should be able to name a failure in its own words. This PR adds that override, and closes the two places where the vocabulary could not be reached at all.

Completes the 4-PR series: #716 (problem-object level) → #717 (mechanism layer) → #718 (frozen vocabulary) → this.

## Overriding a constraint's reason code

Seven constraint attributes gain a `Code` property:

```csharp
[StringLength(8, MinimumLength = 3, Code = "account.reference.length")]
public partial class AccountReference : RequiredString<AccountReference> { }
```

```json
{ "pointer": "/accountReference", "code": "account.reference.length",
  "args": { "minLength": "3", "maxLength": "8", "totalLength": "24" } }
```

`[Range]`, `[StringLength]`, `[NotDefault]`, and the four sign conveniences (`[Positive]`, `[NonNegative]`, `[Negative]`, `[NonPositive]`). **Set nothing and nothing changes** — the default emission is byte-identical, verified against generated output.

Three deliberate boundaries:

- **`[Trim]` gets no `Code`.** It normalizes and cannot fail, so there is no failure to name.
- **`[Range].Code` collapses both directional failures onto one code.** Per-bound `MinCode`/`MaxCode` would double the attribute surface to serve a case `ValidateAdditional` already serves. The four sign attributes share the same slot because they synthesize into the same range emission.
- **The null check is never overridable.** It belongs to no attribute, so `value.not-null` always means *absent* — the one distinction a consumer can rely on without reading the producer's source.

The default is still emitted as a `ValidationCodes` reference rather than its literal value, so renaming a constant stays a compile error in generated code instead of a silently divergent string.

## `ValidateAdditional` can name its failure

Hand-written extra validation previously had no way to reach the vocabulary at all — every failure came out `error.unspecified`.

```csharp
private static void ValidateAdditional(
    string value, string fieldName, ref string? message, ref string? code)
{
    if (!value.StartsWith("AC-", StringComparison.Ordinal))
    {
        message = "Account references start with AC-.";
        code = "account.reference.prefix";
    }
}
```

An **overload**, not a changed signature: an existing three-argument implementation compiles untouched and keeps emitting `error.unspecified`, which is what it emitted before.

## `totalLength` on generated length violations

Generated `[StringLength]` violations now carry `totalLength` alongside the bounds, so a client can render "24 of 8 characters" without parsing the detail string. It is an operand, not the rejected value — PR 3's disclosure invariant holds.

## FluentValidation args opt-in

`ValidationArgsProjection` gated arg emission on **both** (a) the culture-active template naming the placeholder and (b) the rendered value appearing in the message. A `Must()` rule has no language-manager template, so (a) could never hold — **no widening was reachable for exactly the validators that needed it.**

```csharp
services.Configure<ValidationArgsOptions>(o => o.AllowArgs("MinimumAge", "MinAge"));
```

`AllowArgs` satisfies (a) explicitly. The justification is narrow: (a) defends against a placeholder *Trellis guessed* was safe, and an application naming its own validator's placeholder is not guessing. **(b) is the actual disclosure control and still holds unchanged** — a value that does not appear in the rendered message is still never emitted.

`PropertyValue` and `PropertyPath` **throw** rather than drop silently, because a silent drop leaves the caller waiting for an arg that is never coming.

## Diagnostics

| ID | Fires when |
|---|---|
| `TRLS060` | `Code` is empty or whitespace — would ship an empty string to the wire |
| `TRLS061` | Both the 3-arg and 4-arg `ValidateAdditional` are declared |

## Examples sweep

`Examples/` no longer teaches the legacy `"validation.error"` sentinel (~44 sites). Where a check is a domain rule rather than a vocabulary entry, the example now names the rule — `product.insufficient-stock`, `order.invalid-transition` — because reaching for `error.unspecified` is the habit the vocabulary exists to break.

## Breaking change

`ValidateToResultAsync` takes `argsOptions` **before** `cancellationToken` (CA1068 requires the token last). Source-breaking for a caller passing the token positionally:

```csharp
// before
await validator.ValidateToResultAsync(cmd, "cmd", null, ct);
// after
await validator.ValidateToResultAsync(cmd, "cmd", null, cancellationToken: ct);
```

Recorded in `CHANGELOG.md` and in a new `Trellis.FluentValidation/src/CompatibilitySuppressions.xml`, per the policy in `Directory.Build.props` that a break must be reviewable in the diff rather than invisible.

## Validation

| Gate | Result |
|---|---|
| Debug build + full test | clean — **7848 / 7887** pass, 39 skipped, 0 fail |
| Release build | clean |
| Doc completeness audit | 0 undocumented types/members |
| `lint-api-reference.ps1` | passed, 28 files |
| `dotnet pack` APICompat | clean (3 deliberate CP0002s recorded) |
| Native AOT publish | succeeded, 0 IL/AOT warnings |

One review finding fixed: `CodeOrDefault` hand-escaped only `\` and `"`, so a `Code` containing a newline emitted source that would not compile. Now uses `SymbolDisplay.FormatLiteral`, with a regression test pinning quotes, backslashes, newlines, and tabs.

## Docs

`trellis-api-primitives.md` (two new sections), `trellis-api-core.md` (`Code` rows on three attribute tables + an override subsection), `trellis-api-fluentvalidation.md` (`ValidationArgsOptions`), `trellis-api-analyzers.md`, `trellis-api-cookbook.md`, `MIGRATION_v3.md`, `CHANGELOG.md`.

## Follow-up

An analyzer flagging `Must()` rules that leave the sentinel code in place — agreed as a separate PR.
