### PR TITLE
Add TRLS064: keep frozen reason codes off the wire as literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — an Info diagnostic that keeps reason codes off the wire by accident
+
+`ValidationCodes` and `FaultCodes` freeze a small set of reason codes, and Trellis dispatches on their exact wire
+spelling — so the reference has always said to emit them by constant, because a typo in a literal is a silent wire
+break while a typo in a constant name does not compile. Nothing enforced it.
+
+**`TRLS064`** (`ReasonCodeVocabularyAnalyzer`, `Trellis.Analyzers`) reports a string literal in a reason-code
+position that restates a frozen code, claims the reserved `error.*` namespace, or claims a namespace the framework
+publishes a meaning for. `ReasonCodeVocabularyCodeFixProvider` rewrites the first shape to its constant, with
+fix-all, because the motivating case is one literal repeated across dozens of call sites.
+
+Three positions carry a reason code and all three are inspected: a `reasonCode` parameter on any Trellis method or
+constructor, FluentValidation's `WithErrorCode(...)`, and `Code` on the Trellis primitive attributes. It reads the
+vocabulary out of the compilation rather than carrying its own copy, so a code added to the frozen set is covered
+the day it is added — and it matches by parameter or property *name* rather than by a list of members, so it covers
+all eleven `ForField`/`ForRule`/`ForReason`/`For` overloads regardless of arity or argument position, plus the
+twelfth the day it is added.
+
+**It deliberately does not check vocabulary membership.** The freeze constrains Trellis, not your application, and
+`trellis-api-primitives.md` promises that no analyzer pressures the choice to override a framework code or keep it.
+A novel, well-formed code of your own — `order.cancel-after-ship`, or a bare `required` — is silent, including where
+it is a synonym for a code Trellis also has. Only *literals* are reported: `ValidationCodes.ValueNotNull` is the
+recommended shape, so matching on constant value rather than syntax would flag the fix itself.
+
+WRONG/FIX shapes: [`trellis-api-anti-patterns.md` → TRLS064](docs/docfx_project/api_reference/trellis-api-anti-patterns.md#trls064--reason-code-literal-that-collides-with-the-frozen-vocabulary).
+
 ### Added — validation failures now say which part of the request they came from
 
 A violation raised in the domain names the field that failed but cannot know where the value arrived from, so it

--- a/Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md
+++ b/Trellis.Analyzers/src/AnalyzerReleases.Unshipped.md
@@ -27,3 +27,4 @@ TRLS023  | Trellis  | Warning  | CreatedAtRoute, CreatedAtAction, or WithLocatio
 TRLS054  | Trellis  | Warning  | Maybe<T>.Equals or object.Equals over Maybe<T> inside an IQueryable expression is not translatable; use == or != instead.
 TRLS055  | Trellis  | Warning  | HasValueWhere inside an IQueryable expression requires an inline lambda predicate.
 TRLS063  | Trellis  | Info     | FluentValidation Must/MustAsync rule has no WithErrorCode; its failure maps to error.unspecified.
+TRLS064  | Trellis  | Info     | Reason-code literal restates a frozen framework code, or claims a namespace the framework owns.

--- a/Trellis.Analyzers/src/DiagnosticDescriptors.cs
+++ b/Trellis.Analyzers/src/DiagnosticDescriptors.cs
@@ -375,4 +375,22 @@ public static class DiagnosticDescriptors
                      "error.unspecified sentinel, so a client receiving the failure has nothing to branch on. " +
                      "Chain WithErrorCode(\"...\") onto the rule to name it.",
         helpLinkUri: HelpLinkBase);
+
+    /// <summary>
+    /// TRLS064: A reason-code literal restates a frozen code or claims a framework namespace.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ReasonCodeVocabulary = new(
+        id: TrellisDiagnosticIds.ReasonCodeVocabulary,
+        title: "Reason code literal conflicts with the frozen vocabulary",
+        messageFormat: "Reason code \"{0}\" {1}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Trellis freezes the reason codes it emits itself and publishes a meaning for each namespace, " +
+                     "so a client may fall back on the prefix when it does not recognise a full code. This rule reports " +
+                     "a literal that restates one of those frozen codes, which should be emitted by its constant so a " +
+                     "typo fails the build rather than the wire, and a literal that claims a namespace the framework owns, " +
+                     "which makes an application failure read as a framework one. It does not check membership: the freeze " +
+                     "constrains Trellis, not the application, and an application is free to mint its own codes.",
+        helpLinkUri: HelpLinkBase);
 }

--- a/Trellis.Analyzers/src/ReasonCodeVocabularyAnalyzer.cs
+++ b/Trellis.Analyzers/src/ReasonCodeVocabularyAnalyzer.cs
@@ -1,0 +1,392 @@
+﻿namespace Trellis.Analyzers;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+/// <summary>
+/// Analyzer that inspects string literals passed as a reason code and reports the three ways such a
+/// literal interacts badly with the frozen Trellis vocabulary: it restates a framework code that has
+/// a constant, it squats the reserved <c>error.*</c> namespace, or it squats one of the framework's
+/// own namespaces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Three surfaces carry a reason code to the wire, and all three are analyzed: a <c>reasonCode</c>
+/// parameter on any Trellis method or constructor, FluentValidation's <c>WithErrorCode</c>, and the
+/// <c>Code</c> property on the Trellis primitive attributes. They are matched by parameter or property
+/// name rather than by a list of members, so a surface added later is covered without a change here.
+/// </para>
+/// <para>
+/// The rule deliberately does <b>not</b> check vocabulary membership. <c>trellis-api-core.md</c> scopes
+/// the freeze to "the reason codes the framework itself emits" and states that it "constrains Trellis,
+/// not the application"; <c>trellis-api-primitives.md</c> adds that "no analyzer pressures either
+/// choice". An application code such as <c>order.cancel-after-ship</c> is legitimate and stays silent.
+/// What is reported is narrower: a literal that is already a framework code (so the constant exists and
+/// the literal is a silent wire break waiting on a typo), or one that claims a namespace the framework
+/// has given a published meaning.
+/// </para>
+/// <para>
+/// The vocabulary is read from the compilation rather than copied into the analyzer. A hard-coded table
+/// would be a second source of truth that goes stale the first time a code is added, and this analyzer
+/// exists precisely because duplicated reason codes drift. When <c>Trellis.Core</c> is not referenced
+/// there is no vocabulary to compare against and the analyzer does nothing.
+/// </para>
+/// <para>
+/// Only literal syntax is reported. A constant reference has a constant <em>value</em> too, so testing
+/// <c>ConstantValue</c> alone would flag <c>ForField(f, ValidationCodes.ValueNotNull)</c> — the exact
+/// shape this rule tells authors to write. A code reached through an application's own
+/// <c>const string</c> indirection is therefore invisible here, which is the accepted trade.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ReasonCodeVocabularyAnalyzer : DiagnosticAnalyzer
+{
+    private const string ValidationCodesMetadataName = "Trellis.ValidationCodes";
+    private const string FaultCodesMetadataName = "Trellis.FaultCodes";
+    private const string TrellisRootNamespace = "Trellis";
+    private const string ReasonCodeParameterName = "reasonCode";
+    private const string ErrorNamespacePrefix = "error.";
+
+    /// <summary>
+    /// FluentValidation's own naming surface. A code written here reaches the wire through
+    /// <c>Trellis.FluentValidation</c>'s projection exactly as a <c>reasonCode</c> does, so the same
+    /// three findings apply.
+    /// </summary>
+    private const string FluentValidationRootNamespace = "FluentValidation";
+    private const string WithErrorCodeName = "WithErrorCode";
+    private const string ErrorCodeParameterName = "errorCode";
+
+    /// <summary>
+    /// The settable property through which the Trellis primitive attributes
+    /// (<c>[StringLength]</c>, <c>[Range]</c>, <c>[NotDefault]</c> and the sign-convenience
+    /// attributes) override a generated value object's reason code.
+    /// </summary>
+    private const string CodePropertyName = "Code";
+
+    /// <summary>
+    /// The pre-vocabulary placeholder. It is a frozen value with a constant, but the documented
+    /// guidance is not "use the constant" — it is "do not emit this at all", so it gets its own
+    /// message and no code fix.
+    /// </summary>
+    private const string LegacyPlaceholder = "validation.error";
+
+    /// <summary>
+    /// Key under which the code fix reads the constant to substitute, e.g. <c>ValidationCodes.ValueNotNull</c>.
+    /// </summary>
+    internal const string ConstantPropertyKey = "TrellisReasonCodeConstant";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [DiagnosticDescriptors.ReasonCodeVocabulary];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var vocabulary = Vocabulary.Load(compilationContext.Compilation);
+            if (vocabulary.IsEmpty)
+                return;
+
+            compilationContext.RegisterOperationAction(
+                ctx => AnalyzeInvocation(ctx, vocabulary),
+                OperationKind.Invocation);
+
+            compilationContext.RegisterOperationAction(
+                ctx => AnalyzeObjectCreation(ctx, vocabulary),
+                OperationKind.ObjectCreation);
+
+            compilationContext.RegisterSyntaxNodeAction(
+                ctx => AnalyzeAttribute(ctx, vocabulary),
+                SyntaxKind.Attribute);
+        });
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, Vocabulary vocabulary)
+    {
+        var operation = (IInvocationOperation)context.Operation;
+        var method = operation.TargetMethod;
+
+        var parameterName =
+            IsTrellisDeclared(method.ContainingType) ? ReasonCodeParameterName
+            : IsFluentValidationErrorCode(method) ? ErrorCodeParameterName
+            : null;
+
+        if (parameterName is null)
+            return;
+
+        AnalyzeArguments(context, vocabulary, operation.Arguments, parameterName);
+    }
+
+    /// <summary>
+    /// Matches FluentValidation's <c>WithErrorCode</c>, the one naming surface outside Trellis whose
+    /// argument becomes a Trellis reason code verbatim.
+    /// </summary>
+    /// <remarks>
+    /// The declaring namespace is required so an unrelated API that happens to expose a method of the
+    /// same name is not analyzed. An application's own <c>WithErrorCode</c> declared in
+    /// <c>namespace FluentValidation</c> — a common convention — is deliberately still matched: whatever
+    /// wraps it, the argument is an error code, so restating a frozen one there is the same defect.
+    /// </remarks>
+    private static bool IsFluentValidationErrorCode(IMethodSymbol method) =>
+        method.Name == WithErrorCodeName
+        && IsInNamespace(method.ContainingType, FluentValidationRootNamespace);
+
+    private static void AnalyzeObjectCreation(OperationAnalysisContext context, Vocabulary vocabulary)
+    {
+        var operation = (IObjectCreationOperation)context.Operation;
+        if (operation.Constructor is not { } constructor || !IsTrellisDeclared(constructor.ContainingType))
+            return;
+
+        AnalyzeArguments(context, vocabulary, operation.Arguments, ReasonCodeParameterName);
+    }
+
+    /// <summary>
+    /// Reports a frozen or squatting literal assigned to <c>Code</c> on a Trellis primitive attribute.
+    /// </summary>
+    /// <remarks>
+    /// Attribute arguments must be compile-time constants, so the constant the code fix substitutes is
+    /// legal here for the same reason the literal is.
+    /// </remarks>
+    private static void AnalyzeAttribute(SyntaxNodeAnalysisContext context, Vocabulary vocabulary)
+    {
+        var attribute = (AttributeSyntax)context.Node;
+        if (attribute.ArgumentList is not { } argumentList)
+            return;
+
+        if (context.SemanticModel.GetSymbolInfo(attribute, context.CancellationToken).Symbol
+            is not IMethodSymbol constructor
+            || !IsTrellisDeclared(constructor.ContainingType))
+        {
+            return;
+        }
+
+        foreach (var argument in argumentList.Arguments)
+        {
+            if (argument.NameEquals?.Name.Identifier.ValueText != CodePropertyName)
+                continue;
+
+            if (argument.Expression is not LiteralExpressionSyntax literal
+                || !literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                continue;
+            }
+
+            Report(
+                context.ReportDiagnostic,
+                vocabulary,
+                literal.Token.ValueText,
+                literal.GetLocation());
+        }
+    }
+
+    private static void AnalyzeArguments(
+        OperationAnalysisContext context,
+        Vocabulary vocabulary,
+        ImmutableArray<IArgumentOperation> arguments,
+        string parameterName)
+    {
+        foreach (var argument in arguments)
+        {
+            if (!IsReasonCodeParameter(argument.Parameter, parameterName))
+                continue;
+
+            if (UnwrapLiteral(argument.Value) is not { } literal)
+                continue;
+
+            if (literal.ConstantValue.Value is not string code)
+                continue;
+
+            Report(context.ReportDiagnostic, vocabulary, code, literal.Syntax.GetLocation());
+        }
+    }
+
+    private static void Report(
+        Action<Diagnostic> report,
+        Vocabulary vocabulary,
+        string code,
+        Location location)
+    {
+        if (code.Length == 0 || Classify(code, vocabulary) is not { } finding)
+            return;
+
+        report(Diagnostic.Create(
+            DiagnosticDescriptors.ReasonCodeVocabulary,
+            location,
+            finding.Properties,
+            code,
+            finding.Explanation));
+    }
+
+    /// <summary>
+    /// Matches the parameter every Trellis reason-code surface uses, whether written as a method
+    /// parameter (<c>ForField</c>, <c>ForRule</c>, <c>ForReason</c>, <c>For</c>) or as a positional
+    /// record parameter (<c>FieldViolation.ReasonCode</c>, <c>RuleViolation.ReasonCode</c>).
+    /// </summary>
+    /// <remarks>
+    /// Keying on the parameter name rather than a list of method names and argument positions is what
+    /// keeps this rule from going stale: the eleven current factory overloads differ in arity and in
+    /// where the code sits, and a twelfth is covered the day it is added. Comparison is
+    /// case-insensitive because positional records declare the parameter as <c>ReasonCode</c>.
+    /// </remarks>
+    private static bool IsReasonCodeParameter(IParameterSymbol? parameter, string parameterName) =>
+        parameter is not null
+        && string.Equals(parameter.Name, parameterName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns the literal underneath an argument, seeing through the implicit conversions the
+    /// operation tree inserts, or <see langword="null"/> when the argument is anything else.
+    /// </summary>
+    private static IOperation? UnwrapLiteral(IOperation value)
+    {
+        var current = value;
+
+        while (current is IConversionOperation conversion)
+            current = conversion.Operand;
+
+        return current is ILiteralOperation ? current : null;
+    }
+
+    private static bool IsTrellisDeclared(INamedTypeSymbol? containingType) =>
+        IsInNamespace(containingType, TrellisRootNamespace);
+
+    private static bool IsInNamespace(INamedTypeSymbol? containingType, string rootNamespace)
+    {
+        if (containingType?.ContainingNamespace is not { } containingNamespace)
+            return false;
+
+        var name = containingNamespace.ToDisplayString();
+        return name == rootNamespace
+            || name.StartsWith(rootNamespace + ".", StringComparison.Ordinal);
+    }
+
+    private static Finding? Classify(string code, Vocabulary vocabulary)
+    {
+        if (string.Equals(code, LegacyPlaceholder, StringComparison.Ordinal))
+        {
+            return new Finding(
+                "is the pre-vocabulary placeholder, which the boundary normalizes away; emit a real "
+                + "reason code instead",
+                ImmutableDictionary<string, string?>.Empty);
+        }
+
+        if (vocabulary.ConstantsByValue.TryGetValue(code, out var constant))
+        {
+            return new Finding(
+                $"is the framework reason code {constant}; emit it by constant, because a typo in a "
+                + "literal is a silent wire break while a typo in a constant name does not compile",
+                ImmutableDictionary<string, string?>.Empty.Add(ConstantPropertyKey, constant));
+        }
+
+        if (code.StartsWith(ErrorNamespacePrefix, StringComparison.Ordinal))
+        {
+            return new Finding(
+                "claims the reserved 'error.*' namespace, which carries only the 'error.unspecified' "
+                + "sentinel; a second member there makes the \"no reason available\" fallback lossy",
+                ImmutableDictionary<string, string?>.Empty);
+        }
+
+        var separator = code.IndexOf('.');
+        if (separator > 0)
+        {
+            var prefix = code.Substring(0, separator);
+            if (vocabulary.FrameworkNamespaces.Contains(prefix))
+            {
+                return new Finding(
+                    $"claims the framework namespace '{prefix}.*', whose meaning Trellis publishes, so a "
+                    + "client falling back on the prefix will read this application code as a framework one "
+                    + "— application codes are free-form, so pick a namespace the framework does not own",
+                    ImmutableDictionary<string, string?>.Empty);
+            }
+        }
+
+        return null;
+    }
+
+    private readonly struct Finding
+    {
+        public Finding(string explanation, ImmutableDictionary<string, string?> properties)
+        {
+            Explanation = explanation;
+            Properties = properties;
+        }
+
+        public string Explanation { get; }
+
+        public ImmutableDictionary<string, string?> Properties { get; }
+    }
+
+    /// <summary>
+    /// The frozen vocabulary as read from the compilation being analyzed.
+    /// </summary>
+    private sealed class Vocabulary
+    {
+        private Vocabulary(
+            ImmutableDictionary<string, string> constantsByValue,
+            ImmutableHashSet<string> frameworkNamespaces)
+        {
+            ConstantsByValue = constantsByValue;
+            FrameworkNamespaces = frameworkNamespaces;
+        }
+
+        /// <summary>Wire value to the display form of its constant, e.g. <c>value.not-null</c> to <c>ValidationCodes.ValueNotNull</c>.</summary>
+        public ImmutableDictionary<string, string> ConstantsByValue { get; }
+
+        /// <summary>First segment of every dotted frozen code — the namespaces the framework has given a published meaning.</summary>
+        public ImmutableHashSet<string> FrameworkNamespaces { get; }
+
+        public bool IsEmpty => ConstantsByValue.IsEmpty;
+
+        public static Vocabulary Load(Compilation compilation)
+        {
+            var constants = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+            var namespaces = ImmutableHashSet.CreateBuilder(StringComparer.Ordinal);
+
+            foreach (var metadataName in new[] { ValidationCodesMetadataName, FaultCodesMetadataName })
+            {
+                if (compilation.GetTypeByMetadataName(metadataName) is not { } type)
+                    continue;
+
+                foreach (var value in StringConstants(type))
+                {
+                    // A duplicate value would already have failed ValidationCodesTests; keep the first
+                    // so the analyzer stays deterministic rather than throwing during a build.
+                    constants[value.Value] = $"{type.Name}.{value.Name}";
+
+                    // The legacy placeholder's namespace is an artifact rather than a published one:
+                    // reserving `validation.*` against applications on its account would flag codes the
+                    // framework never claimed.
+                    if (string.Equals(value.Value, LegacyPlaceholder, StringComparison.Ordinal))
+                        continue;
+
+                    var separator = value.Value.IndexOf('.');
+                    if (separator > 0)
+                        namespaces.Add(value.Value.Substring(0, separator));
+                }
+            }
+
+            return new Vocabulary(constants.ToImmutable(), namespaces.ToImmutable());
+        }
+
+        private static IEnumerable<(string Name, string Value)> StringConstants(INamedTypeSymbol type) =>
+            type.GetMembers()
+                .OfType<IFieldSymbol>()
+                .Where(f => f is
+                {
+                    IsConst: true,
+                    HasConstantValue: true,
+                    DeclaredAccessibility: Accessibility.Public
+                })
+                .Select(f => (f.Name, Value: f.ConstantValue as string))
+                .Where(f => !string.IsNullOrEmpty(f.Value))
+                .Select(f => (f.Name, f.Value!));
+    }
+}

--- a/Trellis.Analyzers/src/ReasonCodeVocabularyAnalyzer.cs
+++ b/Trellis.Analyzers/src/ReasonCodeVocabularyAnalyzer.cs
@@ -358,8 +358,10 @@ public sealed class ReasonCodeVocabularyAnalyzer : DiagnosticAnalyzer
                 foreach (var value in StringConstants(type))
                 {
                     // A duplicate value would already have failed ValidationCodesTests; keep the first
-                    // so the analyzer stays deterministic rather than throwing during a build.
-                    constants[value.Value] = $"{type.Name}.{value.Name}";
+                    // so the analyzer stays deterministic rather than throwing during a build. Types are
+                    // walked in a fixed order, so "first" means the ValidationCodes spelling wins.
+                    if (!constants.ContainsKey(value.Value))
+                        constants[value.Value] = $"{type.Name}.{value.Name}";
 
                     // The legacy placeholder's namespace is an artifact rather than a published one:
                     // reserving `validation.*` against applications on its account would flag codes the

--- a/Trellis.Analyzers/src/ReasonCodeVocabularyCodeFixProvider.cs
+++ b/Trellis.Analyzers/src/ReasonCodeVocabularyCodeFixProvider.cs
@@ -1,0 +1,88 @@
+﻿namespace Trellis.Analyzers;
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
+
+/// <summary>
+/// Replaces a reason-code literal that restates a frozen framework code with the constant that holds
+/// it — <c>"value.not-null"</c> becomes <c>ValidationCodes.ValueNotNull</c>.
+/// </summary>
+/// <remarks>
+/// Only the restated-code case is fixable, and the analyzer says so by attaching the constant to the
+/// diagnostic. A literal that squats a framework namespace has no mechanical replacement, because only
+/// the author knows which namespace the code belongs in; those diagnostics carry no property and are
+/// left for a human. Fix-all is supported because the motivating case is a codebase that spelled the
+/// same literal at dozens of call sites.
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReasonCodeVocabularyCodeFixProvider))]
+[Shared]
+public sealed class ReasonCodeVocabularyCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DiagnosticDescriptors.ReasonCodeVocabulary.Id);
+
+    public override FixAllProvider GetFixAllProvider() =>
+        WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            if (!diagnostic.Properties.TryGetValue(
+                    ReasonCodeVocabularyAnalyzer.ConstantPropertyKey, out var constant)
+                || string.IsNullOrEmpty(constant))
+            {
+                continue;
+            }
+
+            // The argument and its expression have identical spans, and on a tie FindNode returns the
+            // outer node — so without getInnermostNodeForTie this yields an ArgumentSyntax and the fix
+            // silently never registers.
+            if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                is not LiteralExpressionSyntax literal)
+                continue;
+
+            var title = $"Use {constant}";
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: title,
+                    createChangedDocument: c => ReplaceWithConstantAsync(context.Document, literal, constant!, c),
+                    equivalenceKey: title),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document> ReplaceWithConstantAsync(
+        Document document,
+        LiteralExpressionSyntax literal,
+        string constant,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return document;
+
+        // Fully qualified and then annotated for simplification, so the result reads as
+        // `ValidationCodes.ValueNotNull` where `Trellis` is imported and stays correct where it is not.
+        var replacement = SyntaxFactory
+            .ParseExpression($"global::Trellis.{constant}")
+            .WithAdditionalAnnotations(Simplifier.Annotation)
+            .WithTriviaFrom(literal);
+
+        return document.WithSyntaxRoot(root.ReplaceNode(literal, replacement));
+    }
+}

--- a/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
+++ b/Trellis.Analyzers/src/TrellisDiagnosticIds.cs
@@ -14,7 +14,7 @@
 ///     Justification = "guarded by HasValue check earlier in the pipeline")]
 /// </code>
 /// <para>
-/// IDs in the <c>TRLS001</c>–<c>TRLS023</c> and <c>TRLS054</c>–<c>TRLS055</c> ranges, plus the single ID <c>TRLS063</c>, are emitted by the
+/// IDs in the <c>TRLS001</c>–<c>TRLS023</c> and <c>TRLS054</c>–<c>TRLS055</c> ranges, plus the IDs <c>TRLS063</c> and <c>TRLS064</c>, are emitted by the
 /// <c>Trellis.Analyzers</c> assembly. IDs in the <c>TRLS031</c>–<c>TRLS045</c>, <c>TRLS056</c>–<c>TRLS058</c> and <c>TRLS060</c>–<c>TRLS062</c>
 /// ranges are emitted by the bundled source generators
 /// (<c>Trellis.Core.Generator</c>, <c>Trellis.EntityFrameworkCore.Generator</c>,
@@ -173,4 +173,7 @@ public static class TrellisDiagnosticIds
 
     /// <summary>TRLS063 — a FluentValidation <c>Must</c>/<c>MustAsync</c> rule has no <c>WithErrorCode</c>, so its failure projects to the <c>error.unspecified</c> sentinel.</summary>
     public const string MustWithoutErrorCode = "TRLS063";
+
+    /// <summary>TRLS064 — a reason-code string literal restates a frozen framework code, or claims a namespace the framework owns.</summary>
+    public const string ReasonCodeVocabulary = "TRLS064";
 }

--- a/Trellis.Analyzers/tests/ReasonCodeTestStubs.cs
+++ b/Trellis.Analyzers/tests/ReasonCodeTestStubs.cs
@@ -1,0 +1,97 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+/// <summary>
+/// Stub source for the reason-code surfaces TRLS064 inspects.
+/// </summary>
+/// <remarks>
+/// The vocabulary here is a deliberate subset of the real one. The analyzer reads the frozen codes out
+/// of the compilation rather than from a table of its own, so a subset is enough to exercise every
+/// branch — and using a subset proves the reading actually happens, which a copy of the full set would
+/// not distinguish from a hard-coded list.
+/// </remarks>
+public static class ReasonCodeTestStubs
+{
+    public const string Source = """
+        namespace Trellis
+        {
+            public static class ValidationCodes
+            {
+                public const string Unspecified = "error.unspecified";
+                public const string LegacyUnspecified = "validation.error";
+                public const string ValueNotNull = "value.not-null";
+                public const string FormatGuid = "format.guid";
+                public const string StringMaxLength = "string.max-length";
+                public const string PageSizeOutOfRange = "page-size.out-of-range";
+            }
+
+            public static class FaultCodes
+            {
+                public const string NotImplemented = "not-implemented";
+                public const string StateMachineInvalidTransition = "state-machine.invalid-transition";
+            }
+
+            public sealed record FieldViolation(string Field, string ReasonCode, string? Detail = null);
+
+            public sealed record RuleViolation(string ReasonCode, string? Detail = null);
+
+            public static class Failure
+            {
+                public static object ForField(string propertyName, string reasonCode, string? detail = null) => null!;
+
+                public static object ForRule(string reasonCode, string? detail = null) => null!;
+
+                public static object ForReason(string reasonCode, string? detail = null) => null!;
+
+                public static object For(string resourceType, string reasonCode, object? id = null) => null!;
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class StringLengthAttribute : System.Attribute
+            {
+                public StringLengthAttribute(int maxLength) { }
+
+                public string? Code { get; set; }
+
+                public string? Message { get; set; }
+            }
+        }
+
+        namespace FluentValidation
+        {
+            public interface IRuleBuilderOptions<T, TProperty> { }
+
+            public static class DefaultValidatorOptions
+            {
+                public static IRuleBuilderOptions<T, TProperty> WithErrorCode<T, TProperty>(
+                    this IRuleBuilderOptions<T, TProperty> rule, string errorCode) => rule;
+            }
+        }
+
+        namespace FluentValidation.TestHelper
+        {
+            public interface ITestValidationContinuation { }
+
+            public static class ValidationTestExtension
+            {
+                public static ITestValidationContinuation WithErrorCode(
+                    this ITestValidationContinuation failures, string expectedErrorCode) => failures;
+            }
+        }
+
+        namespace NotTrellis
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class ForeignAttribute : System.Attribute
+            {
+                public string? Code { get; set; }
+            }
+
+            public static class Unrelated
+            {
+                public static object ForRule(string reasonCode, string? detail = null) => null!;
+
+                public static object WithErrorCode(string errorCode) => null!;
+            }
+        }
+        """;
+}

--- a/Trellis.Analyzers/tests/ReasonCodeVocabularyAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/ReasonCodeVocabularyAnalyzerTests.cs
@@ -1,0 +1,310 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="ReasonCodeVocabularyAnalyzer"/> (TRLS064).
+/// </summary>
+/// <remarks>
+/// The rule's risk is not missing a case, it is firing on a legitimate application code. The docs
+/// promise the freeze constrains Trellis rather than the application, so roughly half of these tests
+/// assert silence.
+/// </remarks>
+public class ReasonCodeVocabularyAnalyzerTests
+{
+    private static async Task VerifyAsync(string body, params DiagnosticResult[] expected)
+    {
+        var source = $$"""
+            public class Codes
+            {
+                public void Emit()
+                {
+            {{body}}
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<ReasonCodeVocabularyAnalyzer>(source, expected);
+        test.TestState.Sources.Add(("ReasonCodeStubs.cs", ReasonCodeTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    private static DiagnosticResult Expect(int location) =>
+        AnalyzerTestHelper.Diagnostic(DiagnosticDescriptors.ReasonCodeVocabulary).WithLocation(location);
+
+    private static DiagnosticResult ExpectFrozen(int location, string code, string constant) =>
+        Expect(location).WithArguments(code, FrozenExplanation(constant));
+
+    private static string FrozenExplanation(string constant) =>
+        $"is the framework reason code {constant}; emit it by constant, because a typo in a literal is "
+        + "a silent wire break while a typo in a constant name does not compile";
+
+    private static string SquatExplanation(string prefix) =>
+        $"claims the framework namespace '{prefix}.*', whose meaning Trellis publishes, so a client "
+        + "falling back on the prefix will read this application code as a framework one — application "
+        + "codes are free-form, so pick a namespace the framework does not own";
+
+    private const string ReservedExplanation =
+        "claims the reserved 'error.*' namespace, which carries only the 'error.unspecified' sentinel; "
+        + "a second member there makes the \"no reason available\" fallback lossy";
+
+    private const string PlaceholderExplanation =
+        "is the pre-vocabulary placeholder, which the boundary normalizes away; emit a real reason code "
+        + "instead";
+
+    // ---- Restating a frozen code (fixable) ----
+
+    [Fact]
+    public async Task Literal_matching_a_ValidationCodes_value_is_reported() =>
+        await VerifyAsync("""
+                    Failure.ForField("name", {|#0:"value.not-null"|});
+            """, ExpectFrozen(0, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task Literal_matching_a_FaultCodes_value_is_reported() =>
+        await VerifyAsync("""
+                    Failure.ForReason({|#0:"state-machine.invalid-transition"|});
+            """, ExpectFrozen(0, "state-machine.invalid-transition", "FaultCodes.StateMachineInvalidTransition"));
+
+    [Fact]
+    public async Task Single_segment_fault_code_is_reported() =>
+        await VerifyAsync("""
+                    Failure.ForReason({|#0:"not-implemented"|});
+            """, ExpectFrozen(0, "not-implemented", "FaultCodes.NotImplemented"));
+
+    [Fact]
+    public async Task Positional_record_parameter_is_reported() =>
+        await VerifyAsync("""
+                    _ = new FieldViolation("name", {|#0:"format.guid"|});
+                    _ = new RuleViolation({|#1:"value.not-null"|});
+            """,
+            ExpectFrozen(0, "format.guid", "ValidationCodes.FormatGuid"),
+            ExpectFrozen(1, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task Named_argument_is_reported() =>
+        await VerifyAsync("""
+                    Failure.ForField(reasonCode: {|#0:"value.not-null"|}, propertyName: "name");
+            """, ExpectFrozen(0, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task Reason_code_in_a_later_position_is_reported() =>
+        // `For` puts the code third; keying on the parameter name rather than an index is what makes
+        // the differing arities across the eleven factory overloads a non-issue.
+        await VerifyAsync("""
+                    Failure.For("Order", {|#0:"value.not-null"|}, 1);
+            """, ExpectFrozen(0, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    // ---- The reserved and squatted namespaces ----
+
+    [Fact]
+    public async Task Error_namespace_is_reported_as_reserved() =>
+        await VerifyAsync("""
+                    Failure.ForRule({|#0:"error.my-own"|});
+            """, Expect(0).WithArguments("error.my-own", ReservedExplanation));
+
+    [Fact]
+    public async Task Framework_namespace_squatting_is_reported() =>
+        await VerifyAsync("""
+                    Failure.ForRule({|#0:"value.my-own-check"|});
+            """, Expect(0).WithArguments("value.my-own-check", SquatExplanation("value")));
+
+    [Fact]
+    public async Task Hyphenated_framework_namespace_is_recognised() =>
+        // `page-size` is a single segment containing a hyphen; splitting on the hyphen rather than the
+        // dot would miss it.
+        await VerifyAsync("""
+                    Failure.ForRule({|#0:"page-size.made-up"|});
+            """, Expect(0).WithArguments("page-size.made-up", SquatExplanation("page-size")));
+
+    [Fact]
+    public async Task Legacy_placeholder_is_reported_without_a_constant_suggestion() =>
+        await VerifyAsync("""
+                    Failure.ForRule({|#0:"validation.error"|});
+            """, Expect(0).WithArguments("validation.error", PlaceholderExplanation));
+
+    // ---- Silence: the application's own vocabulary ----
+
+    [Fact]
+    public async Task Application_code_in_its_own_namespace_is_clean() =>
+        await VerifyAsync("""
+                    Failure.ForRule("order.cancel-after-ship");
+            """);
+
+    [Fact]
+    public async Task Bare_application_code_is_clean() =>
+        // The trial agent that requested this rule wanted `required` flagged for duplicating
+        // `value.not-null`. It is a synonym, not a collision, and the docs promise no analyzer
+        // pressures the choice — so it stays silent, deliberately.
+        await VerifyAsync("""
+                    Failure.ForRule("required");
+            """);
+
+    [Fact]
+    public async Task Legacy_namespace_is_not_reserved_against_applications() =>
+        // `validation.error` itself is reported above, but the namespace is a pre-vocabulary artifact
+        // rather than something the framework published a meaning for.
+        await VerifyAsync("""
+                    Failure.ForRule("validation.my-own");
+            """);
+
+    [Fact]
+    public async Task Constant_reference_is_clean() =>
+        // The whole rule collapses if this fires: a constant reference carries a constant *value*, so
+        // testing the value alone would flag the exact shape the diagnostic tells authors to write.
+        await VerifyAsync("""
+                    Failure.ForField("name", ValidationCodes.ValueNotNull);
+                    Failure.ForReason(FaultCodes.StateMachineInvalidTransition);
+            """);
+
+    [Fact]
+    public async Task Local_constant_indirection_is_clean() =>
+        // Accepted blind spot, asserted so it is a decision rather than a surprise.
+        await VerifyAsync("""
+                    const string code = "value.not-null";
+                    Failure.ForRule(code);
+            """);
+
+    [Fact]
+    public async Task Non_Trellis_method_with_a_reasonCode_parameter_is_clean() =>
+        await VerifyAsync("""
+                    NotTrellis.Unrelated.ForRule("value.not-null");
+            """);
+
+    [Fact]
+    public async Task Frozen_value_in_a_non_reasonCode_parameter_is_clean() =>
+        // The field name happens to read like a code; only the reason-code slot is the wire contract.
+        await VerifyAsync("""
+                    Failure.ForField("value.not-null", "order.rejected");
+            """);
+
+    [Fact]
+    public async Task Empty_literal_is_clean() =>
+        // Not this rule's business; an empty code is TRLS060's.
+        await VerifyAsync("""
+                    Failure.ForRule("");
+            """);
+
+    // ---- FluentValidation's WithErrorCode ----
+
+    private static async Task VerifySourceAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<ReasonCodeVocabularyAnalyzer>(source, expected);
+        test.TestState.Sources.Add(("ReasonCodeStubs.cs", ReasonCodeTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    private const string RuleBuilderHost = """
+        using FluentValidation;
+
+        public class Rules
+        {
+            public IRuleBuilderOptions<object, string> Builder = null!;
+
+        """;
+
+    [Fact]
+    public async Task WithErrorCode_restating_a_frozen_code_is_reported() =>
+        await VerifySourceAsync(RuleBuilderHost + """
+                public void Apply() => Builder.WithErrorCode({|#0:"value.not-null"|});
+            }
+            """, ExpectFrozen(0, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task WithErrorCode_squatting_a_framework_namespace_is_reported() =>
+        await VerifySourceAsync(RuleBuilderHost + """
+                public void Apply() => Builder.WithErrorCode({|#0:"page-size.too-big"|});
+            }
+            """, Expect(0).WithArguments("page-size.too-big", SquatExplanation("page-size")));
+
+    [Fact]
+    public async Task WithErrorCode_carrying_an_application_code_is_clean() =>
+        // The whole point of WithErrorCode is to name an application failure.
+        await VerifySourceAsync(RuleBuilderHost + """
+                public void Apply() => Builder.WithErrorCode("customer.unknown");
+            }
+            """);
+
+    [Fact]
+    public async Task WithErrorCode_referencing_the_constant_is_clean() =>
+        await VerifySourceAsync(RuleBuilderHost + """
+                public void Apply() => Builder.WithErrorCode(Trellis.ValidationCodes.ValueNotNull);
+            }
+            """);
+
+    [Fact]
+    public async Task WithErrorCode_outside_the_FluentValidation_namespace_is_clean() =>
+        // Same method name, unrelated API — matching on name alone would be a false positive.
+        await VerifySourceAsync("""
+            public class Other
+            {
+                public void Apply() => NotTrellis.Unrelated.WithErrorCode("value.not-null");
+            }
+            """);
+
+    [Fact]
+    public async Task Test_helper_WithErrorCode_assertion_is_clean() =>
+        // FluentValidation's TestHelper overload names its parameter `expectedErrorCode`, so the
+        // parameter-name gate excludes it — which is the behavior we want, not an accident to tidy
+        // away. Asserting the literal wire value is the deliberate pin that catches a renamed
+        // constant; a test comparing the constant to itself stays green through exactly that break.
+        await VerifySourceAsync("""
+            using FluentValidation.TestHelper;
+
+            public class Assertions
+            {
+                public ITestValidationContinuation Failures = null!;
+
+                public void Assert() => Failures.WithErrorCode("value.not-null");
+            }
+            """);
+
+    // ---- The Code property on Trellis primitive attributes ----
+
+    [Fact]
+    public async Task Attribute_Code_restating_a_frozen_code_is_reported() =>
+        await VerifySourceAsync("""
+            [Trellis.StringLength(10, Code = {|#0:"string.max-length"|})]
+            public class Name { }
+            """, ExpectFrozen(0, "string.max-length", "ValidationCodes.StringMaxLength"));
+
+    [Fact]
+    public async Task Attribute_Code_squatting_the_reserved_namespace_is_reported() =>
+        await VerifySourceAsync("""
+            [Trellis.StringLength(10, Code = {|#0:"error.too-long"|})]
+            public class Name { }
+            """, Expect(0).WithArguments("error.too-long", ReservedExplanation));
+
+    [Fact]
+    public async Task Attribute_Code_carrying_an_application_code_is_clean() =>
+        // The documented reason to set Code at all; trellis-api-primitives.md's own example is this shape.
+        await VerifySourceAsync("""
+            [Trellis.StringLength(10, Code = "tenant.id.missing")]
+            public class Name { }
+            """);
+
+    [Fact]
+    public async Task Attribute_Code_referencing_the_constant_is_clean() =>
+        await VerifySourceAsync("""
+            [Trellis.StringLength(10, Code = Trellis.ValidationCodes.StringMaxLength)]
+            public class Name { }
+            """);
+
+    [Fact]
+    public async Task Attribute_property_other_than_Code_is_clean() =>
+        // Only Code reaches the wire as a reason code.
+        await VerifySourceAsync("""
+            [Trellis.StringLength(10, Message = "value.not-null")]
+            public class Name { }
+            """);
+
+    [Fact]
+    public async Task Non_Trellis_attribute_with_a_Code_property_is_clean() =>
+        await VerifySourceAsync("""
+            [NotTrellis.Foreign(Code = "value.not-null")]
+            public class Name { }
+            """);
+}

--- a/Trellis.Analyzers/tests/ReasonCodeVocabularyAnalyzerTests.cs
+++ b/Trellis.Analyzers/tests/ReasonCodeVocabularyAnalyzerTests.cs
@@ -307,4 +307,44 @@ public class ReasonCodeVocabularyAnalyzerTests
             [NotTrellis.Foreign(Code = "value.not-null")]
             public class Name { }
             """);
+
+    [Fact]
+    public async Task Duplicate_wire_value_reports_the_first_declaring_class()
+    {        // The reflection guard in Trellis.Core already forbids a duplicate wire value, so this is
+        // defensive — but "keep the first" was a claim in a comment with nothing holding it, and the
+        // code did the opposite until a reviewer noticed. Pinning it makes the tie deterministic:
+        // types are walked ValidationCodes then FaultCodes, so the ValidationCodes spelling wins.
+        const string duplicateVocabulary = """
+            namespace Trellis
+            {
+                public static class ValidationCodes
+                {
+                    public const string ValueNotNull = "value.not-null";
+                }
+
+                public static class FaultCodes
+                {
+                    public const string AlsoValueNotNull = "value.not-null";
+                }
+
+                public static class Failure
+                {
+                    public static object ForRule(string reasonCode) => null!;
+                }
+            }
+            """;
+
+        var test = AnalyzerTestHelper.CreateDiagnosticTest<ReasonCodeVocabularyAnalyzer>(
+            """
+            public class Codes
+            {
+                public void Emit() => Failure.ForRule({|#0:"value.not-null"|});
+            }
+            """,
+            [ExpectFrozen(0, "value.not-null", "ValidationCodes.ValueNotNull")]);
+
+        test.TestState.Sources.Add(("DuplicateVocabulary.cs", duplicateVocabulary));
+
+        await test.RunAsync();
+    }
 }

--- a/Trellis.Analyzers/tests/ReasonCodeVocabularyCodeFixProviderTests.cs
+++ b/Trellis.Analyzers/tests/ReasonCodeVocabularyCodeFixProviderTests.cs
@@ -1,0 +1,151 @@
+﻿namespace Trellis.Analyzers.Tests;
+
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="ReasonCodeVocabularyCodeFixProvider"/> (TRLS064).
+/// </summary>
+public class ReasonCodeVocabularyCodeFixProviderTests
+{
+    private static async Task VerifyFixAsync(string source, string fixedSource, params DiagnosticResult[] expected)
+    {
+        var test = CodeFixTestHelper
+            .CreateCodeFixTest<ReasonCodeVocabularyAnalyzer, ReasonCodeVocabularyCodeFixProvider>(
+                source, fixedSource, expected);
+
+        test.TestState.Sources.Add(("ReasonCodeStubs.cs", ReasonCodeTestStubs.Source));
+        test.FixedState.Sources.Add(("ReasonCodeStubs.cs", ReasonCodeTestStubs.Source));
+
+        await test.RunAsync();
+    }
+
+    private static DiagnosticResult Expect(int location, string code, string constant) =>
+        CodeFixTestHelper.Diagnostic(DiagnosticDescriptors.ReasonCodeVocabulary)
+            .WithLocation(location)
+            .WithArguments(
+                code,
+                $"is the framework reason code {constant}; emit it by constant, because a typo in a "
+                + "literal is a silent wire break while a typo in a constant name does not compile");
+
+    [Fact]
+    public async Task Frozen_literal_is_replaced_by_its_constant() =>
+        await VerifyFixAsync(
+            """
+            public class Codes
+            {
+                public void Emit() => Failure.ForField("name", {|#0:"value.not-null"|});
+            }
+            """,
+            """
+            public class Codes
+            {
+                public void Emit() => Failure.ForField("name", ValidationCodes.ValueNotNull);
+            }
+            """,
+            Expect(0, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task Fault_code_literal_is_replaced_by_its_constant() =>
+        await VerifyFixAsync(
+            """
+            public class Codes
+            {
+                public void Emit() => Failure.ForReason({|#0:"not-implemented"|});
+            }
+            """,
+            """
+            public class Codes
+            {
+                public void Emit() => Failure.ForReason(FaultCodes.NotImplemented);
+            }
+            """,
+            Expect(0, "not-implemented", "FaultCodes.NotImplemented"));
+
+    [Fact]
+    public async Task All_occurrences_are_fixed_together() =>
+        // The motivating case for fix-all: one literal repeated across many call sites.
+        await VerifyFixAsync(
+            """
+            public class Codes
+            {
+                public void First() => Failure.ForRule({|#0:"value.not-null"|});
+                public void Second() => Failure.ForRule({|#1:"value.not-null"|});
+                public void Third() => Failure.ForField("x", {|#2:"value.not-null"|});
+            }
+            """,
+            """
+            public class Codes
+            {
+                public void First() => Failure.ForRule(ValidationCodes.ValueNotNull);
+                public void Second() => Failure.ForRule(ValidationCodes.ValueNotNull);
+                public void Third() => Failure.ForField("x", ValidationCodes.ValueNotNull);
+            }
+            """,
+            Expect(0, "value.not-null", "ValidationCodes.ValueNotNull"),
+            Expect(1, "value.not-null", "ValidationCodes.ValueNotNull"),
+            Expect(2, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task Namespace_squatting_offers_no_fix()
+    {
+        // There is no mechanical replacement — only the author knows which namespace the code belongs
+        // in — so the source is expected to come back unchanged.
+        const string source = """
+            public class Codes
+            {
+                public void Emit() => Failure.ForRule({|#0:"value.my-own-check"|});
+            }
+            """;
+
+        await VerifyFixAsync(
+            source,
+            source,
+            CodeFixTestHelper.Diagnostic(DiagnosticDescriptors.ReasonCodeVocabulary)
+                .WithLocation(0)
+                .WithArguments(
+                    "value.my-own-check",
+                    "claims the framework namespace 'value.*', whose meaning Trellis publishes, so a "
+                    + "client falling back on the prefix will read this application code as a framework "
+                    + "one — application codes are free-form, so pick a namespace the framework does not own"));
+    }
+
+    [Fact]
+    public async Task WithErrorCode_literal_is_replaced_by_its_constant() =>
+        await VerifyFixAsync(
+            """
+            using FluentValidation;
+
+            public class Rules
+            {
+                public IRuleBuilderOptions<object, string> Builder = null!;
+
+                public void Apply() => Builder.WithErrorCode({|#0:"value.not-null"|});
+            }
+            """,
+            """
+            using FluentValidation;
+
+            public class Rules
+            {
+                public IRuleBuilderOptions<object, string> Builder = null!;
+
+                public void Apply() => Builder.WithErrorCode(ValidationCodes.ValueNotNull);
+            }
+            """,
+            Expect(0, "value.not-null", "ValidationCodes.ValueNotNull"));
+
+    [Fact]
+    public async Task Attribute_Code_literal_is_replaced_by_its_constant() =>
+        // Attribute arguments must be compile-time constants, which a const string is.
+        await VerifyFixAsync(
+            """
+            [Trellis.StringLength(10, Code = {|#0:"string.max-length"|})]
+            public class Name { }
+            """,
+            """
+            [Trellis.StringLength(10, Code = ValidationCodes.StringMaxLength)]
+            public class Name { }
+            """,
+            Expect(0, "string.max-length", "ValidationCodes.StringMaxLength"));
+}

--- a/docs/docfx_project/api_reference/trellis-api-analyzers.md
+++ b/docs/docfx_project/api_reference/trellis-api-analyzers.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Analyzers
 namespaces: [Trellis, Trellis.Analyzers]
-types: [TrellisDiagnosticIds, EmptyReasonCodeOverride, ValidateAdditionalOverloadConflict, UnnamedValidateAdditionalFailure, MustWithoutErrorCode, DiagnosticDescriptors, ResultNotHandledAnalyzer, UseBindInsteadOfMapAnalyzer, UnsafeValueAccessAnalyzer, ResultDoubleWrappingAnalyzer, AsyncResultMisuseAnalyzer, MaybeDoubleWrappingAnalyzer, UseResultCombineAnalyzer, AsyncLambdaWithSyncMethodAnalyzer, ThrowInResultChainAnalyzer, UnsafeValueInLinqAnalyzer, CombineLimitAnalyzer, UseSaveChangesResultAnalyzer, HasIndexMaybePropertyAnalyzer, UnsafeResultDeconstructionAnalyzer, DefaultResultOrMaybeAnalyzer, CompositeValueObjectDtoConverterAnalyzer, RedundantEfConfigurationAnalyzer, OwnedEntityInitOnlyPropertyAnalyzer, MustWithoutErrorCodeAnalyzer, AddResultGuardCodeFixProvider, UseBindInsteadOfMapCodeFixProvider, UseAsyncMethodVariantCodeFixProvider, UseSaveChangesResultCodeFixProvider, TRLS043, TRLS044, TRLS045, TRLS054, TRLS055, TRLS057, TRLS058, TRLS062, TRLS063]
+types: [TrellisDiagnosticIds, EmptyReasonCodeOverride, ValidateAdditionalOverloadConflict, UnnamedValidateAdditionalFailure, MustWithoutErrorCode, DiagnosticDescriptors, ResultNotHandledAnalyzer, UseBindInsteadOfMapAnalyzer, UnsafeValueAccessAnalyzer, ResultDoubleWrappingAnalyzer, AsyncResultMisuseAnalyzer, MaybeDoubleWrappingAnalyzer, UseResultCombineAnalyzer, AsyncLambdaWithSyncMethodAnalyzer, ThrowInResultChainAnalyzer, UnsafeValueInLinqAnalyzer, CombineLimitAnalyzer, UseSaveChangesResultAnalyzer, HasIndexMaybePropertyAnalyzer, UnsafeResultDeconstructionAnalyzer, DefaultResultOrMaybeAnalyzer, CompositeValueObjectDtoConverterAnalyzer, RedundantEfConfigurationAnalyzer, OwnedEntityInitOnlyPropertyAnalyzer, MustWithoutErrorCodeAnalyzer, AddResultGuardCodeFixProvider, UseBindInsteadOfMapCodeFixProvider, UseAsyncMethodVariantCodeFixProvider, UseSaveChangesResultCodeFixProvider, TRLS043, TRLS044, TRLS045, TRLS054, TRLS055, TRLS057, TRLS058, TRLS062, TRLS063, TRLS064, ReasonCodeVocabulary, ReasonCodeVocabularyAnalyzer, ReasonCodeVocabularyCodeFixProvider]
 version: v3
 last_verified: 2026-06-17
 audience: [llm]
@@ -104,6 +104,7 @@ In test projects, `TRLS001` and `TRLS015` are the rules most likely to need tuni
 | `TRLS061` | Error | Both `ValidateAdditional` overloads declared | Emitted by `RequiredPartialClassGenerator` when a value object declares both the three-argument `ValidateAdditional` and the four-argument overload that can set a reason code. The generator emits one defining declaration, so the other implementation would fail with a compiler error that names no Trellis concept. Keep one. |
 | `TRLS062` | Info | `ValidateAdditional` rejects without naming a reason | Emitted by `RequiredPartialClassGenerator` when a value object implements the three-argument `ValidateAdditional`. That overload can reject a value but has nowhere to put a reason, so the failure reaches the client as `error.unspecified` and there is nothing to branch on. Add a `ref string? errorCode` parameter and set it. Info by default because the three-argument form is legal and unchanged; raise it with `dotnet_diagnostic.TRLS062.severity` once your value objects name their failures. |
 | `TRLS063` | Info | `Must` rule has no `WithErrorCode` | Emitted by `MustWithoutErrorCodeAnalyzer` when a FluentValidation `Must`/`MustAsync` rule component carries no `WithErrorCode`. Every built-in validator has a name Trellis projects to a real reason code; `Must` and `MustAsync` report as `PredicateValidator`/`AsyncPredicateValidator`, which project to the `error.unspecified` sentinel. Chain `WithErrorCode("...")`. The analyzer walks only as far as the next rule component, so a code attached to a later `Must` does not count for an earlier one. |
+| `TRLS064` | Info | Reason-code literal conflicts with the frozen vocabulary | Emitted by `ReasonCodeVocabularyAnalyzer` when a string literal in a reason-code position restates a frozen framework code (use the `ValidationCodes`/`FaultCodes` constant — a code fix does this, with fix-all), claims the reserved `error.*` namespace, or claims a namespace the framework publishes a meaning for. Three positions are inspected: a `reasonCode` parameter on any Trellis method or constructor, FluentValidation's `WithErrorCode(...)`, and `Code` on the Trellis primitive attributes. It does **not** check membership: an application code such as `order.cancel-after-ship` is legitimate and stays silent. |
 
 ## Constants — `TrellisDiagnosticIds`
 
@@ -115,7 +116,7 @@ The public static class `Trellis.TrellisDiagnosticIds` (in the `Trellis.Analyzer
 public string GetCity(Maybe<Address> address) => address.Value.City;
 ```
 
-Generator IDs (`TRLS031`–`TRLS045`, `TRLS056`–`TRLS058`, `TRLS060`–`TRLS062`), the LINQ-analyzer IDs (`TRLS054`–`TRLS055`), and `TRLS063` are also exposed as constants on the same class so consumers have a single canonical reference for the unified namespace.
+Generator IDs (`TRLS031`–`TRLS045`, `TRLS056`–`TRLS058`, `TRLS060`–`TRLS062`), the LINQ-analyzer IDs (`TRLS054`–`TRLS055`), and `TRLS063`–`TRLS064` are also exposed as constants on the same class so consumers have a single canonical reference for the unified namespace.
 
 ### Constant → diagnostic ID → emitter
 
@@ -164,6 +165,7 @@ Every `public const string` field on `TrellisDiagnosticIds`, the diagnostic ID i
 | `ValidateAdditionalOverloadConflict` | `TRLS061` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `UnnamedValidateAdditionalFailure` | `TRLS062` | `RequiredPartialClassGenerator` (Trellis.Core.Generator) |
 | `MustWithoutErrorCode` | `TRLS063` | `MustWithoutErrorCodeAnalyzer` |
+| `ReasonCodeVocabulary` | `TRLS064` | `ReasonCodeVocabularyAnalyzer` |
 
 ## Descriptors — `DiagnosticDescriptors`
 
@@ -195,6 +197,7 @@ Every descriptor uses the single shared category `Trellis` (defined as `private 
 | `MaybeEqualsInQueryable` | `TRLS054` | Warning |
 | `NonInlineHasValueWhereInQueryable` | `TRLS055` | Warning |
 | `MustWithoutErrorCode` | `TRLS063` | Info |
+| `ReasonCodeVocabulary` | `TRLS064` | Info |
 
 > **Note:** The TRLS013 descriptor was originally exposed as `UnsafeValueInLinq`. The current canonical name is `UnsafeMaybeValueInLinq` (matching the `TrellisDiagnosticIds.UnsafeMaybeValueInLinq` constant); the old name is retained as an `[Obsolete]` alias pointing at the same `DiagnosticDescriptor` instance for backward compatibility. New code should reference `UnsafeMaybeValueInLinq`.
 
@@ -450,6 +453,29 @@ When the guarded statements end the method with a `return`, the wrapped code no 
 - Default severity is Info, not Warning: an uncoded `Must` is legal and pre-existing code is full of them. Raise it with `dotnet_diagnostic.TRLS063.severity = warning` once a codebase has caught up.
 - No code fix — only the author knows what the rule's failure should be called, and a placeholder code on the wire is worse than the sentinel because it looks deliberate.
 
+#### `ReasonCodeVocabularyAnalyzer` — `TRLS064`
+- Activates only when the compilation can see `Trellis.ValidationCodes`. The frozen vocabulary is read **out of the compilation** — the analyzer enumerates the `public const string` fields on `ValidationCodes` and `FaultCodes` rather than carrying a table of its own, so a code added to the vocabulary is covered the day it is added. A hard-coded copy would be a second source of truth, and duplicated reason codes drifting is the problem this rule exists to catch.
+- Matches an argument by **parameter or property name**, never by a list of members. Three positions carry a reason code to the wire, and all three are inspected:
+
+  | Position | Matched by | Note |
+  | --- | --- | --- |
+  | Any Trellis method or constructor | a parameter named `reasonCode`, compared case-insensitively | Covers all eleven `ForField`/`ForRule`/`ForReason`/`For` overloads regardless of arity or argument position, plus positional records (`FieldViolation.ReasonCode`, `RuleViolation.ReasonCode`), plus the twelfth overload the day it is added |
+  | FluentValidation `WithErrorCode(...)` | the method name plus its declaring namespace | Its argument becomes a Trellis reason code verbatim through `Trellis.FluentValidation`'s projection. The namespace is required so an unrelated API of the same method name is not analyzed; an application's own `WithErrorCode` declared in `namespace FluentValidation` *is* matched, because whatever wraps it, the argument is still an error code. FluentValidation's **test-helper** overload of the same name is excluded, because it names its parameter `expectedErrorCode` rather than `errorCode` |
+  | `Code` on a Trellis primitive attribute | the property name, on a Trellis-declared attribute | `[StringLength]`, `[Range]`, `[NotDefault]` and the sign-convenience attributes. A `Code` property on a non-Trellis attribute is ignored |
+
+- Reports three things, all Info:
+
+  | Shape | Message | Fixable |
+  | --- | --- | --- |
+  | Literal equals a frozen code (`"value.not-null"`) | Names the constant to use | Yes — replaces with `ValidationCodes.ValueNotNull`, with fix-all |
+  | Literal is the pre-vocabulary placeholder (`"validation.error"`) | Says to emit a real code | No — the guidance is not "use the constant" but "do not emit this" |
+  | Literal claims `error.*`, or a namespace the framework publishes (`value.*`, `format.*`, `page-size.*`, …) | Names the namespace and why it misleads | No — only the author knows where the code belongs |
+
+- **It does not check membership.** The freeze [constrains Trellis, not the application](trellis-api-core.md#validationcodes--the-reason-code-vocabulary), and [trellis-api-primitives.md](trellis-api-primitives.md#overriding-the-reason-code--code) promises that no analyzer pressures the choice to override or keep a framework code. A novel, well-formed application code such as `order.cancel-after-ship` — or a bare `required` — is silent. What is reported is narrower: restating a code that already has a constant, or claiming a namespace whose meaning Trellis has published, which makes an application failure read as a framework one to a client using the documented prefix fallback.
+- The `validation.*` namespace is **not** reserved against applications, even though `validation.error` itself is reported. That namespace is a pre-vocabulary artifact rather than one the framework gave a meaning to.
+- **Assertions are not reported.** Because the match requires the parameter to be named `reasonCode` or `errorCode`, a test asserting a literal wire value — `ShouldHaveValidationErrorFor(...).WithErrorCode("value.not-null")`, whose parameter is `expectedErrorCode` — stays silent. That is deliberate: pinning the exact published string in a test is what catches a renamed constant, and a test that compares the constant to itself stays green through precisely that break.
+- **Only literal syntax is reported.** A constant reference carries a constant *value* too, so testing the value alone would flag `ForField(f, ValidationCodes.ValueNotNull)` — precisely the shape this rule tells authors to write. The consequence is that a code reached through an application's own `const string` indirection is invisible here; that is the accepted trade, not an oversight.
+
 ## Code fix providers
 
 | Code fix provider | Fixes | Behavior |
@@ -458,6 +484,7 @@ When the guarded statements end the method with a `return`, the wrapped code no 
 | `UseBindInsteadOfMapCodeFixProvider` | `TRLS002` | Replaces `Map` with `Bind` and `MapAsync` with `BindAsync`. |
 | `UseAsyncMethodVariantCodeFixProvider` | `TRLS009` | Replaces sync method names with async variants, awaits the rewritten call, and adds `async` to Task/ValueTask-returning methods when that is locally safe. It withholds the fix for chained/nested calls and scopes that require manual delegate, parameter, or return-flow changes. |
 | `UseSaveChangesResultCodeFixProvider` | `TRLS015` | Replaces `SaveChangesAsync` / `SaveChanges` with `SaveChangesResultAsync` or `SaveChangesResultUnitAsync`, adds `await`/`async` for sync `SaveChanges`, and adds `using Trellis.EntityFrameworkCore;` when needed. When the returned row count is *used*, the fix is offered only where the consuming context can rebind to `Result<int>` — an implicitly-typed (`var`) local. It is withheld for explicit `int` locals, assignments, conditions, arguments, and `return` statements, because the mechanical rename would produce `CS0029`/`CS0019`; restructure those call sites into the railway by hand. |
+| `ReasonCodeVocabularyCodeFixProvider` | `TRLS064` | Replaces a literal that restates a frozen code with its constant — `"value.not-null"` becomes `ValidationCodes.ValueNotNull`. Fix-all is supported, because the motivating case is one literal repeated across dozens of call sites. Only that shape is fixed: the analyzer attaches the constant to the diagnostic, and a namespace-squatting diagnostic carries none, so no fix is offered where no mechanical replacement exists. |
 | `CreatedAtRouteMissingApiVersionCodeFixProvider` | `TRLS023` | Appends `.WithVersionedRoute()` to the flagged `CreatedAtRoute(...)`, `CreatedAtAction(...)`, or `WithLocation(...)` call (so the chain becomes `<original>.WithVersionedRoute()`) and inserts `using Trellis.Asp.ApiVersioning;` in the same scope as existing usings (file-scoped namespace, block-scoped namespace, or top-level) when missing. |
 
 ## Compilable examples

--- a/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
+++ b/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
@@ -1,7 +1,7 @@
 ﻿---
 package: Trellis.Analyzers (applied form)
 namespaces: [Trellis, Trellis.Analyzers]
-types: [TRLS001, TRLS003, TRLS010, TRLS013, TRLS014, TRLS015, TRLS016, TRLS018, TRLS019, TRLS020, TRLS021, TRLS035, TRLS036, TRLS037, TRLS038, TRLS039, TRLS054, TRLS055, TRLS056, TRLS059, TRLS062, TRLS063]
+types: [TRLS001, TRLS003, TRLS010, TRLS013, TRLS014, TRLS015, TRLS016, TRLS018, TRLS019, TRLS020, TRLS021, TRLS035, TRLS036, TRLS037, TRLS038, TRLS039, TRLS054, TRLS055, TRLS056, TRLS059, TRLS062, TRLS063, TRLS064]
 related_docs: [trellis-api-analyzers.md, trellis-api-cookbook.md]
 version: v4
 last_verified: 2026-08-18
@@ -550,6 +550,56 @@ RuleFor(x => x.Name)
 > Severity: Info, because uncoded `Must` rules are legal and existing validators are full of them. Raise it with `dotnet_diagnostic.TRLS063.severity = warning` once a codebase has caught up. There is deliberately no code fix: only the author knows what the rule's failure should be called, and a placeholder code looks deliberate on the wire in a way the sentinel does not.
 
 The analyzer reports only where it can prove no code applies. It stays silent when the rule's value escapes the statement (`var rule = RuleFor(...).Must(...);`), when the chain calls `Configure(...)` — which can set `ErrorCode` directly — or when it passes through any helper your application declared, including one placed in `namespace FluentValidation`, since such a helper may itself wrap `WithErrorCode`. Those shapes may well be uncoded, but a false accusation against an author who did the right thing costs more than a miss on a shape this rule flags everywhere else.
+
+## TRLS064 — reason-code literal that collides with the frozen vocabulary
+
+Trellis freezes a small set of reason codes and dispatches on their exact wire spelling. Restating one as a literal works right up until the day it doesn't: a typo in a literal is a silent wire break, whereas a typo in a constant name does not compile.
+
+```csharp
+// WRONG — the literal is unchecked, and there are usually dozens of it
+Error.InvalidInput.ForField("email", "value.not-null");        // TRLS064
+Error.InvalidInput.ForField("name", "string.max-length");      // TRLS064
+
+// FIX — the constant is the same string, checked by the compiler
+Error.InvalidInput.ForField("email", ValidationCodes.ValueNotNull);
+Error.InvalidInput.ForField("name", ValidationCodes.StringMaxLength);
+```
+
+A code fix applies this, and because the motivating case is one literal repeated across a codebase, fix-all is supported.
+
+The other two shapes claim a name that is not yours to claim. `error.*` is reserved for the single `error.unspecified` sentinel — a second member there makes the fallback lossy, because a client that sees `error.` can no longer read it as "this failure was never named". And a first segment the framework publishes a meaning for makes an application failure read as a framework one to any client using the documented prefix fallback:
+
+```csharp
+// WRONG — squats a reserved or framework-owned namespace
+Error.InvalidInput.ForField("token", "error.expired");         // TRLS064
+Error.InvalidInput.ForField("total", "money.over-budget");     // TRLS064
+
+// FIX — name it in your own domain's terms
+Error.InvalidInput.ForField("token", "session.expired");
+Error.InvalidInput.ForField("total", "budget.exceeded");
+```
+
+The same three findings apply wherever a reason code is written, not only to a `reasonCode` argument. FluentValidation's `WithErrorCode` and the `Code` property on the Trellis primitive attributes both reach the wire the same way:
+
+```csharp
+// WRONG
+RuleFor(x => x.Name).NotEmpty().WithErrorCode("value.not-empty");   // TRLS064 — restates a frozen code
+RuleFor(x => x.Age).Must(BeAdult).WithErrorCode("value.too-young"); // TRLS064 — squats value.*
+
+[StringLength(50, Code = "string.max-length")]                      // TRLS064 — restates a frozen code
+public partial class DisplayName : RequiredString<DisplayName>;
+
+// FIX
+RuleFor(x => x.Name).NotEmpty().WithErrorCode(ValidationCodes.ValueNotEmpty);
+RuleFor(x => x.Age).Must(BeAdult).WithErrorCode("customer.under-age");
+
+[StringLength(50, Code = ValidationCodes.StringMaxLength)]
+public partial class DisplayName : RequiredString<DisplayName>;
+```
+
+Setting `Code` to a name of your own is the documented reason the property exists, so `[NotDefault(Code = "tenant.id.missing")]` is silent — as it should be.
+
+> Severity: Info. **This rule does not check vocabulary membership**, and that boundary is deliberate: the freeze constrains Trellis, not your application, and `trellis-api-primitives.md` promises that no analyzer pressures the choice to override a framework code or keep it. A novel, well-formed code of your own — `order.cancel-after-ship`, or a bare `required` — is silent, including where it is a synonym for a code Trellis also has. Only restating a frozen code, or claiming a namespace whose meaning Trellis has published, is reported. Note also that only *literals* are reported: `ValidationCodes.ValueNotNull` is the recommended shape, so matching on constant value rather than syntax would flag the fix itself.
 
 ## (No analyzer) — `Result.FailAfterCommit` composed with aggregating operators
 Not an analyzer-flagged rule (no diagnostic ID), but a recurring shape that the FailAfterCommit XML doc cautions against. `Result.FailAfterCommit<TValue>(error)` is a **leaf** worker-handler operation: it converts a single aggregate's transient external rejection into a persisted `permanently_failed` state and returns. Threading that result through `Combine` / `TraverseAll` / `SequenceAll` / `WhenAllAsync` OR-accumulates the `PersistOnFailure` flag onto the aggregated failure — `TransactionalCommandBehavior` then commits the staged permanent-failure mutation alongside whatever the other legs produced, which is almost never what the handler author intended.

--- a/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
+++ b/docs/docfx_project/api_reference/trellis-api-anti-patterns.md
@@ -556,7 +556,7 @@ The analyzer reports only where it can prove no code applies. It stays silent wh
 Trellis freezes a small set of reason codes and dispatches on their exact wire spelling. Restating one as a literal works right up until the day it doesn't: a typo in a literal is a silent wire break, whereas a typo in a constant name does not compile.
 
 ```csharp
-// WRONG — the literal is unchecked, and there are usually dozens of it
+// WRONG — the literal is unchecked, and there are usually dozens of them
 Error.InvalidInput.ForField("email", "value.not-null");        // TRLS064
 Error.InvalidInput.ForField("name", "string.max-length");      // TRLS064
 

--- a/docs/docfx_project/api_reference/trellis-api-cookbook.md
+++ b/docs/docfx_project/api_reference/trellis-api-cookbook.md
@@ -25,7 +25,7 @@ audience: [llm]
   - [trellis-api-statemachine.md](trellis-api-statemachine.md#use-this-file-when) — `FireResult`, `LazyStateMachine<,>`
   - [trellis-api-testing-reference.md](trellis-api-testing-reference.md#use-this-file-when) — `Should().Be(...)`, `UnwrapError()`
   - [trellis-api-testing-aspnetcore.md](trellis-api-testing-aspnetcore.md#use-this-file-when) — `WebApplicationFactoryExtensions`, `.http` replay helpers
-  - [trellis-api-analyzers.md](trellis-api-analyzers.md#use-this-file-when) — `TRLS001`-`TRLS063`, `TrellisDiagnosticIds`
+  - [trellis-api-analyzers.md](trellis-api-analyzers.md#use-this-file-when) — `TRLS001`-`TRLS064`, `TrellisDiagnosticIds`
 
 ## How to read these recipes
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -155,7 +155,7 @@ The table is keyed on the **error-code string, never the CLR validator type**. T
 
 **A custom `WithErrorCode` passes through verbatim.** A caller who wrote `WithErrorCode("order.too-large")` means it; rewriting it would make `WithErrorCode` useless.
 
-**`Must(...)` maps to the sentinel.** A predicate can express any condition, so its validator name says only "some custom predicate failed" — which is exactly what `error.unspecified` means. Give a `Must(...)` rule a real code with `WithErrorCode`, or a client has nothing to branch on. `TRLS063` reports an uncoded `Must`/`MustAsync` when the project references `Trellis.Analyzers`; see [trellis-api-anti-patterns.md](trellis-api-anti-patterns.md#trls063--fluentvalidation-must-rule-with-no-witherrorcode) for the WRONG/FIX shapes, including where a trailing `WithErrorCode` stops applying to an earlier rule.
+**`Must(...)` maps to the sentinel.** A predicate can express any condition, so its validator name says only "some custom predicate failed" — which is exactly what `error.unspecified` means. Give a `Must(...)` rule a real code with `WithErrorCode`, or a client has nothing to branch on. `TRLS063` reports an uncoded `Must`/`MustAsync` when the project references `Trellis.Analyzers`; see [trellis-api-anti-patterns.md](trellis-api-anti-patterns.md#trls063--fluentvalidation-must-rule-with-no-witherrorcode) for the WRONG/FIX shapes, including where a trailing `WithErrorCode` stops applying to an earlier rule. `TRLS064` covers the other half of the same question — the code you pass to `WithErrorCode` — reporting one that restates a frozen framework code or claims a framework namespace.
 
 ### `ValidationArgsProjection`
 

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -137,7 +137,7 @@ public partial class TenantId : RequiredGuid<TenantId>;
 
 Three consequences are worth stating plainly, because each surprises someone:
 
-- **The framework vocabulary stays frozen and stays the default.** Overriding is not encouraged or discouraged; no analyzer pressures either choice. The freeze constrains *Trellis*, not your application — an application that overrides owns both ends of its own contract.
+- **The framework vocabulary stays frozen and stays the default.** Overriding is not encouraged or discouraged; no analyzer pressures either choice. The freeze constrains *Trellis*, not your application — an application that overrides owns both ends of its own contract. `TRLS064` does not narrow this: it never asks whether you *should* override, and a novel code of your own is silent. It reports only a `Code` that restates a frozen code verbatim (where the constant is the safer spelling of the same string) or one that claims a namespace the framework publishes a meaning for.
 - **`[Range].Code` collapses both directions.** One attribute produces two failures — below the minimum and above the maximum — and one `Code` renames both. When a client must tell them apart, keep the framework codes and use `ValidateAdditional` for the case that needs its own name.
 - **The four sign-convenience attributes share the range slot.** `[Positive]`, `[NonNegative]`, `[Negative]`, and `[NonPositive]` synthesize into the same range emission, so their `Code` overrides the same reason code `[Range]` would.
 


### PR DESCRIPTION
## Why

`ValidationCodes` and `FaultCodes` freeze a small set of reason codes, and Trellis **dispatches on their exact wire spelling**. The reference has always said to emit them by constant — *"a typo in a literal is a silent wire break, while a typo in a constant name does not compile"* — but nothing enforced it. A sweep found 33 call sites in this repo alone passing a frozen wire value as a bare literal.

## What

**`TRLS064`** (`ReasonCodeVocabularyAnalyzer`, Info severity) reports a string **literal** in a reason-code position that:

| Shape | Message | Fixable |
|---|---|---|
| Restates a frozen code (`"value.not-null"`) | Names the constant to use | **Yes** — `ValidationCodes.ValueNotNull`, with fix-all |
| Is the pre-vocabulary placeholder (`"validation.error"`) | Says to emit a real code | No — the guidance is "do not emit this", not "use the constant" |
| Claims the reserved `error.*` namespace | Names why the sentinel fallback goes lossy | No |
| Claims a framework namespace (`value.*`, `money.*`, `page-size.*`, …) | Names the namespace and why it misleads | No |

Three positions carry a reason code and all three are inspected — a `reasonCode` parameter on any Trellis method or constructor, FluentValidation's `WithErrorCode(...)`, and `Code` on the Trellis primitive attributes.

## Design decisions worth reviewing

**It deliberately does not check vocabulary membership.** The freeze [constrains Trellis, not the application](docs/docfx_project/api_reference/trellis-api-core.md), and `trellis-api-primitives.md` promises that *"no analyzer pressures either choice"* about overriding a framework code. A novel, well-formed application code — `order.cancel-after-ship`, or a bare `required` — stays **silent**, including where it is a semantic synonym for a code Trellis also has. Firing on a legitimate application code is this feature's main risk, so roughly half the tests assert silence.

**It matches literal *syntax*, not constant *value*.** A constant reference has a constant value too, so testing `ConstantValue` alone would flag `ForField(f, ValidationCodes.ValueNotNull)` — the exact shape the fix produces. The trade is that a code reached through an application's own `const string` is invisible.

**It matches by parameter/property *name*, not by a member list.** That covers all eleven `ForField`/`ForRule`/`ForReason`/`For` overloads regardless of arity or argument position, plus positional records, plus the twelfth overload the day it is added.

**It reads the vocabulary out of the compilation**, not from a hard-coded table. A copy would be a second source of truth that goes stale — which is the very problem this rule exists to catch. The test stubs use a deliberate *subset* of the real vocabulary, which is what proves the reading actually happens.

**FluentValidation's test-helper `WithErrorCode` is excluded.** Its parameter is named `expectedErrorCode` rather than `errorCode`, so the name gate skips it. That is deliberate and now pinned by a test: asserting the literal wire value is what catches a renamed constant, and a test comparing the constant to itself stays green through exactly that break.

## Verification

- **8028 tests, 0 failed** (+36 new); clean `--no-incremental` solution build, 0 warnings / 0 errors
- Doc lint (28 files), completeness audit, and the documented-symbol audit all pass
- **Proven end-to-end in a real `.csproj` build**, not just the Roslyn test harness: a temporary probe confirmed all four shapes fire with correct messages while an application code, a bare `required`, and a constant reference stayed silent
- **Mutation-tested the silence guards.** Each of the four negative guards was individually broken and the corresponding test failed — so none of the "is_clean" tests pass vacuously

Two defects were caught and fixed during review: the anti-pattern snippets originally used `Error.Validation.ForField` and `NumberOutOfRange`, neither of which exists — they would have shipped as uncompilable guidance.

## Docs

`trellis-api-analyzers.md` (full spec), `trellis-api-anti-patterns.md` (WRONG/FIX shapes), `CHANGELOG.md`, plus pointers from `trellis-api-fluentvalidation.md` and `trellis-api-primitives.md` — the latter clarifying that TRLS064 does not narrow the "no analyzer pressures either choice" promise.
