### PR TITLE
refactor(observability)!: unify instrumentation helper naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — instrumentation helpers are named for the telemetry they register
+
+The OpenTelemetry registration helpers were spelled four different ways: `AddResultsInstrumentation`, `AddPrimitiveValueObjectInstrumentation`, `AddTrellisMediatorInstrumentation`, and `AddTrellisValidationInstrumentation`. They now all follow `AddTrellis{Segment}Instrumentation`, where `{Segment}` is exactly the text after `Trellis.` in the source or meter the helper registers:
+
+| Before | After | Registers |
+| --- | --- | --- |
+| `AddResultsInstrumentation()` | `AddTrellisResultsInstrumentation()` | `"Trellis.Results"` |
+| `AddPrimitiveValueObjectInstrumentation()` | `AddTrellisPrimitivesInstrumentation()` | `"Trellis.Primitives"` |
+
+The value is a two-way mapping: someone looking at a span tagged `Trellis.Mediator` can derive the call, and someone reading the call can derive what will appear in their backend. `AddPrimitiveValueObjectInstrumentation` broke that by naming a concept — `PrimitiveValueObject` — that appears nowhere in the emitted telemetry.
+
+The ROP `ActivitySource` is renamed `"Trellis.Core"` → `"Trellis.Results"` to complete the mapping. The previous name was collateral from the v1 package rename (ADR-002 §2 renamed the *package* `Trellis.Results` → `Trellis.Core`, and the source silently followed) rather than a decision about the source itself. It had become actively misleading: the `Trellis.Core` package emits three telemetry names, and naming one of them after the package read as though it covered all three — while the rule would otherwise have forced `AddTrellisCoreInstrumentation()` on the deliberately high-volume, break-glass ROP source that the docs tell you to reserve for debugging. The three are now `"Trellis.Results"`, `"Trellis.Primitives"` and `"Trellis.Validation"`, each named for its role rather than for the package that ships it. As a side effect the source returns to its v1 name, so a v1 `AddSource("Trellis.Results")` subscription is correct again.
+
+`RopTrace.ActivitySourceName` continues to expose the name programmatically. Update any dashboard or `AddSource` call pinned to the literal `"Trellis.Core"`.
+
+The rule is enforced by `InstrumentationNamingTests`, which invokes every helper against a recording builder and derives the expected method name from the source actually registered — so the telemetry name is the single source of truth rather than an approved-names table that a maintainer has to remember to update. A companion test cross-checks reflection against a repository source scan, so a helper in a package the test does not reference fails the build asking for a `ProjectReference` instead of silently escaping enforcement.
+
 ### Added — `AddTrellisValidationInstrumentation()` and the `trellis.validation.failures` counter
 
 Trellis now publishes one `Meter`, `Trellis.Validation`, with a counter incremented once per violation as a `FieldViolation` or `RuleViolation` is created, tagged `validation.code` and `validation.violation`.
@@ -25,7 +42,7 @@ As with the mediator source, the counter is inert until the helper is called and
 
 ### Added — `AddTrellisMediatorInstrumentation()`, so mediator spans are actually collected
 
-`AddTrellisBehaviors()` registers `TracingBehavior`, so every command and query already calls `StartActivity` — but that returns a live activity only if a `TracerProvider` listens to the `"Trellis.Mediator"` source. Trellis.Core ships `AddResultsInstrumentation()` and Trellis.Primitives ships `AddPrimitiveValueObjectInstrumentation()`; Trellis.Mediator shipped no equivalent, so the handler span was collected only by consumers who knew to type `AddSource("Trellis.Mediator")` as a raw string.
+`AddTrellisBehaviors()` registers `TracingBehavior`, so every command and query already calls `StartActivity` — but that returns a live activity only if a `TracerProvider` listens to the `"Trellis.Mediator"` source. Trellis.Core ships `AddTrellisResultsInstrumentation()` and Trellis.Primitives ships `AddTrellisPrimitivesInstrumentation()`; Trellis.Mediator shipped no equivalent, so the handler span was collected only by consumers who knew to type `AddSource("Trellis.Mediator")` as a raw string.
 
 The gap is silent, which is what makes it worth closing rather than documenting. A service that never registers the source looks exactly like a service in which nothing failed: no warning, no startup error, no empty-result signal. And this is the span carrying `error.code` and `error.type` — the same values the HTTP body reports — so the missing configuration is normally discovered *during* an incident, at the moment those tags were wanted. It is also the altitude the Trellis.Core tracing guidance recommends in preference to per-`Result`-operator spans, so the package was steering people to a span it did not help them collect.
 

--- a/Examples/TestingPatterns/TraceFixture.cs
+++ b/Examples/TestingPatterns/TraceFixture.cs
@@ -21,7 +21,7 @@ public class TraceFixture : IDisposable
     {
         var builder = Sdk.CreateTracerProviderBuilder()
             .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("FunctionDddExample"))
-            .AddResultsInstrumentation()
+            .AddTrellisResultsInstrumentation()
             .AddSource(ActivitySourceName)
             .AddOtlpExporter();
 

--- a/Trellis.Benchmark/TracingOverheadBenchmarks.cs
+++ b/Trellis.Benchmark/TracingOverheadBenchmarks.cs
@@ -76,7 +76,7 @@ public class TracingOverheadBenchmarks
         {
             _trellisListener = new ActivityListener
             {
-                ShouldListenTo = src => src.Name == "Trellis.Core",
+                ShouldListenTo = src => src.Name == "Trellis.Results",
                 Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
                 ActivityStarted = _ => { },
                 ActivityStopped = _ => { },

--- a/Trellis.Core/DEBUGGING.md
+++ b/Trellis.Core/DEBUGGING.md
@@ -234,7 +234,7 @@ Enable Results tracing when you need to see the full pipeline as a distributed t
 ```csharp
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
-        .AddSource("Trellis.Core")
+        .AddSource("Trellis.Results")
         .AddOtlpExporter());
 ```
 

--- a/Trellis.Core/src/CompatibilitySuppressions.xml
+++ b/Trellis.Core/src/CompatibilitySuppressions.xml
@@ -107,6 +107,13 @@
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.ResultsTraceProviderBuilderExtensions.AddResultsInstrumentation(OpenTelemetry.Trace.TracerProviderBuilder)</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0012</DiagnosticId>
     <Target>M:Trellis.Error.get_Code</Target>
     <Left>lib/net10.0/Trellis.Core.dll</Left>

--- a/Trellis.Core/src/ResultsTraceProviderBuilderExtensions.cs
+++ b/Trellis.Core/src/ResultsTraceProviderBuilderExtensions.cs
@@ -25,9 +25,9 @@ public static class ResultsTraceProviderBuilderExtensions
     /// </para>
     /// <para>
     /// <strong>Performance characteristics.</strong> Trellis is designed so the per-operation tracing
-    /// is essentially free when no listener is registered. <c>AddResultsInstrumentation</c> is the
-    /// Trellis-provided helper for registering the <c>"Trellis.Core"</c> source with OpenTelemetry;
-    /// consumers may also call <c>AddSource("Trellis.Core")</c> directly or attach an
+    /// is essentially free when no listener is registered. <c>AddTrellisResultsInstrumentation</c> is the
+    /// Trellis-provided helper for registering the <c>"Trellis.Results"</c> source with OpenTelemetry;
+    /// consumers may also call <c>AddSource("Trellis.Results")</c> directly or attach an
     /// <c>ActivityListener</c>.
     /// Measured on .NET 10 / x64 with an ambient ASP.NET request activity present:
     /// </para>
@@ -40,7 +40,7 @@ public static class ResultsTraceProviderBuilderExtensions
     /// that activity was started by the Trellis ROP <c>ActivitySource</c>.
     ///   </description></item>
     ///   <item><description>
-    /// <b>With listener registered</b> via <c>AddResultsInstrumentation</c> and
+    /// <b>With listener registered</b> via <c>AddTrellisResultsInstrumentation</c> and
     /// <c>AllDataAndRecorded</c> sampling: each <c>Bind</c>/<c>Map</c>/<c>Tap</c> call costs
     /// ~200 ns and allocates ~400 B (the Activity object + name + tags). A 10-step chain
     /// costs ~2.3 μs and ~4 KB. At 10 000 RPS with a 10-step pipeline this adds up to
@@ -53,7 +53,7 @@ public static class ResultsTraceProviderBuilderExtensions
     /// They appear as a deeply nested tree under the outer span with no business context — most
     /// observability backends collapse or charge per span. For high-throughput services prefer
     /// instrumenting at the pipeline-behavior or HTTP-boundary altitude and reserve
-    /// <c>AddResultsInstrumentation</c> for development/debugging or low-rate request paths where
+    /// <c>AddTrellisResultsInstrumentation</c> for development/debugging or low-rate request paths where
     /// step-by-step ROP visibility is the diagnostic goal.
     /// </para>
     /// <para>
@@ -65,12 +65,12 @@ public static class ResultsTraceProviderBuilderExtensions
     /// <code>
     /// services.AddOpenTelemetry()
     ///     .WithTracing(builder => builder
-    ///         .AddResultsInstrumentation()
+    ///         .AddTrellisResultsInstrumentation()
     ///         .AddAspNetCoreInstrumentation()
     ///         .AddConsoleExporter());
     /// </code>
     /// </example>
-    public static TracerProviderBuilder AddResultsInstrumentation(this TracerProviderBuilder builder)
+    public static TracerProviderBuilder AddTrellisResultsInstrumentation(this TracerProviderBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
         return builder.AddSource(RopTrace.ActivitySourceName);

--- a/Trellis.Core/src/RopTrace.cs
+++ b/Trellis.Core/src/RopTrace.cs
@@ -26,7 +26,7 @@ using System.Reflection;
 /// </para>
 /// <para>
 /// To enable tracing in your application, register the activity source with your
-/// OpenTelemetry configuration using <see cref="ResultsTraceProviderBuilderExtensions.AddResultsInstrumentation"/>.
+/// OpenTelemetry configuration using <see cref="ResultsTraceProviderBuilderExtensions.AddTrellisResultsInstrumentation"/>.
 /// </para>
 /// </remarks>
 /// <example>
@@ -37,7 +37,7 @@ using System.Reflection;
 /// builder.Services.AddOpenTelemetry()
 ///     .WithTracing(tracerProviderBuilder =>
 ///         tracerProviderBuilder
-///             .AddResultsInstrumentation()  // Adds ROP activity source
+///             .AddTrellisResultsInstrumentation()  // Adds ROP activity source
 ///             .AddAspNetCoreInstrumentation()
 ///             .AddHttpClientInstrumentation()
 ///             .AddConsoleExporter());
@@ -63,14 +63,21 @@ internal static class RopTrace
 
     /// <summary>
     /// Gets the name of the activity source used for ROP tracing.
-    /// Value: "Trellis.Core"
+    /// Value: "Trellis.Results"
     /// </summary>
     /// <remarks>
     /// This name is used to identify traces from this library in observability platforms.
     /// Register this name when configuring OpenTelemetry tracing using
-    /// <see cref="ResultsTraceProviderBuilderExtensions.AddResultsInstrumentation"/>.
+    /// <see cref="ResultsTraceProviderBuilderExtensions.AddTrellisResultsInstrumentation"/>.
+    /// <para>
+    /// The source is named for what it traces — <c>Result</c> operations — rather than for the
+    /// package that ships it. <c>Trellis.Core</c> also emits the <c>Trellis.Primitives</c> source
+    /// and the <c>Trellis.Validation</c> meter, so a source named after the package would suggest
+    /// it carried all three and would invite subscribing to this deliberately high-volume,
+    /// break-glass source by accident.
+    /// </para>
     /// </remarks>
-    internal static readonly string ActivitySourceName = "Trellis.Core";
+    internal static readonly string ActivitySourceName = "Trellis.Results";
 
     /// <summary>
     /// Gets the version of the ROP library.
@@ -97,7 +104,7 @@ internal static class RopTrace
     /// To enable tracing, add this source to your OpenTelemetry configuration:
     /// <code>
     /// builder.Services.AddOpenTelemetry()
-    ///     .WithTracing(b => b.AddResultsInstrumentation());
+    ///     .WithTracing(b => b.AddTrellisResultsInstrumentation());
     /// </code>
     /// </para>
     /// <para>

--- a/Trellis.Core/tests/ResultsTraceProviderBuilderExtensionsTests.cs
+++ b/Trellis.Core/tests/ResultsTraceProviderBuilderExtensionsTests.cs
@@ -6,7 +6,7 @@ using Trellis.Testing;
 public class ResultsTraceProviderBuilderExtensionsTests
 {
     [Fact]
-    public void AddResultsInstrumentation_NullBuilder_ThrowsArgumentNullException_WithBuilderParamName()
+    public void AddTrellisResultsInstrumentation_NullBuilder_ThrowsArgumentNullException_WithBuilderParamName()
     {
         // N-C-6 (GPT-5.5 meta-review): public extension methods should throw
         // ArgumentNullException with the user's paramName at entry rather than relying on the
@@ -14,7 +14,7 @@ public class ResultsTraceProviderBuilderExtensionsTests
         // late.
         TracerProviderBuilder builder = null!;
 
-        var act = () => builder.AddResultsInstrumentation();
+        var act = () => builder.AddTrellisResultsInstrumentation();
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("builder");

--- a/Trellis.Mediator/src/MediatorTraceProviderBuilderExtensions.cs
+++ b/Trellis.Mediator/src/MediatorTraceProviderBuilderExtensions.cs
@@ -33,8 +33,8 @@ public static class MediatorTraceProviderBuilderExtensions
     /// The registered source is <see cref="TracingBehavior{TMessage, TResponse}.ActivitySourceName"/>
     /// (<c>"Trellis.Mediator"</c>). Consumers may equivalently call <c>AddSource("Trellis.Mediator")</c>;
     /// this helper exists so the name does not have to be repeated as a string literal, matching
-    /// <c>AddResultsInstrumentation()</c> in Trellis.Core and
-    /// <c>AddPrimitiveValueObjectInstrumentation()</c> in Trellis.Primitives. The method is named for
+    /// <c>AddTrellisResultsInstrumentation()</c> in Trellis.Core and
+    /// <c>AddTrellisPrimitivesInstrumentation()</c> in Trellis.Primitives. The method is named for
     /// the Trellis pipeline specifically because it instruments Trellis behaviors rather than the
     /// underlying Mediator library.
     /// </para>

--- a/Trellis.Primitives/src/CompatibilitySuppressions.xml
+++ b/Trellis.Primitives/src/CompatibilitySuppressions.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.PrimitiveValueObjectTraceProviderBuilderExtensions.AddPrimitiveValueObjectInstrumentation(OpenTelemetry.Trace.TracerProviderBuilder)</Target>
+    <Left>lib/net10.0/Trellis.Primitives.dll</Left>
+    <Right>lib/net10.0/Trellis.Primitives.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/Trellis.Primitives/src/PrimitiveValueObjectTraceProviderBuilderExtensions.cs
+++ b/Trellis.Primitives/src/PrimitiveValueObjectTraceProviderBuilderExtensions.cs
@@ -54,7 +54,7 @@ public static class PrimitiveValueObjectTraceProviderBuilderExtensions
     /// builder.Services.AddOpenTelemetry()
     ///     .WithTracing(tracerProviderBuilder =>
     ///         tracerProviderBuilder
-    ///             .AddPrimitiveValueObjectInstrumentation()  // Enable Trellis primitive tracing
+    ///             .AddTrellisPrimitivesInstrumentation()  // Enable Trellis primitive tracing
     ///             .AddAspNetCoreInstrumentation()         // Add ASP.NET Core tracing
     ///             .AddHttpClientInstrumentation()         // Add HTTP client tracing
     ///             .AddConsoleExporter());                 // Export to console
@@ -69,7 +69,7 @@ public static class PrimitiveValueObjectTraceProviderBuilderExtensions
     /// builder.Services.AddOpenTelemetry()
     ///     .WithTracing(tracerProviderBuilder =>
     ///         tracerProviderBuilder
-    ///             .AddPrimitiveValueObjectInstrumentation()
+    ///             .AddTrellisPrimitivesInstrumentation()
     ///             .AddAspNetCoreInstrumentation()
     ///             .AddAzureMonitorTraceExporter(options =>
     ///             {
@@ -121,7 +121,7 @@ public static class PrimitiveValueObjectTraceProviderBuilderExtensions
     /// </example>
     /// <seealso cref="PrimitiveValueObjectTrace"/>
     /// <seealso cref="TracerProviderBuilder"/>
-    public static TracerProviderBuilder AddPrimitiveValueObjectInstrumentation(this TracerProviderBuilder builder)
+    public static TracerProviderBuilder AddTrellisPrimitivesInstrumentation(this TracerProviderBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
         return builder.AddSource(PrimitiveValueObjectTrace.ActivitySourceName);

--- a/Trellis.Primitives/tests/PvoTracingExtensionsTests.cs
+++ b/Trellis.Primitives/tests/PvoTracingExtensionsTests.cs
@@ -15,13 +15,13 @@ public class PvoTracingExtensionsTests : IDisposable
     private readonly PvoActivityTestHelper _activityHelper = new();
 
     [Fact]
-    public void AddPrimitiveValueObjectInstrumentation_RegistersActivitySource()
+    public void AddTrellisPrimitivesInstrumentation_RegistersActivitySource()
     {
         // Arrange
         var builder = Sdk.CreateTracerProviderBuilder();
 
         // Act
-        var result = builder.AddPrimitiveValueObjectInstrumentation();
+        var result = builder.AddTrellisPrimitivesInstrumentation();
 
         // Assert - Method should return builder for chaining
         result.Should().BeSameAs(builder);
@@ -29,11 +29,11 @@ public class PvoTracingExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void AddPrimitiveValueObjectInstrumentation_EnablesActivityCapture()
+    public void AddTrellisPrimitivesInstrumentation_EnablesActivityCapture()
     {
         // Arrange
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddPrimitiveValueObjectInstrumentation()
+            .AddTrellisPrimitivesInstrumentation()
             .Build();
 
         // Act
@@ -51,11 +51,11 @@ public class PvoTracingExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void AddPrimitiveValueObjectInstrumentation_SupportsMethodChaining()
+    public void AddTrellisPrimitivesInstrumentation_SupportsMethodChaining()
     {
         // Arrange & Act
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-            .AddPrimitiveValueObjectInstrumentation()
+            .AddTrellisPrimitivesInstrumentation()
             .AddSource("TestSource")  // Chain another call
             .Build();
 
@@ -64,7 +64,7 @@ public class PvoTracingExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void AddPrimitiveValueObjectInstrumentation_RegistersCorrectActivitySourceName()
+    public void AddTrellisPrimitivesInstrumentation_RegistersCorrectActivitySourceName()
     {
         // Arrange
         var expectedSourceName = "Trellis.Primitives";
@@ -180,9 +180,9 @@ public class PvoTracingExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void AddPrimitiveValueObjectInstrumentation_NullBuilder_ThrowsArgumentNullException() =>
+    public void AddTrellisPrimitivesInstrumentation_NullBuilder_ThrowsArgumentNullException() =>
         FluentActions.Invoking(() => PrimitiveValueObjectTraceProviderBuilderExtensions
-            .AddPrimitiveValueObjectInstrumentation(builder: null!))
+            .AddTrellisPrimitivesInstrumentation(builder: null!))
             .Should().Throw<ArgumentNullException>()
             .Where(ex => ex.ParamName == "builder");
 

--- a/Trellis.ServiceDefaults/tests/InstrumentationNamingTests.cs
+++ b/Trellis.ServiceDefaults/tests/InstrumentationNamingTests.cs
@@ -1,0 +1,205 @@
+﻿namespace Trellis.ServiceDefaults.Tests;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+/// <summary>
+/// Encodes the naming rule for OpenTelemetry registration helpers: a helper must be called
+/// <c>AddTrellis{Segment}Instrumentation</c>, where <c>{Segment}</c> is exactly the text following
+/// <c>"Trellis."</c> in the <see cref="System.Diagnostics.ActivitySource"/> or
+/// <see cref="System.Diagnostics.Metrics.Meter"/> name it registers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule makes the method name derivable from the telemetry name, in both directions: a reader
+/// who sees a span tagged <c>Trellis.Mediator</c> knows to call
+/// <c>AddTrellisMediatorInstrumentation()</c>, and a reader who sees the call knows which source
+/// appears in their backend. That mapping is the whole value, and it is what drifted — the four
+/// helpers were previously spelled four different ways, one of which named a concept
+/// (<c>PrimitiveValueObject</c>) that appeared nowhere in the emitted telemetry.
+/// </para>
+/// <para>
+/// Deriving the expectation from the registered source, rather than comparing against a table of
+/// approved names, is deliberate. A table would be satisfied by a new helper that a maintainer
+/// remembered to add to it, which is exactly the memory that failed the first time. Here the
+/// telemetry name is the single source of truth and the method name must follow it.
+/// </para>
+/// <para>
+/// Discovery is a source scan of the whole repository rather than reflection alone, because
+/// reflection sees only this assembly's reference closure — a new instrumentation helper in a
+/// package this test does not reference would otherwise be silently exempt. The two views are
+/// cross-checked below, so an unreferenced package fails the build with an actionable message
+/// instead of quietly dropping out of enforcement.
+/// </para>
+/// </remarks>
+public class InstrumentationNamingTests
+{
+    private static readonly Regex DeclarationPattern = new(
+        @"public\s+static\s+(?<builder>TracerProviderBuilder|MeterProviderBuilder)\s+(?<name>\w+)\s*\(\s*this\s+",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void Every_instrumentation_helper_is_named_for_the_source_it_registers()
+    {
+        var violations = DiscoverHelpers()
+            .Select(helper => new { helper, Expected = ExpectedName(helper) })
+            .Where(x => !string.Equals(x.helper.Method.Name, x.Expected, StringComparison.Ordinal))
+            .Select(x => $"{x.helper.Method.Name} registers \"{x.helper.RegisteredName}\" so it must be called {x.Expected}")
+            .ToList();
+
+        violations.Should().BeEmpty(
+            "an instrumentation helper must be named AddTrellis<Segment>Instrumentation for the "
+            + "source or meter it registers, so the call and the telemetry name identify each other");
+    }
+
+    /// <summary>
+    /// Asserts that every instrumentation helper declared anywhere in the repository is visible to
+    /// this test, so the naming rule is enforced against all of them rather than a subset.
+    /// </summary>
+    /// <remarks>
+    /// Guards the discovery mechanism itself. Reflection covers only this assembly's reference
+    /// closure, so without this a new instrumentation helper in an unreferenced package would pass
+    /// by never being examined — a green test that enforces nothing.
+    /// </remarks>
+    [Fact]
+    public void Every_instrumentation_helper_in_the_repository_is_reachable_for_verification()
+    {
+        var reflected = DiscoverHelpers().Select(h => h.Method.Name).ToHashSet(StringComparer.Ordinal);
+
+        var unreachable = ScanRepositoryForHelperNames().Except(reflected, StringComparer.Ordinal).ToList();
+
+        unreachable.Should().BeEmpty(
+            "every instrumentation helper must be verifiable by this test. Add a ProjectReference "
+            + "from Trellis.ServiceDefaults.Tests to the package declaring {0}, so the naming rule "
+            + "is enforced rather than skipped");
+    }
+
+    private static string ExpectedName(DiscoveredHelper helper)
+    {
+        const string prefix = "Trellis.";
+
+        var segment = helper.RegisteredName.StartsWith(prefix, StringComparison.Ordinal)
+            ? helper.RegisteredName[prefix.Length..]
+            : helper.RegisteredName;
+
+        return $"AddTrellis{segment.Replace(".", string.Empty, StringComparison.Ordinal)}Instrumentation";
+    }
+
+    /// <summary>
+    /// Invokes each candidate helper against a recording builder, so the source it registers is
+    /// observed rather than inferred from its name — the name is the thing under test.
+    /// </summary>
+    private static IEnumerable<DiscoveredHelper> DiscoverHelpers()
+    {
+        foreach (var method in ReferencedTrellisAssemblies().SelectMany(CandidateMethods))
+        {
+            var parameter = method.GetParameters()[0].ParameterType;
+
+            if (parameter == typeof(TracerProviderBuilder))
+            {
+                var recorder = new RecordingTracerProviderBuilder();
+                method.Invoke(null, [recorder]);
+                foreach (var name in recorder.Sources)
+                    yield return new DiscoveredHelper(method, name);
+            }
+            else if (parameter == typeof(MeterProviderBuilder))
+            {
+                var recorder = new RecordingMeterProviderBuilder();
+                method.Invoke(null, [recorder]);
+                foreach (var name in recorder.Meters)
+                    yield return new DiscoveredHelper(method, name);
+            }
+        }
+    }
+
+    private static IEnumerable<MethodInfo> CandidateMethods(Assembly assembly) =>
+        assembly.GetExportedTypes()
+            .Where(t => t is { IsAbstract: true, IsSealed: true })
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .Where(m => m.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), inherit: false))
+            .Where(m => m.ReturnType == typeof(TracerProviderBuilder) || m.ReturnType == typeof(MeterProviderBuilder))
+            .Where(m => m.GetParameters().Length == 1);
+
+    /// <summary>
+    /// Every Trellis assembly present in the test's output directory.
+    /// </summary>
+    /// <remarks>
+    /// Loaded from the test's output directory rather than from
+    /// <see cref="Assembly.GetReferencedAssemblies"/>: the compiler omits assembly references the
+    /// test code does not actually use, so a package referenced solely to bring it under this rule
+    /// would vanish from metadata and silently drop out of enforcement. A <c>ProjectReference</c>
+    /// always copies the assembly to the output directory, which makes "add a ProjectReference" the
+    /// complete fix the failure message promises.
+    /// </remarks>
+    private static Assembly[] ReferencedTrellisAssemblies() =>
+        Directory.EnumerateFiles(AppContext.BaseDirectory, "Trellis.*.dll")
+            .Select(Assembly.LoadFrom)
+            .Distinct()
+            .ToArray();
+
+    private static HashSet<string> ScanRepositoryForHelperNames()
+    {
+        var separator = Path.DirectorySeparatorChar;
+        var names = new HashSet<string>(StringComparer.Ordinal);
+
+        var sourceFiles = Directory
+            .EnumerateFiles(RepositoryRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(path => path.Contains($"{separator}src{separator}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{separator}obj{separator}", StringComparison.Ordinal)
+                && !path.Contains($"{separator}bin{separator}", StringComparison.Ordinal));
+
+        foreach (var path in sourceFiles)
+            foreach (Match match in DeclarationPattern.Matches(File.ReadAllText(path)))
+                names.Add(match.Groups["name"].Value);
+
+        return names;
+    }
+
+    private static string RepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Trellis.slnx")))
+            directory = directory.Parent;
+
+        directory.Should().NotBeNull("the test must be able to locate the repository root (Trellis.slnx)");
+        return directory!.FullName;
+    }
+
+    private sealed record DiscoveredHelper(MethodInfo Method, string RegisteredName);
+
+    private sealed class RecordingTracerProviderBuilder : TracerProviderBuilder
+    {
+        public List<string> Sources { get; } = [];
+
+        public override TracerProviderBuilder AddInstrumentation<TInstrumentation>(
+            Func<TInstrumentation> instrumentationFactory) => this;
+
+        public override TracerProviderBuilder AddLegacySource(string operationName) => this;
+
+        public override TracerProviderBuilder AddSource(params string[] names)
+        {
+            Sources.AddRange(names);
+            return this;
+        }
+    }
+
+    private sealed class RecordingMeterProviderBuilder : MeterProviderBuilder
+    {
+        public List<string> Meters { get; } = [];
+
+        public override MeterProviderBuilder AddInstrumentation<TInstrumentation>(
+            Func<TInstrumentation> instrumentationFactory) => this;
+
+        public override MeterProviderBuilder AddMeter(params string[] names)
+        {
+            Meters.AddRange(names);
+            return this;
+        }
+    }
+}

--- a/Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj
+++ b/Trellis.ServiceDefaults/tests/Trellis.ServiceDefaults.Tests.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <ProjectReference Include="..\src\Trellis.ServiceDefaults.csproj" />
+    <!-- Not part of the composition root; referenced so InstrumentationNamingTests can verify
+         the instrumentation helper Trellis.Primitives ships. -->
+    <ProjectReference Include="..\..\Trellis.Primitives\src\Trellis.Primitives.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />

--- a/docs/docfx_project/api_reference/audit-stale-docs.ps1
+++ b/docs/docfx_project/api_reference/audit-stale-docs.ps1
@@ -51,7 +51,7 @@ try {
         @{ Pattern = '^\s*///,'; Message = 'Fix XML doc punctuation after line wrapping.' },
         @{ Pattern = '\bvoid/No-payload\b'; Message = 'Use no-payload wording without mixed casing/slashes.' },
         @{ Pattern = 'Error\.Equals\(\.\.\.\) compares \*\*only the error code\*\*'; Message = 'Error equality is value-based; compare Code for category-only checks.' },
-        @{ Pattern = '\bTrellis\.Results\b'; Message = 'Trellis.Results is not a current package; use Trellis.Core unless this is historical migration content.' },
+        @{ Pattern = '(?<!")\bTrellis\.Results\b(?!")'; Message = 'Trellis.Results is not a current package; use Trellis.Core unless this is historical migration content. (The ActivitySource of the same name is current — write it double-quoted, as "Trellis.Results", so it is distinguishable from the dead package id.)' },
         @{ Pattern = '\bTrellis\.DomainDrivenDesign\b'; Message = 'Trellis.DomainDrivenDesign is not a current package; use Trellis.Core unless this is historical migration content.' },
         @{ Pattern = '\b(ToActionResult|ToActionResultAsync|ToHttpResult|ToHttpResultAsync|ToCreatedAtActionResult|ToCreatedAtRouteHttpResult|ToCreatedHttpResult|ToUpdatedActionResult|ToUpdatedHttpResult|ToPagedActionResult|ToPagedHttpResult)\b'; Message = 'Use ToHttpResponse(Async) and AsActionResult<T>(Async) for current ASP response mapping.' },
         @{ Pattern = '\bResult\.Success\s*[(<]'; Message = 'Result.Success is removed; use Result.Ok(...).' },

--- a/docs/docfx_project/api_reference/audit-stale-docs.ps1
+++ b/docs/docfx_project/api_reference/audit-stale-docs.ps1
@@ -52,6 +52,7 @@ try {
         @{ Pattern = '\bvoid/No-payload\b'; Message = 'Use no-payload wording without mixed casing/slashes.' },
         @{ Pattern = 'Error\.Equals\(\.\.\.\) compares \*\*only the error code\*\*'; Message = 'Error equality is value-based; compare Code for category-only checks.' },
         @{ Pattern = '(?<!")\bTrellis\.Results\b(?!")'; Message = 'Trellis.Results is not a current package; use Trellis.Core unless this is historical migration content. (The ActivitySource of the same name is current — write it double-quoted, as "Trellis.Results", so it is distinguishable from the dead package id.)' },
+        @{ Pattern = '\b(?:Include|Update|Remove|PackageId)\s*=\s*"Trellis\.Results"'; Message = 'Trellis.Results is not a current package; the double-quoted form is exempted above only so the ActivitySource name can be written as a string literal, which an MSBuild item attribute is not.' },
         @{ Pattern = '\bTrellis\.DomainDrivenDesign\b'; Message = 'Trellis.DomainDrivenDesign is not a current package; use Trellis.Core unless this is historical migration content.' },
         @{ Pattern = '\b(ToActionResult|ToActionResultAsync|ToHttpResult|ToHttpResultAsync|ToCreatedAtActionResult|ToCreatedAtRouteHttpResult|ToCreatedHttpResult|ToUpdatedActionResult|ToUpdatedHttpResult|ToPagedActionResult|ToPagedHttpResult)\b'; Message = 'Use ToHttpResponse(Async) and AsActionResult<T>(Async) for current ASP response mapping.' },
         @{ Pattern = '\bResult\.Success\s*[(<]'; Message = 'Result.Success is removed; use Result.Ok(...).' },

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -145,7 +145,7 @@ Migration notes for users moving from the previous `Trellis.Core` API surface.
 | Public `Value` / `Error` accessors on `Result<T>` | Both threw on the wrong branch. | `result.Error` is `public Error?` and **never throws** (null on success). The throwing `result.Value` getter was removed entirely because it was the primary cause of unsafe value access. | Read errors with `if (result.Error is { } error) { ... }` or `result.TryGetError(out var error)`. Extract success values with `result.TryGetValue(out var v)`, `result.TryGetValue(out var v, out var err)`, `result.Match(...)`, or `var (ok, v, err) = result;` (Deconstruct). | <!-- stale-doc-ok: migration-comparison row intentionally cites removed value accessor -->
 | HTTP transport abstractions package | `Trellis.Core` | `Trellis.Http.Abstractions` | Add a PackageReference to `Trellis.Http.Abstractions` for code that names `WriteOutcome<T>`, `RepresentationMetadata`, `EntityTagValue`, `RetryAfterValue`, `PreconditionKind`, `AuthChallenge`, or `AggregateETagExtensions`. The CLR namespace stays `Trellis`, so most source files only need the package-reference change. |
 | Package id | `Trellis.Results` | `Trellis.Core` | Replace `<PackageReference Include="Trellis.Results" ... />` with `<PackageReference Include="Trellis.Core" ... />`. The CLR namespace stays `Trellis` — no `using` changes are needed. The legacy `Trellis.Results` package is unlisted with a redirect notice; there is no metapackage shim. | <!-- stale-doc-ok: migration-comparison row intentionally cites previous package id -->
-| OpenTelemetry `ActivitySource` name | `"Trellis.Results"` | `"Trellis.Core"` | Update OTel subscriptions: `builder.AddSource("Trellis.Results")` → `builder.AddSource("Trellis.Core")`. The `RopTrace.ActivitySourceName` constant exposes the name programmatically. | <!-- stale-doc-ok: migration-comparison row intentionally cites previous activity source name -->
+| OpenTelemetry `ActivitySource` name | `"Trellis.Results"` | `"Trellis.Results"` (unchanged) | No change needed. The source is named for the operations it traces, not for the package that ships it, so the v1 name carried over. The `RopTrace.ActivitySourceName` constant exposes it programmatically. | <!-- stale-doc-ok: migration-comparison row intentionally cites the v1 activity source name -->
 | Test helper namespace | `Trellis.Results.Tests.*` | `Trellis.Core.Tests.*` | Internal change only — affects users who took an InternalsVisibleTo dependency on the test assembly (none expected). | <!-- stale-doc-ok: migration-comparison row intentionally cites previous test namespace -->
 | Package merge: DDD | <PackageReference Include="Trellis.DomainDrivenDesign" .../> | *(removed)* | All DDD types (`Aggregate<T>`, `Entity<T>`, `ValueObject`, `Specification<T>`, etc.) moved into `Trellis.Core`. Drop the `Trellis.DomainDrivenDesign` PackageReference; the types are still in `namespace Trellis;` so no using changes are needed. | <!-- stale-doc-ok: migration-comparison row intentionally cites previous package id -->
 | Package merge: Primitives generator | <PackageReference Include="Trellis.Primitives.Generator" .../> | *(removed)* | The Required* source generator is now bundled inside `Trellis.Core.nupkg` (`analyzers/dotnet/cs/Trellis.Core.Generator.dll`). Installing `Trellis.Core` (or any package depending on it) attaches the analyzer automatically. Drop the standalone PackageReference. |
@@ -867,11 +867,11 @@ OpenTelemetry helper for Trellis result instrumentation. Lives in `Trellis.Core\
 
 | Signature | Notes |
 | --- | --- |
-| `public static TracerProviderBuilder AddResultsInstrumentation(this TracerProviderBuilder builder)` | Registers the Trellis ROP `ActivitySource` (named `"Trellis.Core"`, exposed as `RopTrace.ActivitySourceName`) with the supplied OpenTelemetry tracer-provider builder. Returns the same builder for chaining. |
+| `public static TracerProviderBuilder AddTrellisResultsInstrumentation(this TracerProviderBuilder builder)` | Registers the Trellis ROP `ActivitySource` (named `"Trellis.Results"`, exposed as `RopTrace.ActivitySourceName`) with the supplied OpenTelemetry tracer-provider builder. Returns the same builder for chaining. |
 
 #### Performance characteristics
 
-The per-operation tracing is essentially free when no listener is registered. `AddResultsInstrumentation` is the Trellis-provided helper for registering the `"Trellis.Core"` source with OpenTelemetry; consumers may also call `AddSource("Trellis.Core")` directly or attach an `ActivityListener`. Measured on .NET 10 / x64 with an ambient ASP.NET request activity present (benchmark in `Trellis.Benchmark/TracingOverheadBenchmarks.cs`):
+The per-operation tracing is essentially free when no listener is registered. `AddTrellisResultsInstrumentation` is the Trellis-provided helper for registering the `"Trellis.Results"` source with OpenTelemetry; consumers may also call `AddSource("Trellis.Results")` directly or attach an `ActivityListener`. Measured on .NET 10 / x64 with an ambient ASP.NET request activity present (benchmark in `Trellis.Benchmark/TracingOverheadBenchmarks.cs`):
 
 | Pipeline depth | No listener | Listener attached (`AllDataAndRecorded` sampling) |
 |---|---|---|
@@ -881,18 +881,18 @@ The per-operation tracing is essentially free when no listener is registered. `A
 | 10-step `Map` chain | ~115 ns, 0 B | ~2,227 ns, 4,000 B |
 | 10-step `Tap` chain | ~176 ns, 0 B | ~2,281 ns, 4,096 B |
 
-**No listener registered (default):** ~14–20 ns per `Bind`/`Map`/`Tap`, **0 bytes allocated**. The per-extension `using var activity = ActivitySource.StartActivity(...)` returns null almost immediately when no consumer has registered the `"Trellis.Core"` source. Trellis does not set status or `result.error.code` on an ambient ASP.NET or Mediator activity from ROP operators unless that activity was started by the Trellis ROP `ActivitySource`. On a failure the tags are `result.error.code` (`Error.Code`, the same string the HTTP boundary writes) and `result.error.type` (the error class name, which keeps the cases whose wire code is the sentinel distinguishable).
+**No listener registered (default):** ~14–20 ns per `Bind`/`Map`/`Tap`, **0 bytes allocated**. The per-extension `using var activity = ActivitySource.StartActivity(...)` returns null almost immediately when no consumer has registered the `"Trellis.Results"` source. Trellis does not set status or `result.error.code` on an ambient ASP.NET or Mediator activity from ROP operators unless that activity was started by the Trellis ROP `ActivitySource`. On a failure the tags are `result.error.code` (`Error.Code`, the same string the HTTP boundary writes) and `result.error.type` (the error class name, which keeps the cases whose wire code is the sentinel distinguishable).
 
-**With `AddResultsInstrumentation` registered:** each combinator costs ~200 ns and allocates ~400 B (the Activity object + name + tags). At 10 000 RPS with a 10-step pipeline that's ~22 ms/sec of CPU and ~40 MB/sec of GC pressure — material at high throughput.
+**With `AddTrellisResultsInstrumentation` registered:** each combinator costs ~200 ns and allocates ~400 B (the Activity object + name + tags). At 10 000 RPS with a 10-step pipeline that's ~22 ms/sec of CPU and ~40 MB/sec of GC pressure — material at high throughput.
 
 #### Granularity guidance
 
 Per-Result-extension spans add limited signal beyond the outer pipeline span (`Trellis.Mediator.TracingBehavior`) or the ASP.NET request span. They appear as a deeply nested tree under the outer span with no business context — most observability backends collapse or charge per span.
 
-- **Production / high-throughput services**: instrument at the pipeline-behavior altitude (already covered by `Trellis.Mediator.TracingBehavior`) and the HTTP-boundary altitude (`AddAspNetCoreInstrumentation`); skip `AddResultsInstrumentation`.
-- **Development / debugging / low-rate paths**: register `AddResultsInstrumentation` to get step-by-step ROP visibility. The cost is intentional — you opted in.
+- **Production / high-throughput services**: instrument at the pipeline-behavior altitude (already covered by `Trellis.Mediator.TracingBehavior`) and the HTTP-boundary altitude (`AddAspNetCoreInstrumentation`); skip `AddTrellisResultsInstrumentation`.
+- **Development / debugging / low-rate paths**: register `AddTrellisResultsInstrumentation` to get step-by-step ROP visibility. The cost is intentional — you opted in.
 
-The cost is bounded by the consumer's choice; the framework does not gate it further. If `AddResultsInstrumentation` is registered, the spans appear; if not, they don't, and the cost is noise-floor.
+The cost is bounded by the consumer's choice; the framework does not gate it further. If `AddTrellisResultsInstrumentation` is registered, the spans appear; if not, they don't, and the cost is noise-floor.
 
 ---
 
@@ -2590,7 +2590,7 @@ Core-owned JSON converter emitted by the `Required*<TSelf>` source generator for
 public static class PrimitiveValueObjectTrace
 ```
 
-Core-owned trace source used by generated `Required*<TSelf>` value objects and concrete primitives. The activity source name remains `"Trellis.Primitives"` for telemetry compatibility and is exposed as `PrimitiveValueObjectTrace.ActivitySourceName`; register it with `AddPrimitiveValueObjectInstrumentation()` from `Trellis.Primitives` when using the primitives package, or call `TracerProviderBuilder.AddSource(PrimitiveValueObjectTrace.ActivitySourceName)` directly for Core-only generated primitives.
+Core-owned trace source used by generated `Required*<TSelf>` value objects and concrete primitives. The activity source name remains `"Trellis.Primitives"` for telemetry compatibility and is exposed as `PrimitiveValueObjectTrace.ActivitySourceName`; register it with `AddTrellisPrimitivesInstrumentation()` from `Trellis.Primitives` when using the primitives package, or call `TracerProviderBuilder.AddSource(PrimitiveValueObjectTrace.ActivitySourceName)` directly for Core-only generated primitives.
 
 > **Versioning:** the OpenTelemetry activity source `Version` is stamped from the assembly that physically contains this type — `Trellis.Core` — even when consumers depend on `Trellis.Primitives`. The two packages ship lockstep from a single `version.json`, so the version reported in spans is the version of both packages.
 

--- a/docs/docfx_project/api_reference/trellis-api-mediator.md
+++ b/docs/docfx_project/api_reference/trellis-api-mediator.md
@@ -428,7 +428,7 @@ builder.Services.AddOpenTelemetry()
         .AddOtlpExporter());
 ```
 
-`AddSource("Trellis.Mediator")` is equivalent — the helper exists so the name is not repeated as a string literal, and so this package matches `AddResultsInstrumentation()` in Trellis.Core and `AddPrimitiveValueObjectInstrumentation()` in Trellis.Primitives.
+`AddSource("Trellis.Mediator")` is equivalent — the helper exists so the name is not repeated as a string literal, and so this package matches `AddTrellisResultsInstrumentation()` in Trellis.Core and `AddTrellisPrimitivesInstrumentation()` in Trellis.Primitives.
 
 > **This gap is silent.** A service that never registers the source looks exactly like a service in which nothing failed: there is no warning, no startup error, and no empty-result signal — the spans are simply never collected. Because this span carries `error.code` and `error.type`, the gap is normally discovered *during* an incident, at the moment those tags were wanted.
 

--- a/docs/docfx_project/api_reference/trellis-api-primitives.md
+++ b/docs/docfx_project/api_reference/trellis-api-primitives.md
@@ -192,7 +192,7 @@ public static class PrimitiveValueObjectTraceProviderBuilderExtensions
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static TracerProviderBuilder AddPrimitiveValueObjectInstrumentation(this TracerProviderBuilder builder)` | `TracerProviderBuilder` | Registers the Core-owned Trellis primitive activity source (`PrimitiveValueObjectTrace.ActivitySourceName`) with OpenTelemetry. Throws `ArgumentNullException` when `builder` is null. |
+| `public static TracerProviderBuilder AddTrellisPrimitivesInstrumentation(this TracerProviderBuilder builder)` | `TracerProviderBuilder` | Registers the Core-owned Trellis primitive activity source (`PrimitiveValueObjectTrace.ActivitySourceName`) with OpenTelemetry. Throws `ArgumentNullException` when `builder` is null. |
 
 ### `Age`
 

--- a/docs/docfx_project/articles/debugging.md
+++ b/docs/docfx_project/articles/debugging.md
@@ -227,8 +227,8 @@ using Trellis.Primitives;
 
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracerBuilder => tracerBuilder
-        .AddResultsInstrumentation()
-        .AddPrimitiveValueObjectInstrumentation()
+        .AddTrellisResultsInstrumentation()
+        .AddTrellisPrimitivesInstrumentation()
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation());
 ```
@@ -237,11 +237,11 @@ builder.Services.AddOpenTelemetry()
 
 | Instrumentation | Best for |
 | --- | --- |
-| `AddResultsInstrumentation()` | Deep, temporary pipeline forensics |
-| `AddPrimitiveValueObjectInstrumentation()` | Lower-noise validation and parsing diagnostics |
+| `AddTrellisResultsInstrumentation()` | Deep, temporary pipeline forensics |
+| `AddTrellisPrimitivesInstrumentation()` | Lower-noise validation and parsing diagnostics |
 
 > [!WARNING]
-> `AddResultsInstrumentation()` can generate a lot of spans because it traces individual result operations. Treat it as a break-glass diagnostic tool, not a default production setting.
+> `AddTrellisResultsInstrumentation()` can generate a lot of spans because it traces individual result operations. Treat it as a break-glass diagnostic tool, not a default production setting.
 
 ## Common errors and what they usually mean
 
@@ -311,5 +311,5 @@ When you do that, most pipeline bugs become straightforward to locate.
 
 ## Cross-references
 
-- `Result<T>` accessors (`TryGetValue`, `TryGetError`, `Match`), `Tap` / `TapOnFailure`, `ResultDebugSettings`, `AddResultsInstrumentation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
-- `AddPrimitiveValueObjectInstrumentation`: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
+- `Result<T>` accessors (`TryGetValue`, `TryGetError`, `Match`), `Tap` / `TapOnFailure`, `ResultDebugSettings`, `AddTrellisResultsInstrumentation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- `AddTrellisPrimitivesInstrumentation`: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -8,7 +8,7 @@ audience: [developer]
 ---
 # Observability and Monitoring
 
-Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `ActivitySource`s — `Trellis.Mediator`, `Trellis.Primitives`, and `Trellis.Core` — wired through the canonical `AddTrellis(...)` composition root, plus validation counters from one `Meter`, `Trellis.Validation`.
+Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `ActivitySource`s — `Trellis.Mediator`, `Trellis.Primitives`, and `Trellis.Results` — wired through the canonical `AddTrellis(...)` composition root, plus validation counters from one `Meter`, `Trellis.Validation`.
 
 ## Patterns Index
 
@@ -16,8 +16,8 @@ Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `A
 |---|---|---|
 | Wire mediator tracing + logging via the composition root | `services.AddTrellis(o => o.UseMediator())` | [Default registration](#default-registration) |
 | Subscribe an OTel `TracerProvider` to mediator spans | `tracing.AddTrellisMediatorInstrumentation()` | [Tracing](#tracing) |
-| Subscribe to value-object spans (validation/parsing) | `tracing.AddPrimitiveValueObjectInstrumentation()` | [Tracing](#tracing) |
-| Subscribe to ROP spans (deep `Bind` / `Map` debugging) | `tracing.AddResultsInstrumentation()` | [Tracing](#tracing) |
+| Subscribe to value-object spans (validation/parsing) | `tracing.AddTrellisPrimitivesInstrumentation()` | [Tracing](#tracing) |
+| Subscribe to ROP spans (deep `Bind` / `Map` debugging) | `tracing.AddTrellisResultsInstrumentation()` | [Tracing](#tracing) |
 | Read structured per-message logs with elapsed-ms outcomes | Built in via `LoggingBehavior<,>` | [Logging](#logging) |
 | Allow `Error.Detail` into telemetry (non-PII environments only) | `o.UseMediator(t => t.IncludeErrorDetail = true)` | [Redaction](#redaction) |
 | Add business tags to the mediator span from a handler | `Activity.Current?.SetTag(...)` | [Custom enrichment](#custom-enrichment) |
@@ -38,8 +38,8 @@ Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `A
 | Mediator tracing | `TracingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | One `Activity` per mediator message; tags `error.code`, `error.type`; `ActivityStatusCode.Ok` / `Error` (request cancellations stay `Unset`) | Registered by `AddTrellisBehaviors()`; subscribe with `tracing.AddTrellisMediatorInstrumentation()` (source name: `"Trellis.Mediator"`) |
 | Mediator logging | `LoggingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | `Debug` start, `Debug` end (with elapsed ms), `Warning` on failure (with `Error.Code`) | Registered by `AddTrellisBehaviors()`; consumed by any `ILogger` provider. Per-call timing is at Debug so production at the default `Information` minimum is quiet; raise via `"Trellis.Mediator": "Debug"` in logging configuration to opt back in. |
 | Redaction | `TrellisMediatorTelemetryOptions` (`Trellis.Mediator`) | Controls whether `Error.Detail` flows into the activity status description and log message | DI singleton, configured via `o.UseMediator(t => ...)` or `AddTrellisBehaviors(t => ...)` |
-| Primitive value-object tracing | `Trellis.Primitives` `ActivitySource` | Exactly one `Activity` per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call delegates to and is traced under `.TryCreate`), named after the factory (e.g. `EmailAddress.TryCreate`), with `Ok` / `Error` status on both success and failure | `tracing.AddPrimitiveValueObjectInstrumentation()` |
-| Result / ROP tracing | `Trellis.Core` `ActivitySource` (`RopTrace.ActivitySourceName`) | Spans for individual `Result` operations — verbose; intended for diagnostics | `tracing.AddResultsInstrumentation()` |
+| Primitive value-object tracing | `Trellis.Primitives` `ActivitySource` | Exactly one `Activity` per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call delegates to and is traced under `.TryCreate`), named after the factory (e.g. `EmailAddress.TryCreate`), with `Ok` / `Error` status on both success and failure | `tracing.AddTrellisPrimitivesInstrumentation()` |
+| Result / ROP tracing | `Trellis.Results` `ActivitySource` (`RopTrace.ActivitySourceName`) | Spans for individual `Result` operations — verbose; intended for diagnostics | `tracing.AddTrellisResultsInstrumentation()` |
 | Validation metrics | `ValidationMetrics` (`Trellis.Core`) | `trellis.validation.failures`, one increment per violation as a `FieldViolation` or `RuleViolation` is created; tags `validation.code`, `validation.violation` | `metrics.AddTrellisValidationInstrumentation()` (meter name: `"Trellis.Validation"`) |
 | Composition root | `TrellisServiceBuilder.UseMediator(Action<TrellisMediatorTelemetryOptions>?)` | Registers the five canonical behaviors and the telemetry options | `services.AddTrellis(o => o.UseMediator(...))` |
 
@@ -55,7 +55,7 @@ dotnet add package OpenTelemetry.Instrumentation.AspNetCore
 dotnet add package OpenTelemetry.Instrumentation.Http
 ```
 
-`Trellis.Core` already references the OpenTelemetry SDK so `AddResultsInstrumentation()` and `AddPrimitiveValueObjectInstrumentation()` work without extra packages. The exporter and ASP.NET Core / HTTP instrumentation packages above are standard OTel — Trellis does not wrap them.
+`Trellis.Core` already references the OpenTelemetry SDK so `AddTrellisResultsInstrumentation()` and `AddTrellisPrimitivesInstrumentation()` work without extra packages. The exporter and ASP.NET Core / HTTP instrumentation packages above are standard OTel — Trellis does not wrap them.
 
 ## Quick start
 
@@ -80,7 +80,7 @@ builder.Services.AddOpenTelemetry()
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation()
         .AddTrellisMediatorInstrumentation()
-        .AddPrimitiveValueObjectInstrumentation()
+        .AddTrellisPrimitivesInstrumentation()
         .AddOtlpExporter());
 
 var app = builder.Build();
@@ -118,8 +118,8 @@ Trellis ships three independent `ActivitySource`s. Subscribe to each on its own 
 | Source | Constant | Volume | When to subscribe |
 |---|---|---|---|
 | `"Trellis.Mediator"` | `TracingBehavior<,>.ActivitySourceName` | One span per mediator message | Always — this is the primary failure-localisation surface. |
-| `"Trellis.Primitives"` | (internal — use `AddPrimitiveValueObjectInstrumentation()`) | Exactly one span per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call is traced under `.TryCreate`) | When you need to see *why* input validation rejected a request at the edge. |
-| `"Trellis.Core"` | `RopTrace.ActivitySourceName` (= `"Trellis.Core"`) | One span per individual `Result` operation (`Bind`, `Map`, `Tap`, …) | Only for break-glass diagnostics — high cardinality, high volume. |
+| `"Trellis.Primitives"` | (internal — use `AddTrellisPrimitivesInstrumentation()`) | Exactly one span per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call is traced under `.TryCreate`) | When you need to see *why* input validation rejected a request at the edge. |
+| `"Trellis.Results"` | `RopTrace.ActivitySourceName` (= `"Trellis.Results"`) | One span per individual `Result` operation (`Bind`, `Map`, `Tap`, …) | Only for break-glass diagnostics — high cardinality, high volume. |
 
 `TracingBehavior<,>` writes the following on every dispatched message:
 
@@ -140,27 +140,27 @@ builder.Services.AddOpenTelemetry()
         .AddAspNetCoreInstrumentation()
         .AddHttpClientInstrumentation()
         .AddTrellisMediatorInstrumentation()
-        .AddPrimitiveValueObjectInstrumentation()
+        .AddTrellisPrimitivesInstrumentation()
         .AddOtlpExporter());
 ```
 
-To enable ROP forensics during an investigation, add `.AddResultsInstrumentation()` on top — and remove it again when the investigation is over.
+To enable ROP forensics during an investigation, add `.AddTrellisResultsInstrumentation()` on top — and remove it again when the investigation is over.
 
 When ROP instrumentation is not enabled, `Result` operators do not mutate the ambient ASP.NET request span
 or the `Trellis.Mediator` pipeline span. Those outer spans keep their own status semantics; only ROP spans
-created by the `"Trellis.Core"` source receive per-step `Ok` / `Error` status and `result.error.code` / `result.error.type` tags.
+created by the `"Trellis.Results"` source receive per-step `Ok` / `Error` status and `result.error.code` / `result.error.type` tags.
 
 ```csharp
 builder.Services.AddOpenTelemetry()
     .WithTracing(tracing => tracing
         .AddTrellisMediatorInstrumentation()
-        .AddPrimitiveValueObjectInstrumentation()
-        .AddResultsInstrumentation()
+        .AddTrellisPrimitivesInstrumentation()
+        .AddTrellisResultsInstrumentation()
         .AddConsoleExporter());
 ```
 
 > [!WARNING]
-> `AddResultsInstrumentation()` is a debugging tool. It traces every `Bind`, `Map`, and `Tap` and can flood your collector. Keep it off in production unless you have an active incident.
+> `AddTrellisResultsInstrumentation()` is a debugging tool. It traces every `Bind`, `Map`, and `Tap` and can flood your collector. Keep it off in production unless you have an active incident.
 
 ## Logging
 
@@ -314,8 +314,8 @@ tracing.AddSource("Acme.Billing");
 ## Practical guidance
 
 - **Subscribe to `Trellis.Mediator` always.** It is one span per message and is the cheapest lever for failure localisation.
-- **Add `AddPrimitiveValueObjectInstrumentation()` early.** Validation traces are the clearest signal for "why is this request being rejected at the edge?".
-- **Treat `AddResultsInstrumentation()` as break-glass.** Turn it on for an incident, turn it off afterwards.
+- **Add `AddTrellisPrimitivesInstrumentation()` early.** Validation traces are the clearest signal for "why is this request being rejected at the edge?".
+- **Treat `AddTrellisResultsInstrumentation()` as break-glass.** Turn it on for an incident, turn it off afterwards.
 - **Keep `IncludeErrorDetail = false` in production.** Code + type are sufficient for dashboards and alerts; flip it on per-environment only when you have audited every `Error.Detail` write site.
 - **Sample at the collector or via OTel.** Trellis does not sample. Set `SetSampler(new TraceIdRatioBasedSampler(0.1))` on the `TracerProvider` if you need to throttle.
 - **Use `error.code` for grouping.** It is stable across releases (e.g. `validation.error`, `not.found.error`, `forbidden.error`) and far better than free-form messages.
@@ -324,7 +324,7 @@ tracing.AddSource("Acme.Billing");
 
 - Composition-root API: [`trellis-api-servicedefaults.md`](../api_reference/trellis-api-servicedefaults.md)
 - Mediator behaviors, redaction options, pipeline order: [`trellis-api-mediator.md`](../api_reference/trellis-api-mediator.md)
-- ROP `ActivitySource` and `AddResultsInstrumentation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
+- ROP `ActivitySource` and `AddTrellisResultsInstrumentation`: [`trellis-api-core.md`](../api_reference/trellis-api-core.md)
 - Primitive value-object instrumentation: [`trellis-api-primitives.md`](../api_reference/trellis-api-primitives.md)
 - Mediator integration article: [`integration-mediator.md`](integration-mediator.md)
 - HTTP-client integration article: [`integration-http.md`](integration-http.md)

--- a/docs/docfx_project/articles/integration-observability.md
+++ b/docs/docfx_project/articles/integration-observability.md
@@ -8,7 +8,7 @@ audience: [developer]
 ---
 # Observability and Monitoring
 
-Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `ActivitySource`s — `Trellis.Mediator`, `Trellis.Primitives`, and `Trellis.Results` — wired through the canonical `AddTrellis(...)` composition root, plus validation counters from one `Meter`, `Trellis.Validation`.
+Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `ActivitySource`s — `"Trellis.Mediator"`, `"Trellis.Primitives"`, and `"Trellis.Results"` — wired through the canonical `AddTrellis(...)` composition root, plus validation counters from one `Meter`, `Trellis.Validation`.
 
 ## Patterns Index
 
@@ -38,8 +38,8 @@ Trellis emits OpenTelemetry `Activity` spans and `ILogger` entries from three `A
 | Mediator tracing | `TracingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | One `Activity` per mediator message; tags `error.code`, `error.type`; `ActivityStatusCode.Ok` / `Error` (request cancellations stay `Unset`) | Registered by `AddTrellisBehaviors()`; subscribe with `tracing.AddTrellisMediatorInstrumentation()` (source name: `"Trellis.Mediator"`) |
 | Mediator logging | `LoggingBehavior<TMessage, TResponse>` (`Trellis.Mediator`) | `Debug` start, `Debug` end (with elapsed ms), `Warning` on failure (with `Error.Code`) | Registered by `AddTrellisBehaviors()`; consumed by any `ILogger` provider. Per-call timing is at Debug so production at the default `Information` minimum is quiet; raise via `"Trellis.Mediator": "Debug"` in logging configuration to opt back in. |
 | Redaction | `TrellisMediatorTelemetryOptions` (`Trellis.Mediator`) | Controls whether `Error.Detail` flows into the activity status description and log message | DI singleton, configured via `o.UseMediator(t => ...)` or `AddTrellisBehaviors(t => ...)` |
-| Primitive value-object tracing | `Trellis.Primitives` `ActivitySource` | Exactly one `Activity` per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call delegates to and is traced under `.TryCreate`), named after the factory (e.g. `EmailAddress.TryCreate`), with `Ok` / `Error` status on both success and failure | `tracing.AddTrellisPrimitivesInstrumentation()` |
-| Result / ROP tracing | `Trellis.Results` `ActivitySource` (`RopTrace.ActivitySourceName`) | Spans for individual `Result` operations — verbose; intended for diagnostics | `tracing.AddTrellisResultsInstrumentation()` |
+| Primitive value-object tracing | `"Trellis.Primitives"` `ActivitySource` | Exactly one `Activity` per value-object factory call (`TryCreate` / `FromFraction`; a `Parse` call delegates to and is traced under `.TryCreate`), named after the factory (e.g. `EmailAddress.TryCreate`), with `Ok` / `Error` status on both success and failure | `tracing.AddTrellisPrimitivesInstrumentation()` |
+| Result / ROP tracing | `"Trellis.Results"` `ActivitySource` (`RopTrace.ActivitySourceName`) | Spans for individual `Result` operations — verbose; intended for diagnostics | `tracing.AddTrellisResultsInstrumentation()` |
 | Validation metrics | `ValidationMetrics` (`Trellis.Core`) | `trellis.validation.failures`, one increment per violation as a `FieldViolation` or `RuleViolation` is created; tags `validation.code`, `validation.violation` | `metrics.AddTrellisValidationInstrumentation()` (meter name: `"Trellis.Validation"`) |
 | Composition root | `TrellisServiceBuilder.UseMediator(Action<TrellisMediatorTelemetryOptions>?)` | Registers the five canonical behaviors and the telemetry options | `services.AddTrellis(o => o.UseMediator(...))` |
 

--- a/docs/docfx_project/articles/migration.md
+++ b/docs/docfx_project/articles/migration.md
@@ -49,7 +49,6 @@ This page focuses on the public FunctionalDdd 2.x → Trellis 3.0 jump. For rele
 | `Trellis.Asp.Authorization` package | Folded into `Trellis.Asp.nupkg` (namespace unchanged) | [Package map](#package-map-legacy--current) |
 | Raw `string Actor.Id` + `string CreatedByActorId` audit fields | Typed `Actor.Id : ActorId` (`RequiredString<ActorId>` in `Trellis.Authorization`) + `ActorId CreatedByActorId` aggregate fields | [Typed `ActorId` audit fields](#typed-actorid-audit-fields-trellisauthorization) |
 | `services.AddApiVersioning().AddMvc(...)` with default `IActorProvider` | Optional `Maybe<Actor>` return from `IActorProvider.GetCurrentActorAsync` for anonymous-allowed endpoints | (see CHANGELOG `[3.0.0]` for the actor-provider breaking change) |
-| OpenTelemetry source `"Trellis.Results"` | `"Trellis.Core"` (`RopTrace.ActivitySourceName`) | [Observability](#observability) |
 | Analyzer IDs `TRLSGEN001`..`TRLSGEN103` | `TRLS031`..`TRLS038` | [Analyzer ID renames](#analyzer-id-renames) |
 
 ## Use this guide when
@@ -74,7 +73,6 @@ This page focuses on the public FunctionalDdd 2.x → Trellis 3.0 jump. For rele
 | Package merges | DDD, Primitives generator, Asp source generator, EF Core generator, Asp authorization | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
 | `WriteOutcome<T>` move | `Trellis.Asp.WriteOutcome<T>` → `Trellis.WriteOutcome<T>` (in `Trellis.Core`) | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
 | Test helper namespace | `Trellis.Results.Tests.*` → `Trellis.Core.Tests.*` | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
-| OTel `ActivitySource` name | `"Trellis.Results"` → `"Trellis.Core"` | [`trellis-api-core.md` → Breaking changes from v1](../api_reference/trellis-api-core.md#breaking-changes-from-v1) |
 | HTTP surface | 60+ overloads collapsed to one static class with seven methods; all sync removed; new disposal contract | [`trellis-api-http.md` → Breaking changes from v1](../api_reference/trellis-api-http.md#breaking-changes-from-v1) |
 | State machine | Package and namespace renamed `Trellis.Stateless` → `Trellis.StateMachine`; public surface otherwise identical | [`trellis-api-statemachine.md` → Breaking changes from v1](../api_reference/trellis-api-statemachine.md#breaking-changes-from-v1) |
 | Analyzer IDs | `TRLSGEN001`–`TRLSGEN103` renamed to `TRLS031`–`TRLS038` | [`trellis-api-analyzers.md`](../api_reference/trellis-api-analyzers.md) |
@@ -270,19 +268,17 @@ Authoritative diff (with `<PackageReference>` snippets): [`trellis-api-core.md` 
 
 ## Observability
 
-Update OpenTelemetry subscriptions when you upgrade:
+The ROP `ActivitySource` is still named `"Trellis.Results"`, so existing subscriptions keep working:
 
 ```csharp
-// v1
 builder.AddSource("Trellis.Results");
-
-// v2
-builder.AddSource("Trellis.Core");
 // or, programmatically:
 builder.AddSource(RopTrace.ActivitySourceName);
 ```
 
-The OTel extension method names (`AddResultsInstrumentation()`, `AddPrimitiveValueObjectInstrumentation()`) are unchanged. See [`integration-observability.md`](integration-observability.md) for tracing setup and [`debugging.md`](debugging.md) for ROP-trace forensics.
+The source is named for what it traces rather than for the package that ships it — `Trellis.Core` also emits the `"Trellis.Primitives"` source and the `"Trellis.Validation"` meter.
+
+The OTel extension methods are now `AddTrellisResultsInstrumentation()` and `AddTrellisPrimitivesInstrumentation()`, matching the `AddTrellis{Segment}Instrumentation` shape used across the framework. See [`integration-observability.md`](integration-observability.md) for tracing setup and [`debugging.md`](debugging.md) for ROP-trace forensics.
 
 ## Analyzer ID renames
 
@@ -313,7 +309,7 @@ Recommended order — each step is small enough that the build should succeed be
 6. **Replace `result.Value` reads.** Use `TryGetValue`, `Match`, or deconstruction. Replace `result.Error` reads with `if (result.Error is { } e)` or `result.TryGetError(out var e)`.
 7. **Remove `MatchError` / `FlattenValidationErrors` calls.** `MatchError` → `Match` + `switch`. `FlattenValidationErrors` is no-op — `Combine` already merges field/rule violations.
 8. **Audit HTTP call sites.** Replace `EnsureSuccess*` / `HandleClientError*` / `HandleServerError*` / `HandleForbidden*` / `HandleFailureAsync<TContext>` with `ToResultAsync(statusMap)` or body-aware `ToResultAsync(mapper, ct)`. Rename `ReadResultFromJsonAsync` / `ReadResultMaybeFromJsonAsync` to `ReadJsonAsync` / `ReadJsonMaybeAsync`. Stop disposing `HttpResponseMessage` after the chain reaches `ReadJson*` — `Trellis.Http` owns it.
-9. **Update OTel sources.** `"Trellis.Results"` → `"Trellis.Core"` (or `RopTrace.ActivitySourceName`).
+9. **OTel sources are unchanged.** The ROP source is still `"Trellis.Results"` (or `RopTrace.ActivitySourceName`); only the registration helper was renamed, to `AddTrellisResultsInstrumentation()`.
 10. **Update analyzer suppressions.** Apply the `TRLSGEN*` → `TRLS0xx` map.
 11. **Build, run tests, and iterate.** The compiler errors (`CS0029`, `CS0117`, `CS1061`, `CS1593`) are deliberately the migration map — work through them top-down.
 12. **Add `Trellis.Analyzers`** if you want the compiler to enforce current patterns (notably `TRLS003` on `Maybe<T>.Value` and `TRLS019` on `default(Result<T>)`).

--- a/docs/docfx_project/articles/primitives.md
+++ b/docs/docfx_project/articles/primitives.md
@@ -46,7 +46,7 @@ audience: [developer]
 | Scalar JSON converters | `ParsableJsonConverter<T>` (scalars), `RequiredEnumJsonConverter<TRequiredEnum>` | `Trellis.Core` |
 | Composite JSON converter | `CompositeValueObjectJsonConverter<T>` | `Trellis.Primitives` |
 | Tracing source | `PrimitiveValueObjectTrace.ActivitySource`, `PrimitiveValueObjectTrace.ActivitySourceName` | `Trellis.Core` |
-| Tracing registration | `AddPrimitiveValueObjectInstrumentation(this TracerProviderBuilder)` | `Trellis.Primitives` |
+| Tracing registration | `AddTrellisPrimitivesInstrumentation(this TracerProviderBuilder)` | `Trellis.Primitives` |
 
 Full signatures: [trellis-api-primitives.md](../api_reference/trellis-api-primitives.md).
 


### PR DESCRIPTION
## Why

Four OpenTelemetry registration helpers had four different naming shapes. This PR puts all of them on one rule:

**`AddTrellis{Segment}Instrumentation`**, where `{Segment}` is exactly the text after `Trellis.` in the source or meter the helper registers.

| Before | After |
|---|---|
| `AddResultsInstrumentation` | `AddTrellisResultsInstrumentation` |
| `AddPrimitiveValueObjectInstrumentation` | `AddTrellisPrimitivesInstrumentation` |
| `AddTrellisMediatorInstrumentation` | unchanged |
| `AddTrellisValidationInstrumentation` | unchanged |

The point of the rule is that the mapping becomes **two-way**. Seeing `Trellis.Primitives` on a span tells you which call turned it on; reading a call tells you what will show up in your backend. `AddPrimitiveValueObjectInstrumentation` broke that in both directions — "PrimitiveValueObject" appears nowhere in the emitted telemetry.

## The ActivitySource rename

Applying the rule surfaced a mismatch rather than creating one. The ROP `ActivitySource` was named `"Trellis.Core"`, so the rule demanded `AddTrellisCoreInstrumentation()` — and that name is wrong on its own terms:

- The `Trellis.Core` package emits **three** telemetry names. Naming one of them after the package reads as though it covers all three.
- It would attach the most inviting, most general-sounding name to the **deliberately high-volume** ROP source. The existing docs already say to *"reserve it for development/debugging or low-rate request paths."* Results tracing and Primitives tracing are separate opt-ins precisely because most people want Primitives without the noise of Results.

So the source is renamed `"Trellis.Core"` → `"Trellis.Results"`.

**This does not reverse a prior decision.** ADR-002 §2 (item 14) records `Trellis.Results` → `Trellis.Core` as a **package** rename; the `ActivitySource` inherited it silently, and there is no record of anyone deciding the *source* should be named for its package. Naming it for its role restores the original intent.

Two consequences worth calling out:

- The source **returns to its v1 name**, so a v1 `AddSource("Trellis.Results")` subscription is correct again. Two migration-guide rows that described this as a v1→v2 breaking change are now false, and are **removed** rather than reworded.
- All three names the package emits are now role-based: `"Trellis.Results"`, `"Trellis.Primitives"`, `"Trellis.Validation"`.

## Enforcement

`InstrumentationNamingTests` makes the rule fail the build rather than rely on review.

It derives the expectation **from the telemetry itself**, not from a table of approved names. `TracerProviderBuilder` and `MeterProviderBuilder` are abstract, so a recording subclass captures what each helper *actually* registers and the assertion is computed from that. A list of blessed names would be satisfied by whoever remembered to update the list — which is exactly the memory that failed here.

Two details that are load-bearing:

- Helpers are discovered by scanning assemblies in `AppContext.BaseDirectory`, **not** `GetReferencedAssemblies()`. The compiler omits assembly references the test code does not actually use, so a package referenced *solely* to bring its helper under the rule would vanish from metadata and be silently exempt. A `ProjectReference` always copies to output, which makes "add a ProjectReference" the complete fix the failure message promises. (That is why this PR adds one to `Trellis.Primitives`.)
- A second test cross-checks reflection against a repo-wide regex scan of `*/src/**/*.cs`, so a helper living in a package nobody references fails loudly instead of being quietly out of scope.

The test was proven red before being trusted: mutating a registered source name produces the intended actionable failure.

## Verification

- `dotnet build Trellis.slnx` — Debug and Release, **0 warnings**
- `dotnet test Trellis.slnx` — **8062 passed / 0 failed**
- `docs\lint-api-reference.ps1` — pass (28 files)
- API-reference completeness audit — pass

## Breaking changes

Both helper renames and the `ActivitySource` rename are breaking. No `[Obsolete]` shims: this is 3.0.0-alpha with no external consumers.

> Note: overlaps #734 on `CHANGELOG.md`, `trellis-api-core.md` and `integration-observability.md`. Whichever merges second will need a rebase.

## Two gates this tripped, and what they needed

Neither was a surprise in hindsight; both are cases where removing public surface or overloading a string has consequences a compile cannot see.

**Package validation (`CP0002`).** Removing `AddResultsInstrumentation` and `AddPrimitiveValueObjectInstrumentation` is a break against the published `3.0.0-alpha.455` baseline, so `dotnet pack` fails. Both removals are intentional, so they are recorded in `CompatibilitySuppressions.xml` — `Trellis.Primitives` gets its first such file. Entries were generated with `/p:ApiCompatGenerateSuppressionFile=true` rather than hand-written so the `Target` strings match the tool exactly. Note that the `ActivitySource` rename is deliberately **absent**: ApiCompat compares signatures, and renaming a `const`'s *value* changes no surface, even though that rename is the more disruptive of the two for anyone subscribing by name. The migration guide is what covers it.

This reached CI because my local gate list for this branch did not include `dotnet pack` — on a branch whose whole purpose is removing public members, which is precisely what package validation exists to catch.

**The stale-docs gate.** `audit-stale-docs.ps1` flagged every occurrence of `Trellis.Results` as a dead package id — correct until this branch made it a live `ActivitySource` name. The string is now overloaded, and a bare substring match cannot tell a stale package reference from a current source name. This is the same ambiguity that, earlier in this branch, let a blanket rename corrupt a `PackageReference` migration instruction.

The pattern now exempts the double-quoted form, so `"Trellis.Results"` passes while a bare or backticked `Trellis.Results` is still reported. That makes quoting the convention for writing a source name, which is worth having independently: a source name *is* a string literal, and writing it as one is what distinguishes it from a type or a package. Verified in both directions against a scratch file — a `PackageReference` line is still flagged, a quoted-source line is not.