### PR TITLE
feat(mediator): ship AddTrellisMediatorInstrumentation so handler spans are actually collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `AddTrellisMediatorInstrumentation()`, so mediator spans are actually collected
+
+`AddTrellisBehaviors()` registers `TracingBehavior`, so every command and query already calls `StartActivity` — but that returns a live activity only if a `TracerProvider` listens to the `"Trellis.Mediator"` source. Trellis.Core ships `AddResultsInstrumentation()` and Trellis.Primitives ships `AddPrimitiveValueObjectInstrumentation()`; Trellis.Mediator shipped no equivalent, so the handler span was collected only by consumers who knew to type `AddSource("Trellis.Mediator")` as a raw string.
+
+The gap is silent, which is what makes it worth closing rather than documenting. A service that never registers the source looks exactly like a service in which nothing failed: no warning, no startup error, no empty-result signal. And this is the span carrying `error.code` and `error.type` — the same values the HTTP body reports — so the missing configuration is normally discovered *during* an incident, at the moment those tags were wanted. It is also the altitude the Trellis.Core tracing guidance recommends in preference to per-`Result`-operator spans, so the package was steering people to a span it did not help them collect.
+
+Measured before the change with an OpenTelemetry SDK exporting to Jaeger: a provider configured with both shipped helpers collected the `Trellis.Core` span and **zero** mediator spans; adding the source collected two. The Core span in the first run is the control — the pipeline was live and exporting, and the handler span alone was absent.
+
+`TracingBehavior<TMessage, TResponse>.ActivitySourceName` keeps its value and its place in the public API. Both it and the new helper now read from one internal constant, so a helper that listens to a name nothing emits from cannot be introduced by editing one of the two — the same silent failure, one level up.
+
 ### Added — TRLDOC015, ambiguous member names must name their receiver
 
 The `Error.Code` collapse below left ten references telling readers to use `Error`'s `ReasonCode`, a member it no longer has. All four existing doc gates passed them, and the reason is worth recording because it will recur: `FieldViolation.ReasonCode` and `RuleViolation.ReasonCode` still exist, so TRLDOC005 saw a name that resolves, TRLDOC008 saw a documented member, and TRLDOC014 saw no receiver to check — a bare name in prose carries none. Deleting a member while a same-named member survives elsewhere is precisely the move that makes every unqualified mention unverifiable.

--- a/Trellis.Mediator/NUGET_README.md
+++ b/Trellis.Mediator/NUGET_README.md
@@ -32,6 +32,7 @@ builder.Services.AddTrellisBehaviors();
 
 ## Key Features
 - Adds validation, authorization, tracing, logging, and exception behaviors that understand `Result<T>`.
+- Tracing is registered but not *collected* until you call `AddTrellisMediatorInstrumentation()` on your `TracerProviderBuilder`; without it the handler span is silently never recorded.
 - Short-circuits failures before handlers do unnecessary work.
 - Unified `ValidationBehavior` composes `IValidate` + every `IMessageValidator<TMessage>` (e.g., the `Trellis.FluentValidation` adapter) and aggregates failures into one response.
 - Supports resource authorization with explicit or assembly-scanned registration.

--- a/Trellis.Mediator/README.md
+++ b/Trellis.Mediator/README.md
@@ -32,6 +32,7 @@ builder.Services.AddTrellisBehaviors();
 
 ## Key Features
 - Adds validation, authorization, tracing, logging, and exception behaviors that understand `Result<T>`.
+- Tracing is registered but not *collected* until you call `AddTrellisMediatorInstrumentation()` on your `TracerProviderBuilder`; without it the handler span is silently never recorded.
 - Short-circuits failures before handlers do unnecessary work.
 - Unified `ValidationBehavior` composes `IValidate` + every `IMessageValidator<TMessage>` (e.g., the `Trellis.FluentValidation` adapter) and aggregates failures into one response.
 - Supports resource authorization with explicit or assembly-scanned registration.

--- a/Trellis.Mediator/src/MediatorTrace.cs
+++ b/Trellis.Mediator/src/MediatorTrace.cs
@@ -1,0 +1,19 @@
+﻿namespace Trellis.Mediator;
+
+/// <summary>
+/// Single source of truth for the mediator pipeline's activity source name.
+/// </summary>
+/// <remarks>
+/// <see cref="TracingBehavior{TMessage, TResponse}"/> emits from this name and
+/// <see cref="MediatorTraceProviderBuilderExtensions.AddTrellisMediatorInstrumentation"/> listens
+/// to it. Holding it here rather than repeating the literal keeps the pair from drifting: a helper
+/// that registers a name nothing emits from fails silently, which is the failure the helper exists
+/// to remove. The public constant stays on <c>TracingBehavior</c>, where consumers already find it;
+/// this type is internal because it adds no capability beyond that constant. Trellis.Core and
+/// Trellis.Primitives anchor their sources the same way, in <c>RopTrace</c> and
+/// <c>PrimitiveValueObjectTrace</c>.
+/// </remarks>
+internal static class MediatorTrace
+{
+    internal const string ActivitySourceName = "Trellis.Mediator";
+}

--- a/Trellis.Mediator/src/MediatorTraceProviderBuilderExtensions.cs
+++ b/Trellis.Mediator/src/MediatorTraceProviderBuilderExtensions.cs
@@ -1,0 +1,61 @@
+﻿namespace Trellis.Mediator;
+
+using OpenTelemetry.Trace;
+
+/// <summary>
+/// Extension methods for configuring OpenTelemetry tracing for the Trellis mediator pipeline.
+/// </summary>
+public static class MediatorTraceProviderBuilderExtensions
+{
+    /// <summary>
+    /// Adds Trellis mediator pipeline instrumentation to the OpenTelemetry tracer provider,
+    /// so the per-command and per-query span opened by
+    /// <see cref="TracingBehavior{TMessage, TResponse}"/> is collected.
+    /// </summary>
+    /// <param name="builder">The <see cref="TracerProviderBuilder"/> to configure.</param>
+    /// <returns>The same <see cref="TracerProviderBuilder"/> instance for method chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// <c>AddTrellisBehaviors()</c> registers <see cref="TracingBehavior{TMessage, TResponse}"/>,
+    /// so every command and query already *calls* <c>StartActivity</c>. That call only produces a
+    /// live activity if a listener is subscribed to the source, so without this registration
+    /// <c>StartActivity</c> returns <see langword="null"/> and the handler span is never collected.
+    /// </para>
+    /// <para>
+    /// <strong>Why this matters more than a missing span.</strong> The absence is indistinguishable
+    /// from success: a service with no handler spans looks exactly like a service in which nothing
+    /// failed. The failure tags this span carries — <c>error.code</c> and <c>error.type</c>, the
+    /// same values the HTTP response body reports — are the ones an operator reaches for when
+    /// asking which rule rejected a request, so the configuration gap is discovered during an
+    /// incident rather than before one.
+    /// </para>
+    /// <para>
+    /// The registered source is <see cref="TracingBehavior{TMessage, TResponse}.ActivitySourceName"/>
+    /// (<c>"Trellis.Mediator"</c>). Consumers may equivalently call <c>AddSource("Trellis.Mediator")</c>;
+    /// this helper exists so the name does not have to be repeated as a string literal, matching
+    /// <c>AddResultsInstrumentation()</c> in Trellis.Core and
+    /// <c>AddPrimitiveValueObjectInstrumentation()</c> in Trellis.Primitives. The method is named for
+    /// the Trellis pipeline specifically because it instruments Trellis behaviors rather than the
+    /// underlying Mediator library.
+    /// </para>
+    /// <para>
+    /// This is the pipeline-behavior altitude that the Trellis.Core tracing guidance recommends for
+    /// high-throughput services, in preference to per-<c>Result</c>-operator spans: one span per
+    /// request carrying the business message name and the failure code.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// services.AddOpenTelemetry()
+    ///     .WithTracing(tracing => tracing
+    ///         .AddAspNetCoreInstrumentation()
+    ///         .AddTrellisMediatorInstrumentation()
+    ///         .AddOtlpExporter());
+    /// </code>
+    /// </example>
+    public static TracerProviderBuilder AddTrellisMediatorInstrumentation(this TracerProviderBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.AddSource(MediatorTrace.ActivitySourceName);
+    }
+}

--- a/Trellis.Mediator/src/TracingBehavior.cs
+++ b/Trellis.Mediator/src/TracingBehavior.cs
@@ -17,7 +17,7 @@ public sealed class TracingBehavior<TMessage, TResponse>
     /// <summary>
     /// The name used for the <see cref="ActivitySource"/> that traces mediator pipeline operations.
     /// </summary>
-    public const string ActivitySourceName = "Trellis.Mediator";
+    public const string ActivitySourceName = MediatorTrace.ActivitySourceName;
     internal static readonly ActivitySource ActivitySource = new(ActivitySourceName);
 
     private readonly TrellisMediatorTelemetryOptions _options;

--- a/Trellis.Mediator/tests/MediatorTraceProviderBuilderExtensionsTests.cs
+++ b/Trellis.Mediator/tests/MediatorTraceProviderBuilderExtensionsTests.cs
@@ -1,0 +1,107 @@
+﻿namespace Trellis.Mediator.Tests;
+
+using System.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using Trellis.Mediator.Tests.Helpers;
+
+/// <summary>
+/// Tests for <see cref="MediatorTraceProviderBuilderExtensions"/>.
+/// </summary>
+/// <remarks>
+/// The behaviour under test is a visibility guarantee, so the assertions are written against a
+/// real <see cref="TracerProvider"/> rather than a bare <see cref="ActivityListener"/>. A listener
+/// proves an activity was created; only a provider proves a consumer's tracing configuration
+/// would actually collect it, which is the thing that was missing.
+/// </remarks>
+[Collection(SerializedMediatorActivitySource.Name)]
+public class MediatorTraceProviderBuilderExtensionsTests
+{
+    [Fact]
+    public async Task AddTrellisMediatorInstrumentation_makes_handler_spans_visible()
+    {
+        var captured = new List<Activity>();
+
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .AddTrellisMediatorInstrumentation()
+            .AddProcessor(new CaptureProcessor(captured))
+            .Build();
+
+        await RunOneRequestAsync();
+
+        captured.Should().ContainSingle()
+            .Which.DisplayName.Should().Be(nameof(TestCommand));
+    }
+
+    /// <remarks>
+    /// The control for the test above. Without it, that test would still pass if the source were
+    /// registered by something else entirely, and the extension would be proven to do nothing.
+    /// This also pins the failure mode the extension exists to remove: the span is not reported
+    /// missing, it is simply never collected.
+    /// </remarks>
+    [Fact]
+    public async Task Without_the_helper_handler_spans_are_silently_absent()
+    {
+        var captured = new List<Activity>();
+
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .AddProcessor(new CaptureProcessor(captured))
+            .Build();
+
+        await RunOneRequestAsync();
+
+        captured.Should().BeEmpty();
+    }
+
+    /// <remarks>
+    /// Pins the helper to the constant the behaviour actually emits from. Were the extension to
+    /// register a hand-typed copy of the name, the two could drift and the helper would go quietly
+    /// inert — the same silent failure it was added to prevent, one level up.
+    /// </remarks>
+    [Fact]
+    public async Task AddTrellisMediatorInstrumentation_registers_the_source_the_behavior_emits_from()
+    {
+        var captured = new List<Activity>();
+
+        using var provider = Sdk.CreateTracerProviderBuilder()
+            .AddTrellisMediatorInstrumentation()
+            .AddProcessor(new CaptureProcessor(captured))
+            .Build();
+
+        await RunOneRequestAsync();
+
+        captured.Should().ContainSingle()
+            .Which.Source.Name.Should().Be(TracingBehavior<TestCommand, Result<string>>.ActivitySourceName);
+    }
+
+    [Fact]
+    public void AddTrellisMediatorInstrumentation_returns_the_same_builder_for_chaining()
+    {
+        var builder = Sdk.CreateTracerProviderBuilder();
+
+        builder.AddTrellisMediatorInstrumentation().Should().BeSameAs(builder);
+    }
+
+    [Fact]
+    public void AddTrellisMediatorInstrumentation_rejects_a_null_builder()
+    {
+        TracerProviderBuilder builder = null!;
+
+        var act = () => builder.AddTrellisMediatorInstrumentation();
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private static async Task RunOneRequestAsync()
+    {
+        var behavior = new TracingBehavior<TestCommand, Result<string>>();
+        var next = NextDelegate.ReturningAsync<TestCommand, Result<string>>(Result.Ok("Hello."));
+
+        await behavior.Handle(new TestCommand("Alice"), next, CancellationToken.None);
+    }
+
+    private sealed class CaptureProcessor(List<Activity> sink) : BaseProcessor<Activity>
+    {
+        public override void OnEnd(Activity data) => sink.Add(data);
+    }
+}

--- a/Trellis.Mediator/tests/SerializedMediatorActivitySource.cs
+++ b/Trellis.Mediator/tests/SerializedMediatorActivitySource.cs
@@ -1,0 +1,18 @@
+﻿namespace Trellis.Mediator.Tests;
+
+/// <summary>
+/// Serializes the test classes that exercise <see cref="TracingBehavior{TMessage, TResponse}"/>.
+/// </summary>
+/// <remarks>
+/// Subscription to an <see cref="System.Diagnostics.ActivitySource"/> is process-wide and by
+/// source name, so a listener or <c>TracerProvider</c> in one test class observes the spans
+/// emitted by every other class running at the same time. Two classes drive the behaviour and
+/// both assert on span counts, so running them in parallel lets one class's spans land in the
+/// other's sink — a failure that surfaces as an unrelated, intermittently red test.
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SerializedMediatorActivitySource
+{
+    /// <summary>The collection name shared by every test class that emits mediator spans.</summary>
+    public const string Name = "Trellis.Mediator ActivitySource";
+}

--- a/Trellis.Mediator/tests/TracingBehaviorTests.cs
+++ b/Trellis.Mediator/tests/TracingBehaviorTests.cs
@@ -7,6 +7,7 @@ using Trellis.Mediator.Tests.Helpers;
 /// <summary>
 /// Tests for <see cref="TracingBehavior{TMessage, TResponse}"/>.
 /// </summary>
+[Collection(SerializedMediatorActivitySource.Name)]
 public class TracingBehaviorTests : IDisposable
 {
     private readonly ActivitySource _activitySource = TracingBehavior<TestCommand, Result<string>>.ActivitySource;

--- a/Trellis.Mediator/tests/Trellis.Mediator.Tests.csproj
+++ b/Trellis.Mediator/tests/Trellis.Mediator.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <Using Include="Trellis.Authorization" />
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mediator.Abstractions" />
+    <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -1,9 +1,9 @@
 ﻿---
 package: Trellis.Mediator
 namespaces: [Trellis.Mediator]
-types: [ICommand<T>, IQuery<T>, "IRequestHandler<,>", "IPipelineBehavior<,>", "AuthorizationBehavior<TMessage,TResponse>", "ExceptionBehavior<TMessage,TResponse>", IValidate, "LoggingBehavior<TMessage,TResponse>", "ResourceAuthorizationViaBehavior<TMessage,TLeaf,TOwner,TResponse>", ResolvedAuthorizationPath, ResolvedAuthorizationHop, HopLoadResult, "ResolvedAuthorizationPathHolder<TMessage,TLeaf,TOwner,TResponse>", ResourceAuthorizationPathResolver, "ResourceAuthorizationBehavior<TMessage,TResource,TResponse>", ServiceCollectionExtensions, "TracingBehavior<TMessage,TResponse>", TrellisMediatorTelemetryOptions, IMessageValidator<TMessage>, IDomainEventHandler<TEvent>, IDomainEventPublisher, IReportingDomainEventPublisher, DomainEventDispatchReport, DomainEventHandlerFailure, IIntegrationEventHandler<TEvent>, IIntegrationEventPublisher, OutboundIntegrationMessage, IntegrationEventNameMap, IIntegrationEventCollector, DomainEventHandlerCascadedException, CascadeOffender, "DomainEventDispatchBehavior<,>", DomainEventDispatchServiceCollectionExtensions, DomainEventPublisherExtensions, IntegrationEventDispatchServiceCollectionExtensions, "TrackedAggregateDomainEventDispatchBehavior<,>", TrackedAggregateDomainEventDispatchServiceCollectionExtensions]
+types: [ICommand<T>, IQuery<T>, "IRequestHandler<,>", "IPipelineBehavior<,>", "AuthorizationBehavior<TMessage,TResponse>", "ExceptionBehavior<TMessage,TResponse>", IValidate, "LoggingBehavior<TMessage,TResponse>", "ResourceAuthorizationViaBehavior<TMessage,TLeaf,TOwner,TResponse>", ResolvedAuthorizationPath, ResolvedAuthorizationHop, HopLoadResult, "ResolvedAuthorizationPathHolder<TMessage,TLeaf,TOwner,TResponse>", ResourceAuthorizationPathResolver, "ResourceAuthorizationBehavior<TMessage,TResource,TResponse>", ServiceCollectionExtensions, "TracingBehavior<TMessage,TResponse>", MediatorTraceProviderBuilderExtensions, TrellisMediatorTelemetryOptions, IMessageValidator<TMessage>, IDomainEventHandler<TEvent>, IDomainEventPublisher, IReportingDomainEventPublisher, DomainEventDispatchReport, DomainEventHandlerFailure, IIntegrationEventHandler<TEvent>, IIntegrationEventPublisher, OutboundIntegrationMessage, IntegrationEventNameMap, IIntegrationEventCollector, DomainEventHandlerCascadedException, CascadeOffender, "DomainEventDispatchBehavior<,>", DomainEventDispatchServiceCollectionExtensions, DomainEventPublisherExtensions, IntegrationEventDispatchServiceCollectionExtensions, "TrackedAggregateDomainEventDispatchBehavior<,>", TrackedAggregateDomainEventDispatchServiceCollectionExtensions]
 version: v3
-last_verified: 2026-08-18
+last_verified: 2026-08-22
 audience: [llm]
 ---
 # Trellis.Mediator — API Reference
@@ -418,15 +418,36 @@ public sealed class TracingBehavior<TMessage, TResponse> : IPipelineBehavior<TMe
 
 **Recording these spans**
 
-`AddTrellisBehaviors()` registers `TracingBehavior`, so on each command/query it *calls* `ActivitySource.StartActivity` — but that only returns a live `Activity` if your `TracerProvider` listens to the `"Trellis.Mediator"` source. If the source is not registered, `StartActivity` returns `null` and the per-command/query span never appears (you still see the HTTP and value-object spans, but not the handler). Add the source to your tracing setup:
+`AddTrellisBehaviors()` registers `TracingBehavior`, so on each command/query it *calls* `ActivitySource.StartActivity` — but that only returns a live `Activity` if your `TracerProvider` listens to the `"Trellis.Mediator"` source. If the source is not registered, `StartActivity` returns `null` and the per-command/query span never appears (you still see the HTTP and value-object spans, but not the handler). Call `AddTrellisMediatorInstrumentation()`:
 
 ```csharp
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddAspNetCoreInstrumentation()
-        .AddSource("Trellis.Mediator") // == TracingBehavior<TMessage, TResponse>.ActivitySourceName
+        .AddTrellisMediatorInstrumentation()
         .AddOtlpExporter());
 ```
+
+`AddSource("Trellis.Mediator")` is equivalent — the helper exists so the name is not repeated as a string literal, and so this package matches `AddResultsInstrumentation()` in Trellis.Core and `AddPrimitiveValueObjectInstrumentation()` in Trellis.Primitives.
+
+> **This gap is silent.** A service that never registers the source looks exactly like a service in which nothing failed: there is no warning, no startup error, and no empty-result signal — the spans are simply never collected. Because this span carries `error.code` and `error.type`, the gap is normally discovered *during* an incident, at the moment those tags were wanted.
+
+### MediatorTraceProviderBuilderExtensions
+**Declaration**
+
+```csharp
+public static class MediatorTraceProviderBuilderExtensions
+```
+
+Registers the mediator pipeline's activity source with an OpenTelemetry `TracerProvider`.
+
+**Methods**
+
+| Signature | Returns | Description |
+| --- | --- | --- |
+| `public static TracerProviderBuilder AddTrellisMediatorInstrumentation(this TracerProviderBuilder builder)` | `TracerProviderBuilder` | Subscribes the tracer provider to `TracingBehavior<TMessage, TResponse>.ActivitySourceName` (`"Trellis.Mediator"`), so the per-command/query span is collected. Returns the same builder for chaining. Throws `ArgumentNullException` when `builder` is null. Equivalent to `AddSource("Trellis.Mediator")`. |
+
+The method is named for the Trellis pipeline rather than for the mediator alone because it instruments Trellis behaviors, not the underlying Mediator library, and the two would otherwise be easy to confuse on a `TracerProviderBuilder` chain.
 
 ### TrellisMediatorTelemetryOptions
 **Declaration**

--- a/docs/docfx_project/articles/integration-mediator.md
+++ b/docs/docfx_project/articles/integration-mediator.md
@@ -772,9 +772,10 @@ The generated `"N"`-format Guid becomes `Error.Code` today, so operators can joi
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
+using Trellis.Mediator;
 
 builder.Services.AddOpenTelemetry().WithTracing(tracing =>
-    tracing.AddSource("Trellis.Mediator"));
+    tracing.AddTrellisMediatorInstrumentation());
 ```
 
 On a failed result, both `LoggingBehavior` and `TracingBehavior` always emit:

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -15,7 +15,7 @@ Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `A
 | Goal | Use | See |
 |---|---|---|
 | Wire mediator tracing + logging via the composition root | `services.AddTrellis(o => o.UseMediator())` | [Default registration](#default-registration) |
-| Subscribe an OTel `TracerProvider` to mediator spans | `tracing.AddSource("Trellis.Mediator")` | [Tracing](#tracing) |
+| Subscribe an OTel `TracerProvider` to mediator spans | `tracing.AddTrellisMediatorInstrumentation()` | [Tracing](#tracing) |
 | Subscribe to value-object spans (validation/parsing) | `tracing.AddPrimitiveValueObjectInstrumentation()` | [Tracing](#tracing) |
 | Subscribe to ROP spans (deep `Bind` / `Map` debugging) | `tracing.AddResultsInstrumentation()` | [Tracing](#tracing) |
 | Read structured per-message logs with elapsed-ms outcomes | Built in via `LoggingBehavior<,>` | [Logging](#logging) |
@@ -34,7 +34,7 @@ Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `A
 
 | Surface | Type / API | Emits | Subscribed via |
 |---|---|---|---|
-| Mediator tracing | `TracingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | One `Activity` per mediator message; tags `error.code`, `error.type`; `ActivityStatusCode.Ok` / `Error` (request cancellations stay `Unset`) | Registered by `AddTrellisBehaviors()`; subscribe with `tracing.AddSource(TracingBehavior<,>.ActivitySourceName)` (value: `"Trellis.Mediator"`) |
+| Mediator tracing | `TracingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | One `Activity` per mediator message; tags `error.code`, `error.type`; `ActivityStatusCode.Ok` / `Error` (request cancellations stay `Unset`) | Registered by `AddTrellisBehaviors()`; subscribe with `tracing.AddTrellisMediatorInstrumentation()` (source name: `"Trellis.Mediator"`) |
 | Mediator logging | `LoggingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | `Debug` start, `Debug` end (with elapsed ms), `Warning` on failure (with `Error.Code`) | Registered by `AddTrellisBehaviors()`; consumed by any `ILogger` provider. Per-call timing is at Debug so production at the default `Information` minimum is quiet; raise via `"Trellis.Mediator": "Debug"` in logging configuration to opt back in. |
 | Redaction | `TrellisMediatorTelemetryOptions` (`Trellis.Mediator`) | Controls whether `Error.Detail` flows into the activity status description and log message | DI singleton, configured via `o.UseMediator(t => ...)` or `AddTrellisBehaviors(t => ...)` |
 | Primitive value-object tracing | `Trellis.Primitives` `ActivitySource` | Exactly one `Activity` per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call delegates to and is traced under `.TryCreate`), named after the factory (e.g. `EmailAddress.TryCreate`), with `Ok` / `Error` status on both success and failure | `tracing.AddPrimitiveValueObjectInstrumentation()` |
@@ -77,7 +77,7 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation()
-        .AddSource(TracingBehavior<IMessage, IResult>.ActivitySourceName)
+        .AddTrellisMediatorInstrumentation()
         .AddPrimitiveValueObjectInstrumentation()
         .AddOtlpExporter());
 
@@ -137,7 +137,7 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation()
-        .AddSource(TracingBehavior<IMessage, IResult>.ActivitySourceName)
+        .AddTrellisMediatorInstrumentation()
         .AddPrimitiveValueObjectInstrumentation()
         .AddOtlpExporter());
 ```
@@ -151,7 +151,7 @@ created by the `"Trellis.Core"` source receive per-step `Ok` / `Error` status an
 ```csharp
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
-        .AddSource(TracingBehavior<IMessage, IResult>.ActivitySourceName)
+        .AddTrellisMediatorInstrumentation()
         .AddPrimitiveValueObjectInstrumentation()
         .AddResultsInstrumentation()
         .AddConsoleExporter());


### PR DESCRIPTION
## The defect

`TracingBehavior` opens an `Activity` per command/query from the `"Trellis.Mediator"` `ActivitySource`, and `AddTrellisBehaviors()` registers it — so `StartActivity` is **always called**. But it only returns a live `Activity` if a `TracerProvider` subscribes to that source.

`Trellis.Core` ships `AddResultsInstrumentation()`. `Trellis.Primitives` ships `AddPrimitiveValueObjectInstrumentation()`. `Trellis.Mediator` shipped **no equivalent**, so consumers had to hand-type `AddSource("Trellis.Mediator")` — and nothing tells them to.

**The failure is silent.** `StartActivity` returns `null`, the handler span is never created, and the trace still looks plausible because the HTTP and value-object spans are there. Absence of a span is indistinguishable from "nothing happened."

This was a *known* hazard, already written down at `trellis-api-mediator.md:421` ("*If the source is not registered, `StartActivity` returns `null`…*") — documented, never closed. Worse, `ResultsTraceProviderBuilderExtensions` steers high-throughput consumers **toward** the pipeline-behavior altitude, i.e. the one altitude with no helper.

## Measured, not assumed

A probe drives the **real** `TracingBehavior<ProbeCommand, Result<string>>.Handle` and runs an identical workload three times, changing only listener setup:

| Mode | Exported spans |
|---|---|
| **A** — both shipped helpers, no mediator source | `Trellis.Core / Map` — **and nothing else** |
| **B** — A + `AddSource("Trellis.Mediator")` | Core span + `Trellis.Mediator / ProbeCommand` ×2 |
| **C** — A + `AddTrellisMediatorInstrumentation()` | identical to B |

Run A in full:

```text
Activity.ActivitySourceName: Trellis.Core
Activity.DisplayName:        Map
StatusCode: Ok
```

The Core span is the **control**: the provider and exporter were alive and exporting, so the absence in A is specifically the mediator source, not a broken harness. C being byte-identical to B is the point — the helper *is* `AddSource`, with the name read from the constant the behavior emits from.

**Corollary:** the `error.code` / `error.type` span tagging shipped in #731 is invisible by default. It appears only in B and C:

```text
Activity.ActivitySourceName: Trellis.Mediator
Activity.DisplayName:        ProbeCommand
Activity.Tags:
    error.type: Error.NotFound
    error.code: error.unspecified
StatusCode: Error
```

## The change

- **`MediatorTraceProviderBuilderExtensions`** — public `AddTrellisMediatorInstrumentation(this TracerProviderBuilder)`. Null-guards, returns the builder for chaining.
- **`MediatorTrace`** — `internal` holder for the source name. `TracingBehavior<,>.ActivitySourceName` is a const on a *generic* type, so referencing it from the helper would otherwise require arbitrary type arguments (my first draft invented a dummy type purely to name it). This gives one source of truth and mirrors `RopTrace` / `PrimitiveValueObjectTrace`.
- `TracingBehavior.ActivitySourceName` now reads from that holder. **The public value is unchanged** (`"Trellis.Mediator"`); `dotnet pack` is ApiCompat-clean.

### Two decisions worth flagging

**Named `AddTrellisMediatorInstrumentation`, not `AddMediatorInstrumentation`.** The siblings are `AddResultsInstrumentation` / `AddPrimitiveValueObjectInstrumentation`, so the prefix is inconsistent — deliberately. On a `TracerProviderBuilder` chain the unprefixed name would be confusable with the third-party `Mediator` library sitting right next to it.

**No `TrellisServiceBuilder.UseXxx` slot is owed.** Verified rather than assumed: `RegistrationSurfaceTests.cs:237` filters on `first == typeof(IServiceCollection)`, and this extends `TracerProviderBuilder`.

## Tests

Five tests, asserted against a **real `TracerProvider` + `BaseProcessor<Activity>`**, not a bare `ActivityListener` — a listener only proves the Activity was *created*, whereas the guarantee at issue is that a consumer's tracing config would *collect* it. Includes the control (spans silently absent without the helper) and a drift guard tying the helper to the constant the behavior emits from.

### A flakiness bug this PR introduced, and fixes

`ActivitySource` subscription is process-wide and by **name**, so a listener in one test class sees spans from every class running concurrently. `TracingBehaviorTests` installs such a listener; the new class emits `TestCommand` spans from the same source, and under xUnit's parallel classes they landed in the sibling's sink and broke its `ContainSingle` assertions.

This was caught in pre-commit review and confirmed empirically — **3/3 runs failed, a different pre-existing test each time**, while a `git stash` baseline was 3/3 clean. Fixed with a `DisableParallelization` collection shared by exactly the two classes that drive the behavior. Now **5/5 consecutive clean runs**.

Worth noting the full-solution run had gone green by luck before this was found; the single-project loop is what exposed it.

## Docs

Reference section for the new type, plus the observability article (5 sites), the mediator article, both package READMEs, and the CHANGELOG. The reference and the article now lead with the helper instead of the raw string, and carry an explicit *"this gap is silent"* callout.

## Validation

- `dotnet test Trellis.slnx -c Debug` → **0 failed / 8060 succeeded**
- `Trellis.Mediator/tests` **5× consecutive** → 0 failed / 381
- 4 doc audits (TRLDOC005/008/014/015) → EXIT=0
- markdown lint → 28 files
- `dotnet pack Trellis.Mediator/src -c Release` → no ApiCompat warnings