### PR TITLE
Fail the build when a package would ship without API references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -110,6 +110,24 @@ If the new helper falls in the first category, the work is **not complete** unti
 
 If it falls in the second category, say so explicitly in the PR description and add the helper to `RegistrationSurfaceTests.Expected` with `Slot: null` and a reason, so the next session does not re-litigate the decision.
 
+### Adding a new packable package
+
+A new package must deliver the API reference set to whoever installs it. The references are what an agent reads before writing Trellis code, so a package that ships without them leaves an agent in a consuming project with no signatures to work from — and it invents plausible ones instead, which is the failure the reference set exists to prevent.
+
+Delivery is opt-in per csproj, and opt-in is how a package comes to ship with none: `Trellis.ResourceNaming.Azure` published that way and nothing failed. There are three valid routes, and a new package must take one:
+
+| Route | How | Who uses it |
+|---|---|---|
+| Ship the whole set | `<TrellisShipsApiReferenceSet>true</TrellisShipsApiReferenceSet>` | `Trellis.Core` only |
+| Ship its own reference | `<TrellisShipsOwnApiReference>true</TrellisShipsOwnApiReference>` + `<TrellisApiRefName>` | `Trellis.Analyzers`, which cannot depend on Core; and packages published from **other repositories**, which version independently and use `build/Trellis.ApiReference.Payload.targets` |
+| Inherit it | a `ProjectReference` path to `Trellis.Core` | every other first-party package |
+
+**This is enforced, not advisory.** `Trellis.Core/tests/Packaging/ApiReferencePayloadGateTests.cs` enumerates every packable `*/src/*.csproj` and walks the first-party project graph, so a package with no route to a payload fails the build. It enumerates rather than hand-lists deliberately: a hand-listed set stops covering the next package added, which is the same miss one generation later. Two companion assertions close the ways that enumeration could go quiet — a typo'd `TrellisApiRefName` (otherwise silent, because the MSBuild `Include` matches nothing and the package packs successfully with no reference), and a packable project added **outside** the `*/src/` convention, which the enumeration would simply not see.
+
+So: put a new package at `<Package>/src/<Package>.csproj`. A project that lives elsewhere must be marked `IsPackable=false` or it fails the gate.
+
+Also set `<TrellisApiRefName>` on any package that owns a reference file, even when it inherits delivery: TRLDOC004, the freshness audit, and the completeness audit all key off it.
+
 ### Validating sub-agent findings
 
 Sub-agents (rubber-duck, code-review) are recommendation engines, not ground truth. Before adopting a finding:

--- a/Trellis.Core/tests/Packaging/ApiReferencePayloadGateTests.cs
+++ b/Trellis.Core/tests/Packaging/ApiReferencePayloadGateTests.cs
@@ -1,0 +1,224 @@
+﻿namespace Trellis.Core.Tests.Packaging;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Xunit;
+
+/// <summary>
+/// Every packable Trellis package must deliver the API reference set to whoever installs it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The references are what an agent reads before writing Trellis code. A package that ships
+/// without them is not merely undocumented: an agent working in a project that installed it has
+/// no signatures to work from and invents plausible ones instead, which is the failure the whole
+/// reference set exists to prevent.
+/// </para>
+/// <para>
+/// Delivery is opt-in per csproj, and opt-in is exactly how a package comes to ship with none —
+/// <c>Trellis.ResourceNaming.Azure</c> published that way, and nothing failed. Enumerating the
+/// projects rather than hand-listing them is the point: a hand-listed set stops covering the next
+/// package added, which is the same miss one generation later. This is the same class of gate as
+/// <c>RegistrationSurfaceTests</c>, which made the <c>AddXxx</c>/<c>UseXxx</c> slot rule
+/// enforceable rather than merely documented.
+/// </para>
+/// </remarks>
+public class ApiReferencePayloadGateTests
+{
+    [Fact]
+    public void Every_packable_package_delivers_the_api_reference_set()
+    {
+        var projects = PackableProjects();
+
+        projects.Should().NotBeEmpty("the enumeration must actually find the repository's projects");
+
+        var undelivered = projects
+            .Where(p => !DeliversReferenceSet(p, projects))
+            .Select(p => p.Name)
+            .ToList();
+
+        undelivered.Should().BeEmpty(
+            "a packable package must ship the reference set, ship its own reference, or depend on "
+            + "a package that does — otherwise an agent in a consuming project has no signatures to "
+            + "work from and will invent them");
+    }
+
+    [Fact]
+    public void Every_declared_reference_name_resolves_to_a_file()
+    {
+        var root = RepositoryRoot();
+
+        var dangling = PackableProjects()
+            .Where(p => !string.IsNullOrEmpty(p.ApiRefName))
+            .Where(p => !File.Exists(Path.Combine(
+                root, "docs", "docfx_project", "api_reference", $"trellis-api-{p.ApiRefName}.md")))
+            .Select(p => $"{p.Name} -> trellis-api-{p.ApiRefName}.md")
+            .ToList();
+
+        // A typo here is silent: the MSBuild None/Include simply matches nothing, so the package
+        // packs successfully and ships no reference. The audits key off the same property, so they
+        // go quiet at the same moment rather than catching it.
+        dangling.Should().BeEmpty("every TrellisApiRefName must name a reference file that exists");
+    }
+
+    [Fact]
+    public void No_shipping_package_hides_outside_the_src_convention()
+    {
+        // The gate above finds packages by the repo convention that every shipping package lives at
+        // <Package>/src/<Package>.csproj. That filter is load-bearing rather than incidental: it is
+        // the only reason test and example projects, whose csproj files do not declare IsPackable
+        // themselves, stay out of the enumeration.
+        //
+        // So a packable project added anywhere else would be silently skipped -- the enumeration
+        // quietly stops covering it, which is the same "hand-listed set goes stale" failure the
+        // enumeration exists to avoid, one level up. This asserts the convention itself, so such a
+        // project fails here instead of shipping without docs.
+        var stray = OutsideSrcProjects()
+            .Where(path => !Path.GetFileNameWithoutExtension(path).EndsWith(".Tests", StringComparison.Ordinal))
+            .Where(path => !DeclaresNonPackable(path))
+            .Select(path => Path.GetRelativePath(RepositoryRoot(), path))
+            .ToList();
+
+        stray.Should().BeEmpty(
+            "a project outside */src/ that is not marked IsPackable=false is invisible to the "
+            + "payload gate — move it under src/ so it is covered, or mark it non-packable");
+    }
+
+    /// <summary>
+    /// True when the project, or any <c>Directory.Build.props</c> above it, opts out of packing.
+    /// The walk matters: the example projects declare nothing themselves and inherit the opt-out.
+    /// </summary>
+    private static bool DeclaresNonPackable(string projectPath)
+    {
+        if (SaysNotPackable(projectPath))
+            return true;
+
+        var root = RepositoryRoot();
+        var directory = new DirectoryInfo(Path.GetDirectoryName(projectPath)!);
+
+        while (directory is not null)
+        {
+            var props = Path.Combine(directory.FullName, "Directory.Build.props");
+            if (File.Exists(props) && SaysNotPackable(props))
+                return true;
+
+            if (string.Equals(directory.FullName, root, StringComparison.OrdinalIgnoreCase))
+                break;
+
+            directory = directory.Parent;
+        }
+
+        return false;
+    }
+
+    private static bool SaysNotPackable(string path)
+    {
+        // Namespace-agnostic: Directory.Build.props declares the legacy MSBuild namespace while the
+        // csproj files do not, so matching on local name is what makes one reader serve both.
+        var document = XDocument.Load(path);
+        return document.Descendants()
+            .Where(e => e.Name.LocalName == "IsPackable")
+            .Any(e => string.Equals(e.Value.Trim(), "false", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IEnumerable<string> OutsideSrcProjects()
+    {
+        var separator = Path.DirectorySeparatorChar;
+
+        return Directory.EnumerateFiles(RepositoryRoot(), "*.csproj", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{separator}src{separator}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{separator}bin{separator}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{separator}obj{separator}", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A package delivers the set when it ships it, ships its own reference, or reaches — through
+    /// first-party project references — some package that does.
+    /// </summary>
+    private static bool DeliversReferenceSet(ProjectInfo project, IReadOnlyList<ProjectInfo> all)
+    {
+        var byPath = all.ToDictionary(p => p.Path, StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<ProjectInfo>();
+        queue.Enqueue(project);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!seen.Add(current.Path))
+                continue;
+
+            if (current.ShipsReferenceSet || (current.ShipsOwnReference && !string.IsNullOrEmpty(current.ApiRefName)))
+                return true;
+
+            foreach (var reference in current.ProjectReferences)
+            {
+                if (byPath.TryGetValue(reference, out var next))
+                    queue.Enqueue(next);
+            }
+        }
+
+        return false;
+    }
+
+    private static List<ProjectInfo> PackableProjects()
+    {
+        var root = RepositoryRoot();
+        var separator = Path.DirectorySeparatorChar;
+
+        return Directory.EnumerateFiles(root, "*.csproj", SearchOption.AllDirectories)
+            .Where(path => path.Contains($"{separator}src{separator}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{separator}bin{separator}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{separator}obj{separator}", StringComparison.Ordinal))
+            .Select(Read)
+            .Where(p => p.IsPackable)
+            .ToList();
+    }
+
+    private static ProjectInfo Read(string path)
+    {
+        var document = XDocument.Load(path);
+        var directory = Path.GetDirectoryName(path)!;
+
+        string Property(string name) =>
+            document.Descendants(name).FirstOrDefault()?.Value.Trim() ?? string.Empty;
+
+        var references = document.Descendants("ProjectReference")
+            .Select(e => e.Attribute("Include")?.Value)
+            .Where(v => !string.IsNullOrEmpty(v))
+            .Select(v => Path.GetFullPath(Path.Combine(directory, v!.Replace('\\', Path.DirectorySeparatorChar))))
+            .ToList();
+
+        return new ProjectInfo(
+            Name: Path.GetFileNameWithoutExtension(path),
+            Path: Path.GetFullPath(path),
+            IsPackable: !string.Equals(Property("IsPackable"), "false", StringComparison.OrdinalIgnoreCase),
+            ShipsReferenceSet: string.Equals(Property("TrellisShipsApiReferenceSet"), "true", StringComparison.OrdinalIgnoreCase),
+            ShipsOwnReference: string.Equals(Property("TrellisShipsOwnApiReference"), "true", StringComparison.OrdinalIgnoreCase),
+            ApiRefName: Property("TrellisApiRefName"),
+            ProjectReferences: references);
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Trellis.slnx")))
+            directory = directory.Parent;
+
+        directory.Should().NotBeNull("the test must be able to locate the repository root (Trellis.slnx)");
+        return directory!.FullName;
+    }
+
+    private sealed record ProjectInfo(
+        string Name,
+        string Path,
+        bool IsPackable,
+        bool ShipsReferenceSet,
+        bool ShipsOwnReference,
+        string ApiRefName,
+        List<string> ProjectReferences);
+}


### PR DESCRIPTION
## The gap

The API reference set is what an AI agent reads before writing Trellis code — it ships inside the NuGet packages under `trellis/`, and a consuming project's agent reads it to get exact signatures.

Shipping it is **opt-in per csproj**. That is how `Trellis.ResourceNaming.Azure` published with no references at all and nothing failed.

The consequence is worse than missing documentation. An agent in a project that installed such a package has no signatures to work from, so it invents plausible ones — which is precisely the failure the reference set exists to prevent.

## The gate

`Trellis.Core/tests/Packaging/ApiReferencePayloadGateTests.cs` enumerates every packable `*/src/*.csproj` and walks the first-party `ProjectReference` graph. Each package must reach a payload by one of three supported routes:

| Route | Property | Who uses it |
|---|---|---|
| Ship the whole set | `TrellisShipsApiReferenceSet` | `Trellis.Core` |
| Ship its own reference | `TrellisShipsOwnApiReference` + `TrellisApiRefName` | `Trellis.Analyzers` (no dependency on Core), and packages published from other repositories that version independently |
| Inherit it | a `ProjectReference` path to `Trellis.Core` | every other first-party package |

Six packages — `Asp.ApiVersioning`, `Asp.Idempotency.Cosmos`, `EntityFrameworkCore.Inbox`, `EntityFrameworkCore.Outbox`, `ServiceDefaults`, `Testing.AspNetCore` — reach Core only *transitively*, so the graph walk is required rather than decorative. A direct-reference check would have failed all six.

**All 23 packages pass today.** This is a regression gate, not a fix.

It enumerates rather than hand-lists deliberately: a hand-listed set stops covering the next package added, which is the same miss one generation later.

## Two companion assertions

Both close a way the enumeration could go quiet rather than go red.

**A typo'd `TrellisApiRefName`** is otherwise entirely silent. The MSBuild `Include` simply matches nothing, so the package packs successfully and ships no reference — and the freshness and completeness audits key off the same property, so they go quiet at the same moment rather than catching it.

**A packable project outside `*/src/`** would simply not be seen. That filter turns out to be load-bearing rather than incidental: it is the only reason test and example projects, whose csproj files do not declare `IsPackable` themselves, stay out of the enumeration. I confirmed against MSBuild's evaluated `IsPackable` that the repo's real packable set is exactly the `src` projects today — but a new project added elsewhere would be skipped without a sound, which is the same "stops covering what is added next" failure, one level up.

## Mutation-tested

A gate that has never gone red proves nothing, so each assertion was made to fail before being committed:

| Mutation | Result |
|---|---|
| `TrellisShipsApiReferenceSet` → `false` on `Trellis.Core` | fails, listing every undelivered package |
| `TrellisApiRefName` `analyzers` → `analyzerz` | fails, naming the missing file |
| A packable project added outside `src/` | fails, naming the stray project |

## Note on the review

The `gpt-5.5` review returned no findings. The third assertion came from verifying one of its questions myself rather than accepting the clean verdict — checking whether the `src` filter was load-bearing showed that it was, and that the gate had a silent blind spot for anything added outside the convention.

## Validation

- `dotnet build` clean in **Debug and Release**
- **7883 / 7922** tests pass, 39 skipped, **0 failures**
- Doc lint and `dotnet pack` APICompat green
- The existing end-to-end probe `build/test-apireference-payload.ps1` still passes all six scenarios
- `.github/copilot-instructions.md` gains an "Adding a new packable package" section documenting the three routes and the enforcement
