### PR TITLE
Document that RequiredString's query helpers do not share comparison semantics

### DIFF
--- a/Trellis.Core/src/Primitives/RequiredString.cs
+++ b/Trellis.Core/src/Primitives/RequiredString.cs
@@ -302,6 +302,24 @@ public abstract class RequiredString<TSelf> : ScalarValueObject<TSelf, string>
     /// Returns whether the string value starts with the specified prefix.
     /// Enables natural LINQ queries like <c>c.Name.StartsWith("Al")</c> without accessing <c>.Value</c>.
     /// </summary>
+    /// <param name="value">The prefix to test for.</param>
+    /// <returns><see langword="true"/> when the value starts with <paramref name="value"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Evaluated in memory this is <em>culture-sensitive</em>, because
+    /// <see cref="string.StartsWith(string)"/> compares using
+    /// <see cref="StringComparison.CurrentCulture"/>. It therefore does not agree with
+    /// <see cref="Contains(string)"/>, which is ordinal — see
+    /// <see cref="Contains(string)"/> for a worked example of the disagreement.
+    /// </para>
+    /// <para>
+    /// Translated to SQL by EF Core the comparison is performed by the database using the
+    /// provider's own string-matching functions and collations, which may match neither
+    /// and are provider-specific. Use
+    /// <see cref="StartsWith(string, StringComparison)"/> when the semantics must be
+    /// explicit and the call is not part of a query.
+    /// </para>
+    /// </remarks>
     // Single-parameter overloads match what EF Core's ScalarValueExpressionRewriter
     // targets on string — the rewriter maps Name.StartsWith(x) to ((string)Name).StartsWith(x).
     // Adding StringComparison.Ordinal would produce a two-parameter call that EF Core cannot translate.
@@ -312,12 +330,55 @@ public abstract class RequiredString<TSelf> : ScalarValueObject<TSelf, string>
     /// Returns whether the string value contains the specified substring.
     /// Enables natural LINQ queries like <c>c.Name.Contains("li")</c> without accessing <c>.Value</c>.
     /// </summary>
+    /// <param name="value">The substring to test for.</param>
+    /// <returns><see langword="true"/> when the value contains <paramref name="value"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Evaluated in memory this is <em>ordinal</em>, because
+    /// <see cref="string.Contains(string)"/> compares by code unit. That makes it disagree
+    /// with <see cref="StartsWith(string)"/> and <see cref="EndsWith(string)"/>, which are
+    /// culture-sensitive. The difference is observable whenever the data contains
+    /// characters a culture treats as ignorable, such as the soft hyphen
+    /// <c>U+00AD</c> — note that the same argument yields opposite answers:
+    /// </para>
+    /// <code>
+    /// var name = ProductName.TryCreate("cooper\u00ADative").Value;
+    /// name.EndsWith("rative");  // true  — culture-sensitive, ignores the soft hyphen
+    /// name.Contains("rative");  // false — ordinal, the soft hyphen is a real character
+    /// name.StartsWith("coopera"); // true, for the same reason as EndsWith
+    /// </code>
+    /// <para>
+    /// Translated to SQL by EF Core the comparison is performed by the database using the
+    /// provider's own string-matching functions and collations, which may match neither
+    /// and are provider-specific. Use
+    /// <see cref="Contains(string, StringComparison)"/> when the semantics must be explicit
+    /// and the call is not part of a query.
+    /// </para>
+    /// </remarks>
     public bool Contains(string value) => Value.Contains(value);
 
     /// <summary>
     /// Returns whether the string value ends with the specified suffix.
     /// Enables natural LINQ queries like <c>c.Name.EndsWith("ce")</c> without accessing <c>.Value</c>.
     /// </summary>
+    /// <param name="value">The suffix to test for.</param>
+    /// <returns><see langword="true"/> when the value ends with <paramref name="value"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Evaluated in memory this is <em>culture-sensitive</em>, because
+    /// <see cref="string.EndsWith(string)"/> compares using
+    /// <see cref="StringComparison.CurrentCulture"/>. It therefore does not agree with
+    /// <see cref="Contains(string)"/>, which is ordinal — see
+    /// <see cref="Contains(string)"/> for a worked example of the disagreement.
+    /// </para>
+    /// <para>
+    /// Translated to SQL by EF Core the comparison is performed by the database using the
+    /// provider's own string-matching functions and collations, which may match neither
+    /// and are provider-specific. Use
+    /// <see cref="EndsWith(string, StringComparison)"/> when the semantics must be explicit
+    /// and the call is not part of a query.
+    /// </para>
+    /// </remarks>
     public bool EndsWith(string value) => Value.EndsWith(value);
 #pragma warning restore CA1310
 

--- a/Trellis.Core/src/Primitives/RequiredString.cs
+++ b/Trellis.Core/src/Primitives/RequiredString.cs
@@ -342,7 +342,7 @@ public abstract class RequiredString<TSelf> : ScalarValueObject<TSelf, string>
     /// <c>U+00AD</c> — note that the same argument yields opposite answers:
     /// </para>
     /// <code>
-    /// var name = ProductName.TryCreate("cooper\u00ADative").Value;
+    /// var name = ProductName.Create("cooper\u00ADative");
     /// name.EndsWith("rative");  // true  — culture-sensitive, ignores the soft hyphen
     /// name.Contains("rative");  // false — ordinal, the soft hyphen is a real character
     /// name.StartsWith("coopera"); // true, for the same reason as EndsWith

--- a/Trellis.Core/tests/Primitives/RequiredStringTests.cs
+++ b/Trellis.Core/tests/Primitives/RequiredStringTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Trellis.Core.Tests.Primitives;
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 
 public sealed class ComparableString : RequiredString<ComparableString>, IScalarValue<ComparableString, string>
@@ -80,5 +81,73 @@ public class RequiredStringTests
         var value = ComparableString.Create("Hello");
 
         value.Contains("ell").Should().BeTrue();
+    }
+
+    // The three single-argument query helpers deliberately keep the BCL's own comparison
+    // semantics so EF Core can translate them, and the BCL is not self-consistent:
+    // StartsWith/EndsWith are culture-sensitive while Contains is ordinal. These pin that
+    // divergence so it cannot change unnoticed, and so the documented example stays true.
+    //
+    // A globalization-invariant host has no culture data, so `new CultureInfo("en-US")`
+    // throws there and culture-sensitive comparison collapses to ordinal-like behavior.
+    // The divergence these tests describe genuinely does not exist in that configuration,
+    // so they skip rather than fail.
+    //
+    // Invariant mode can be enabled through two channels that must both be checked: the
+    // MSBuild property, which surfaces as the AppContext switch, and the environment
+    // variable, which does NOT set that switch.
+    private static bool IsGlobalizationInvariant
+    {
+        get
+        {
+            if (AppContext.TryGetSwitch("System.Globalization.Invariant", out var enabled) && enabled)
+                return true;
+
+            var value = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
+            return value == "1" || (bool.TryParse(value, out var parsed) && parsed);
+        }
+    }
+
+    [Fact]
+    public void EndsWith_WithSingleArgument_IsCultureSensitive_AndIgnoresSoftHyphen()
+    {
+        Assert.SkipWhen(IsGlobalizationInvariant, "Requires culture data; the host is globalization-invariant.");
+
+        using var _ = new CultureScope("en-US");
+        var value = ComparableString.Create("cooper\u00ADative");
+
+        value.EndsWith("rative").Should().BeTrue();
+    }
+
+    [Fact]
+    public void StartsWith_WithSingleArgument_IsCultureSensitive_AndIgnoresSoftHyphen()
+    {
+        Assert.SkipWhen(IsGlobalizationInvariant, "Requires culture data; the host is globalization-invariant.");
+
+        using var _ = new CultureScope("en-US");
+        var value = ComparableString.Create("cooper\u00ADative");
+
+        value.StartsWith("coopera").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Contains_WithSingleArgument_IsOrdinal_AndDoesNotIgnoreSoftHyphen()
+    {
+        Assert.SkipWhen(IsGlobalizationInvariant, "Requires culture data; the host is globalization-invariant.");
+
+        using var _ = new CultureScope("en-US");
+        var value = ComparableString.Create("cooper\u00ADative");
+
+        // Same receiver and same argument as EndsWith above, opposite answer.
+        value.Contains("rative").Should().BeFalse();
+    }
+
+    private sealed class CultureScope : IDisposable
+    {
+        private readonly CultureInfo original = CultureInfo.CurrentCulture;
+
+        public CultureScope(string name) => CultureInfo.CurrentCulture = new CultureInfo(name);
+
+        public void Dispose() => CultureInfo.CurrentCulture = this.original;
     }
 }

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -2279,14 +2279,58 @@ public abstract class RequiredString<TSelf> : ScalarValueObject<TSelf, string>
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public bool StartsWith(string value)` | `bool` | Delegates to `string.StartsWith(string)` for EF Core-translatable query predicates. |
+| `public bool StartsWith(string value)` | `bool` | Delegates to `string.StartsWith(string)` for EF Core-translatable query predicates. Culture-sensitive in memory — see [Comparison semantics](#comparison-semantics-of-the-single-argument-query-helpers). |
 | `public bool StartsWith(string value, StringComparison comparisonType)` | `bool` | Delegates to `string.StartsWith(string, StringComparison)`. This overload is not EF Core translatable; use the single-argument overload for queries. |
-| `public bool Contains(string value)` | `bool` | Delegates to `string.Contains(string)` for EF Core-translatable query predicates. |
+| `public bool Contains(string value)` | `bool` | Delegates to `string.Contains(string)` for EF Core-translatable query predicates. Ordinal in memory — see [Comparison semantics](#comparison-semantics-of-the-single-argument-query-helpers). |
 | `public bool Contains(string value, StringComparison comparisonType)` | `bool` | Delegates to `string.Contains(string, StringComparison)`. This overload is not EF Core translatable; use the single-argument overload for queries. |
 | `public bool Contains(char value, StringComparison comparisonType)` | `bool` | Delegates to `string.Contains(char, StringComparison)`. This overload is not EF Core translatable; use the single-argument overload for queries. |
-| `public bool EndsWith(string value)` | `bool` | Delegates to `string.EndsWith(string)` for EF Core-translatable query predicates. |
+| `public bool EndsWith(string value)` | `bool` | Delegates to `string.EndsWith(string)` for EF Core-translatable query predicates. Culture-sensitive in memory — see [Comparison semantics](#comparison-semantics-of-the-single-argument-query-helpers). |
 | `public bool EndsWith(string value, StringComparison comparisonType)` | `bool` | Delegates to `string.EndsWith(string, StringComparison)`. This overload is not EF Core translatable; use the single-argument overload for queries. |
 | `public static TSelf Create(string value)` | `TSelf` | Inherited throwing scalar factory. Source-generated overloads are listed below. |
+
+#### Comparison semantics of the single-argument query helpers
+
+The single-argument `StartsWith`, `Contains`, and `EndsWith` exist so EF Core's
+`ScalarValueExpressionRewriter` can translate them: it maps `Name.StartsWith(x)` to
+`((string)Name).StartsWith(x)`, and a two-argument call carrying a `StringComparison`
+would not translate. The consequence is that they inherit the BCL's comparison
+semantics verbatim — **and the BCL is not self-consistent here**:
+
+| Helper | In-memory comparison |
+| --- | --- |
+| `StartsWith(string)` | Culture-sensitive (`StringComparison.CurrentCulture`) |
+| `EndsWith(string)` | Culture-sensitive (`StringComparison.CurrentCulture`) |
+| `Contains(string)` | **Ordinal** |
+
+The divergence is observable on any data containing characters a culture treats as
+ignorable. With the soft hyphen `U+00AD`, the same receiver and the same argument give
+opposite answers:
+
+```csharp
+var name = ProductName.Create("cooper\u00ADative");
+
+name.StartsWith("coopera"); // true  — culture-sensitive, ignores the soft hyphen
+name.EndsWith("rative");    // true  — likewise
+name.Contains("rative");    // false — ordinal, the soft hyphen is a real character
+```
+
+Two further consequences worth planning for:
+
+- **In-memory and SQL evaluation can disagree.** Translated to SQL, the comparison is
+  performed by the database using the provider's own string-matching functions,
+  operators, and collations — which may match neither the culture-sensitive nor the
+  ordinal .NET result. The rules are provider-specific rather than universally the
+  column's collation: SQL Server translates these to `LIKE`, which honours the column
+  collation, whereas the SQLite provider translates `Contains` to `instr`, which does
+  not. The same specification can therefore return different results when evaluated
+  against a `DbSet` versus an in-memory list — which matters for tests that use
+  in-memory collections to stand in for the database.
+- **Host configuration changes the answer.** A host running with
+  `InvariantGlobalization=true` collapses culture-sensitive comparison to ordinal-like
+  behavior, so `StartsWith`/`EndsWith` change results while `Contains` does not.
+
+When the semantics must be explicit and the call is not part of an EF Core query, use the
+two-argument overload and pass `StringComparison.Ordinal` explicitly.
 
 ### `RequiredGuid<TSelf>`
 


### PR DESCRIPTION
## What

`RequiredString<TSelf>` exposes three single-argument query helpers — `StartsWith(string)`, `Contains(string)`, `EndsWith(string)`. They exist so EF Core's `ScalarValueExpressionRewriter` can translate them into SQL; adding a `StringComparison` argument would produce a two-parameter call EF Core cannot translate, which is why they carry a `#pragma warning disable CA1310`.

The consequence was undocumented: because they delegate to the BCL verbatim, they inherit the BCL's comparison semantics — **and the BCL is not self-consistent here**.

| Helper | In-memory comparison |
| --- | --- |
| `StartsWith(string)` | Culture-sensitive (`CurrentCulture`) |
| `EndsWith(string)` | Culture-sensitive (`CurrentCulture`) |
| `Contains(string)` | **Ordinal** |

Verified empirically on .NET/ICU under `en-US`, with the soft hyphen `U+00AD`. The same receiver and the same argument give opposite answers:

```csharp
var name = ProductName.Create("cooper\u00ADative");

name.StartsWith("coopera"); // true  — culture-sensitive, ignores the soft hyphen
name.EndsWith("rative");    // true  — likewise
name.Contains("rative");    // false — ordinal, the soft hyphen is a real character
```

## Why it matters

- **In-memory and SQL evaluation can disagree.** Translated to SQL, matching is done by the provider's own functions and collations. The same specification can return different results against a `DbSet` than against an in-memory list — which is a trap for tests that use in-memory collections to stand in for the database.
- **Host configuration changes the answer.** Under `InvariantGlobalization=true`, culture-sensitive comparison collapses to ordinal-like behavior, so `StartsWith`/`EndsWith` change results while `Contains` does not. Confirmed by probe.

## Changes

- XML `<remarks>` on the three helpers in `Trellis.Core/src/Primitives/RequiredString.cs`, so the warning surfaces in IntelliSense at the point the mistake is made.
- A `#### Comparison semantics of the single-argument query helpers` section in `docs/docfx_project/api_reference/trellis-api-core.md`, plus three table rows linking to it.
- Three characterization tests pinning the behavior so it cannot drift silently.

**No behavior change.** The product-source diff is comment-only — verified by filtering the diff for non-`///` additions, which returns nothing.

## Why document rather than make them consistent

Aligning the three would be a behavior change to a shipped API, and forcing `StringComparison` onto the single-argument overloads is precisely what breaks EF Core translation. The semantics are inherited from the BCL by design; the defect was that callers had no way to know.

## Validation

- Full solution Release build: **0 warnings, 0 errors**.
- Full solution test run: **7986 total, 0 failed, 39 skipped**.
- API reference doc lint (28 files), documented-symbol audit, and completeness gate all pass.
- All three new tests **mutation-verified**: mutating `Contains` to `CurrentCulture` failed exactly the `Contains` test; mutating `StartsWith`/`EndsWith` to `Ordinal` failed exactly those two. Mutations reverted.

## Review findings adopted

A `gpt-5.5` review raised two issues, both verified against source/probe before adopting:

1. **The collation claim was overstated.** "Performed by the database using the column's collation" is not universally true — SQL Server translates to `LIKE`, which honours collation, but the SQLite provider translates `Contains` to `instr`, which does not. Reworded to provider-specific in all four sites.
2. **The tests would throw on a globalization-invariant host.** `new CultureInfo("en-US")` raises `CultureNotFoundException` there. Added an `Assert.SkipWhen` guard, matching the existing repo idiom.

Worth noting on (2): the first guard was wrong and testing it caught that. `AppContext.TryGetSwitch("System.Globalization.Invariant", …)` only reports invariant mode when it is set via the MSBuild property, which writes `runtimeconfig.json`; the `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` environment variable does **not** set that switch, so the guard silently did nothing and the tests still threw. It now checks both channels, re-verified by running the suite with the environment variable set — all three skip cleanly.

## Follow-up, not addressed here

`Showcase.MinimalApi` sets `InvariantGlobalization=true`; `Showcase.Mvc` does not. Both host the same `Showcase.Application`/`Showcase.Domain`, so the two sample hosts can evaluate the same specification differently — a live instance of the hazard documented here. Aligning them is a behavior change and belongs in its own PR.
