### PR TITLE
Make violation args a closed union so numbers reach the wire as numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — **BREAKING**: violation args are a closed union, so numbers reach the wire as numbers
+
+`FieldViolation.Args` and `RuleViolation.Args` change from `ImmutableDictionary<string, string>` to `ImmutableDictionary<string, ValidationArgValue>`, a closed union of `Text`, `Number`, and `List`. A numeric operand is now emitted as a JSON number rather than a quoted string:
+
+```jsonc
+// before
+"args": { "minLength": "3", "maxLength": "50" }
+// after
+"args": { "minLength": 3, "maxLength": 50 }
+```
+
+Args exist so a client can render its own localized message instead of parsing the server's English prose. Quoting every operand undercut that: a client comparing a bound against a length had to parse it back out of a string and guess at the format, which is the same recovery-by-parsing the args were introduced to end. The union keeps the property that motivated `string` in the first place — a producer still cannot hand over an arbitrary `object` and let culture-sensitive formatting leak onto the wire — because `Number` holds a `decimal` and is written invariantly.
+
+`Number` is backed by `decimal` alone rather than one case per CLR numeric type: JSON has a single number type, so a client could not observe the distinction, and `decimal` is the widest choice that keeps integers exact. `List` is what lets a violation name a set without a producer inventing a delimiter a client would then have to know to split on.
+
+**Migrating.** Most call sites need no change — `string`, `int`, `long`, and `decimal` all convert implicitly, so `ValidationArgs.Of("max", 255)` compiles as it did. Two things do change:
+
+- **A numeric operand written as a quoted string keeps compiling and stays quoted.** `ValidationArgs.Of("comparisonValue", "0")` is now `Text("0")`, not a number. Drop the quotes to get the new shape. Every framework producer has been de-quoted, including the code emitted by the `Required*` source generator, so generated value objects and the built-in primitives emit numbers without any consumer action.
+- **The `IFormattable` overloads are removed.** Keeping them would have made every numeric call *ambiguous*: an `int` converts to `IFormattable` by boxing and to `ValidationArgValue` by a user-defined conversion, neither target is better than the other, and `Of("max", 255)` fails to compile with `CS0121`. Their absence is what lets the implicit conversions bind. Format a value with no numeric or textual meaning of its own — a timestamp, say — explicitly and invariantly at the call site.
+
+`ValidationArgs.Of` also gains a `params` overload taking name/value pairs, retiring the previous ceiling of two. A rule with more operands is ordinary — a scale-and-precision failure carries four — and previously had to abandon `ValidationArgs` and assemble the dictionary by hand.
+
+**Deserializing a number rejects what it cannot hold exactly.** `Utf8JsonReader.GetDecimal()` rounds silently — `1E-100` reads back as `0`, and `0.00000000000000000000000000009` as `0.0000000000000000000000000001` — and it raises `FormatException` on overflow, which is not the exception a converter is expected to surface. Since an arg is the operand a client renders a bound from, a rounded value states a limit the producer never wrote; `ValidationArgValueJsonConverter` throws `JsonException` for such tokens instead. Exactness is judged on significant digits rather than on text, so `1e2`, `1.50` and `-0` are accepted normally. The same rule governs `Trellis.FluentValidation`'s promotion of an approved string arg to `Number`, which now requires an exact invariant round-trip before promoting.
+
+Assertions comparing an arg to a bare string need updating: `Args["max"].Should().Be("255")` becomes `Args["max"].Should().Be(new ValidationArgValue.Number(255))`.
+
+The FluentValidation projection's disclosure gate is **unchanged**. It still decides on the rendered string, because it decides by comparing against the message FluentValidation produced and that message is text; an arg is lifted onto the union only after it has already passed. The lift cannot admit anything the gate rejected. Enums remain `Text` — they are encoded by name, and a client matching on the name would otherwise be handed an ordinal it cannot interpret.
+
+`ValidationArgValueJsonConverter` is public and applied to the union by attribute, so no registration is needed. It cannot be internal: the `System.Text.Json` source generator fails with `SYSLIB1220` when a trimmed or AOT-published `JsonSerializerContext` roots a violation payload whose converter it cannot access.
+
 ### Added — `WithLink(rel, href)` for RFC 8288 `Link` relations
 
 `HttpResponseOptionsBuilder<TDomain>.WithLink(rel, href)` advertises a link relation on a response — most usefully a schema for the resource, so a client can validate before it sends rather than only learning what went wrong afterwards. Trellis previously had no way to emit a `Link` header at all: the only one was the hardcoded `next`/`prev` pair inside the pagination path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed — **BREAKING**: violation args are a closed union, so numbers reach the wire as numbers
 
-`FieldViolation.Args` and `RuleViolation.Args` change from `ImmutableDictionary<string, string>` to `ImmutableDictionary<string, ValidationArgValue>`, a closed union of `Text`, `Number`, and `List`. A numeric operand is now emitted as a JSON number rather than a quoted string:
+`FieldViolation.Args` and `RuleViolation.Args` change from `ImmutableDictionary<string, string>` to `ImmutableDictionary<string, ValidationArgValue>`, a closed union of `Text`, `Number`, `Bool`, and `List`. A numeric operand is now emitted as a JSON number rather than a quoted string:
 
 ```jsonc
 // before
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Args exist so a client can render its own localized message instead of parsing the server's English prose. Quoting every operand undercut that: a client comparing a bound against a length had to parse it back out of a string and guess at the format, which is the same recovery-by-parsing the args were introduced to end. The union keeps the property that motivated `string` in the first place — a producer still cannot hand over an arbitrary `object` and let culture-sensitive formatting leak onto the wire — because `Number` holds a `decimal` and is written invariantly.
 
 `Number` is backed by `decimal` alone rather than one case per CLR numeric type: JSON has a single number type, so a client could not observe the distinction, and `decimal` is the widest choice that keeps integers exact. `List` is what lets a violation name a set without a producer inventing a delimiter a client would then have to know to split on.
+
+The cases are JSON's self-describing values — its three scalars, plus a list of them. `null` and objects are deliberately absent: an arg with no value is an arg that is simply not there, so `null` would give the dictionary two spellings of one thing, and an object would require a schema per reason code to interpret, giving up the property that makes a closed union worth having and turning args into an open-ended payload to echo back to a caller. `Bool` earns its place on the same principle even though a boolean is rarely interpolated into a message: without it a producer would write `Text("true")`, reintroducing the quoted-primitive problem this change removes, and a boolean from a non-.NET producer would fail the whole payload rather than one arg.
 
 **Migrating.** Most call sites need no change — `string`, `int`, `long`, and `decimal` all convert implicitly, so `ValidationArgs.Of("max", 255)` compiles as it did. Two things do change:
 

--- a/Trellis.Asp/src/ModelBinding/PrimitiveConverter.cs
+++ b/Trellis.Asp/src/ModelBinding/PrimitiveConverter.cs
@@ -38,14 +38,14 @@ internal static class PrimitiveConverter
     /// <c>args</c>, where it survives structurally instead of only inside the English message.
     /// </para>
     /// </remarks>
-    private static Error.InvalidInput Invalid(string reasonCode, string detail, ImmutableDictionary<string, string>? args = null) =>
+    private static Error.InvalidInput Invalid(string reasonCode, string detail, ImmutableDictionary<string, ValidationArgValue>? args = null) =>
         new(EquatableArray.Create(
             new FieldViolation(InputPointer.Root, reasonCode, args, detail)))
         {
             Detail = detail,
         };
 
-    private static ImmutableDictionary<string, string> ByteRangeArgs { get; } = ValidationArgs.Of("min", "0", "max", "255");
+    private static ImmutableDictionary<string, ValidationArgValue> ByteRangeArgs { get; } = ValidationArgs.Of("min", 0, "max", 255);
 
     /// <summary>
     /// Converts a string value to the specified primitive type.

--- a/Trellis.Asp/src/Response/ResponseFailureWriter.cs
+++ b/Trellis.Asp/src/Response/ResponseFailureWriter.cs
@@ -615,7 +615,7 @@ public sealed record FieldViolationProblemDetail(
     string Code,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Detail,
     ViolationLocation Location,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyDictionary<string, string>? Args);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyDictionary<string, ValidationArgValue>? Args);
 
 /// <summary>JSON shape used for rule violations in ProblemDetails extensions.</summary>
 /// <param name="Code">The machine-readable reason code.</param>
@@ -629,4 +629,4 @@ public sealed record RuleViolationProblemDetail(
     string Code,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? Detail,
     IReadOnlyList<ViolationLocation> Locations,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyDictionary<string, string>? Args);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] IReadOnlyDictionary<string, ValidationArgValue>? Args);

--- a/Trellis.Asp/src/Response/ViolationProjection.cs
+++ b/Trellis.Asp/src/Response/ViolationProjection.cs
@@ -103,6 +103,6 @@ internal static class ViolationProjection
         return extensions;
     }
 
-    private static ImmutableDictionary<string, string>? ToArgs(ImmutableDictionary<string, string>? args) =>
+    private static ImmutableDictionary<string, ValidationArgValue>? ToArgs(ImmutableDictionary<string, ValidationArgValue>? args) =>
         args is { Count: > 0 } ? args : null;
 }

--- a/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
+++ b/Trellis.Asp/src/Validation/ValidationErrorsContext.cs
@@ -201,7 +201,7 @@ public static class ValidationErrorsContext
         string fieldName,
         string code,
         string message,
-        IReadOnlyDictionary<string, string>? args = null)
+        IReadOnlyDictionary<string, ValidationArgValue>? args = null)
     {
         var collector = s_current.Value;
         if (collector is null)

--- a/Trellis.Asp/tests/ProducerIndependenceTests.cs
+++ b/Trellis.Asp/tests/ProducerIndependenceTests.cs
@@ -145,8 +145,8 @@ public class ProducerIndependenceTests
         var violation = ((Error.InvalidInput)result.Error!).Fields.Items[0];
         violation.ReasonCode.Should().Be(ValidationCodes.FormatInteger);
         violation.Args.Should().NotBeNull();
-        violation.Args!["min"].Should().Be("0");
-        violation.Args["max"].Should().Be("255");
+        violation.Args!["min"].Should().Be(new ValidationArgValue.Number(0));
+        violation.Args["max"].Should().Be(new ValidationArgValue.Number(255));
     }
 
     [Fact]

--- a/Trellis.Asp/tests/Validation/ValidationErrorsContextRebaseTests.cs
+++ b/Trellis.Asp/tests/Validation/ValidationErrorsContextRebaseTests.cs
@@ -79,7 +79,7 @@ public class ValidationErrorsContextRebaseTests
             "displayName",
             UnspecifiedCode,
             "too short",
-            new Dictionary<string, string> { ["min"] = "3" });
+            new Dictionary<string, ValidationArgValue> { ["min"] = 3 });
 
         var error = ValidationErrorsContext.GetUnprocessableContent();
 
@@ -87,7 +87,7 @@ public class ValidationErrorsContextRebaseTests
         violation.Field.In.Should().Be(InputLocation.Body);
         violation.ReasonCode.Should().Be(UnspecifiedCode);
         violation.Detail.Should().Be("too short");
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("min", "3"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("min", 3));
     }
 
     // --- explicit non-body locations survive unprefixed and unpromoted ---

--- a/Trellis.Asp/tests/ValidationErrorsContextPreservationTests.cs
+++ b/Trellis.Asp/tests/ValidationErrorsContextPreservationTests.cs
@@ -22,7 +22,7 @@ public class ValidationErrorsContextPreservationTests
     {
         using (ValidationErrorsContext.BeginScope())
         {
-            var args = ImmutableDictionary<string, string>.Empty.Add("min", "3").Add("max", "50");
+            var args = ValidationArgs.Of("min", 3, "max", 50);
             var source = new Error.InvalidInput(EquatableArray.Create(
                 new FieldViolation(InputPointer.ForProperty("name"), "length_out_of_range", args, "Name length out of range.")));
 
@@ -35,8 +35,8 @@ public class ValidationErrorsContextPreservationTests
             violation.ReasonCode.Should().Be("length_out_of_range");
             violation.Detail.Should().Be("Name length out of range.");
             violation.Args.Should().NotBeNull();
-            violation.Args!["min"].Should().Be("3");
-            violation.Args!["max"].Should().Be("50");
+            violation.Args!["min"].Should().Be(new ValidationArgValue.Number(3));
+            violation.Args!["max"].Should().Be(new ValidationArgValue.Number(50));
         }
     }
 

--- a/Trellis.Asp/tests/ViolationProblemDetailSerializationTests.cs
+++ b/Trellis.Asp/tests/ViolationProblemDetailSerializationTests.cs
@@ -40,10 +40,10 @@ public class ViolationProblemDetailSerializationTests
             ValidationCodes.Unspecified,
             "Email address is not valid.",
             new ViolationLocation("body", "/email", null),
-            new Dictionary<string, string> { ["min"] = "3" }));
+            new Dictionary<string, ValidationArgValue> { ["min"] = 3 }));
 
         json.GetProperty("detail").GetString().Should().Be("Email address is not valid.");
-        json.GetProperty("args").GetProperty("min").GetString().Should().Be("3");
+        json.GetProperty("args").GetProperty("min").GetInt32().Should().Be(3);
     }
 
     [Fact]

--- a/Trellis.Core/generator/RequiredPartialClassGenerator.cs
+++ b/Trellis.Core/generator/RequiredPartialClassGenerator.cs
@@ -1197,9 +1197,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {rangeMin})
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {rangeMin})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})));
             if (value > {rangeMax})
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {rangeMax})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             string? additionalError = null;{vaInit}
             ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
@@ -1213,8 +1213,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
-                .Ensure(x => x >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(x => x <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                .Ensure(x => x >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {rangeMin})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
+                .Ensure(x => x <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {rangeMax})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;{vaInit}
@@ -1234,8 +1234,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => int.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedInt), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatInteger) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid integer."" }}))){notDefaultParsedEnsure}
-                .Ensure(_ => parsedInt >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
-                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
+                .Ensure(_ => parsedInt >= {rangeMin}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {rangeMin})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeMin}."" }})))
+                .Ensure(_ => parsedInt <= {rangeMax}, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {rangeMax})) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeMax}."" }})));
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;{vaInit}
@@ -1475,9 +1475,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {minStr}m)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {minStr}m)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})));
             if (value > {maxStr}m)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {maxStr}m)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             string? additionalError = null;{vaInit}
             ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
@@ -1491,8 +1491,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
-                .Ensure(x => x >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(x => x <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                .Ensure(x => x >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {minStr}m)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
+                .Ensure(x => x <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {maxStr}m)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;{vaInit}
@@ -1512,8 +1512,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => decimal.TryParse(x, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out parsedDecimal), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatDecimal) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid decimal."" }}))){notDefaultParsedEnsure}
-                .Ensure(_ => parsedDecimal >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{minStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
-                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{maxStr}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
+                .Ensure(_ => parsedDecimal >= {minStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {minStr}m)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {minStr}."" }})))
+                .Ensure(_ => parsedDecimal <= {maxStr}m, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {maxStr}m)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {maxStr}."" }})));
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;{vaInit}
@@ -1673,7 +1673,7 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
         // The bound is always zero for these four attributes, so it is emitted as a literal arg
         // rather than threaded through: a client comparing against `comparisonValue` gets the same
         // operand it would get from an explicit [Range], which is what producer independence means.
-        const string args = @"ValidationArgs.Of(""comparisonValue"", ""0"")";
+        const string args = @"ValidationArgs.Of(""comparisonValue"", 0)";
 
         var ifCheck = $@"
             if (value {compareOp})
@@ -1758,9 +1758,9 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             using var activity = PrimitiveValueObjectTrace.ActivitySource.StartActivity(""{g.ClassName}.TryCreate"");
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");{notDefaultIfCheck}
             if (value < {rangeLongMin}L)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {rangeLongMin}L)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})));
             if (value > {rangeLongMax}L)
-                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                return Result.Fail<{g.ClassName}>(new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {rangeLongMax}L)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             string? additionalError = null;{vaInit}
             ValidateAdditional(value, field, ref additionalError{vaArg});
             if (additionalError is not null)
@@ -1774,8 +1774,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
             var field = fieldName.NormalizeFieldName(""{g.ClassName.ToCamelCase()}"");
             var validated = valueOrNothing
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }}))){notDefaultNullableEnsure}
-                .Ensure(x => x >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                .Ensure(x => x >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {rangeLongMin}L)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
+                .Ensure(x => x <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {rangeLongMax}L)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             if (validated.TryGetValue(out var value))
             {{
                 string? additionalError = null;{vaInit}
@@ -1795,8 +1795,8 @@ public class RequiredPartialClassGenerator : IIncrementalGenerator
                 .ToResult(() => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotNull) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => !string.IsNullOrWhiteSpace(x), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.ValueNotEmpty) {{ Detail = ""{g.ClassName.SplitPascalCase()} cannot be empty."" }})))
                 .Ensure(x => long.TryParse(x, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out parsedLong), _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), ValidationCodes.FormatInteger) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be a valid long."" }}))){notDefaultParsedEnsure}
-                .Ensure(_ => parsedLong >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMin}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
-                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", ""{rangeLongMax}"")) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
+                .Ensure(_ => parsedLong >= {rangeLongMin}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMinCode}, ValidationArgs.Of(""comparisonValue"", {rangeLongMin}L)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at least {rangeLongMin}."" }})))
+                .Ensure(_ => parsedLong <= {rangeLongMax}L, _ => new Error.InvalidInput(EquatableArray.Create(new FieldViolation(InputPointer.ForProperty(field), {rangeMaxCode}, ValidationArgs.Of(""comparisonValue"", {rangeLongMax}L)) {{ Detail = ""{g.ClassName.SplitPascalCase()} must be at most {rangeLongMax}."" }})));
             if (validated.IsSuccess)
             {{
                 string? additionalError = null;{vaInit}

--- a/Trellis.Core/src/CompatibilitySuppressions.xml
+++ b/Trellis.Core/src/CompatibilitySuppressions.xml
@@ -1,5 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<!--
+  CP0002 on FieldViolation and RuleViolation (constructor, Deconstruct, and get_Args): the Args
+  member changed from ImmutableDictionary<string, string> to
+  ImmutableDictionary<string, ValidationArgValue>, a closed union of Text, Number, Bool and List.
+
+  Args exist so a client can render its own localized message rather than parse the server's
+  prose, and a string-valued dictionary forced every numeric operand onto the wire quoted -
+  "maxLength": "50" - so a client comparing a bound against a length had to parse it back out and
+  guess at the format. That is the recovery-by-parsing the args were introduced to end.
+
+  Deliberate wire-shape and source break, called out in the breaking-changes section of the
+  release notes. Regenerating this file drops hand-written comments; restore them when it is
+  regenerated, because the rationale is the point of recording the break here.
+-->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
@@ -108,7 +122,49 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.FieldViolation.#ctor(Trellis.InputPointer,System.String,System.Collections.Immutable.ImmutableDictionary{System.String,System.String},System.String)</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.FieldViolation.Deconstruct(Trellis.InputPointer@,System.String@,System.Collections.Immutable.ImmutableDictionary{System.String,System.String}@,System.String@)</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.FieldViolation.get_Args</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Trellis.ResultsTraceProviderBuilderExtensions.AddResultsInstrumentation(OpenTelemetry.Trace.TracerProviderBuilder)</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.RuleViolation.#ctor(System.String,Trellis.EquatableArray{Trellis.InputPointer},System.Collections.Immutable.ImmutableDictionary{System.String,System.String},System.String)</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.RuleViolation.Deconstruct(System.String@,Trellis.EquatableArray{Trellis.InputPointer}@,System.Collections.Immutable.ImmutableDictionary{System.String,System.String}@,System.String@)</Target>
+    <Left>lib/net10.0/Trellis.Core.dll</Left>
+    <Right>lib/net10.0/Trellis.Core.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Trellis.RuleViolation.get_Args</Target>
     <Left>lib/net10.0/Trellis.Core.dll</Left>
     <Right>lib/net10.0/Trellis.Core.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/Trellis.Core/src/Errors/Error.cs
+++ b/Trellis.Core/src/Errors/Error.cs
@@ -265,7 +265,7 @@ public abstract record Error
         /// <param name="args">Operands of the rule (e.g. <c>maxLength</c>, <c>comparisonValue</c>), built with <see cref="ValidationArgs"/>. Never put the rejected value itself here.</param>
         /// <param name="detail">Optional human-readable detail; when supplied the boundary renderer prefers it over the default template for <paramref name="reasonCode"/>.</param>
         /// <returns>An <see cref="InvalidInput"/> wrapping the single field violation.</returns>
-        public static InvalidInput ForField(string propertyName, string reasonCode, ImmutableDictionary<string, string>? args, string? detail = null) =>
+        public static InvalidInput ForField(string propertyName, string reasonCode, ImmutableDictionary<string, ValidationArgValue>? args, string? detail = null) =>
             ForField(InputPointer.ForProperty(propertyName), reasonCode, args, detail);
 
         /// <summary>
@@ -277,7 +277,7 @@ public abstract record Error
         /// <param name="args">Operands of the rule (e.g. <c>maxLength</c>, <c>comparisonValue</c>), built with <see cref="ValidationArgs"/>. Never put the rejected value itself here.</param>
         /// <param name="detail">Optional human-readable detail; when supplied the boundary renderer prefers it over the default template for <paramref name="reasonCode"/>.</param>
         /// <returns>An <see cref="InvalidInput"/> wrapping the single field violation.</returns>
-        public static InvalidInput ForField(InputPointer field, string reasonCode, ImmutableDictionary<string, string>? args, string? detail = null) =>
+        public static InvalidInput ForField(InputPointer field, string reasonCode, ImmutableDictionary<string, ValidationArgValue>? args, string? detail = null) =>
             new(EquatableArray.Create(new FieldViolation(field, reasonCode, args, detail)));
 
         /// <summary>
@@ -302,7 +302,7 @@ public abstract record Error
         /// <param name="args">Operands of the rule, built with <see cref="ValidationArgs"/>. Never put a rejected value itself here.</param>
         /// <param name="detail">Optional human-readable detail; when supplied the boundary renderer prefers it over the default template for <paramref name="reasonCode"/>.</param>
         /// <returns>An <see cref="InvalidInput"/> wrapping the single rule violation.</returns>
-        public static InvalidInput ForRule(string reasonCode, ImmutableDictionary<string, string>? args, string? detail = null) =>
+        public static InvalidInput ForRule(string reasonCode, ImmutableDictionary<string, ValidationArgValue>? args, string? detail = null) =>
             new(EquatableArray<FieldViolation>.Empty,
                 EquatableArray.Create(new RuleViolation(reasonCode, Args: args, Detail: detail)))
             { Detail = detail };

--- a/Trellis.Core/src/Errors/FieldViolation.cs
+++ b/Trellis.Core/src/Errors/FieldViolation.cs
@@ -15,8 +15,9 @@ using System.Collections.Immutable;
 /// dot-separated namespaces with <c>kebab-case</c> inside a segment.
 /// </param>
 /// <param name="Args">
-/// Optional structured arguments for the renderer (e.g. <c>{ "min": "3", "max": "50" }</c>
-/// for a length-range violation). Compared by value contents.
+/// Optional structured arguments for the renderer (e.g. <c>{ "min": 3, "max": 50 }</c>
+/// for a length-range violation). Build them with <see cref="ValidationArgs"/>. Compared by
+/// value contents.
 /// </param>
 /// <param name="Detail">
 /// Optional caller-supplied detail string. When non-null the boundary renderer prefers
@@ -25,7 +26,7 @@ using System.Collections.Immutable;
 public sealed record FieldViolation(
     InputPointer Field,
     string ReasonCode,
-    ImmutableDictionary<string, string>? Args = null,
+    ImmutableDictionary<string, ValidationArgValue>? Args = null,
     string? Detail = null)
 {
     /// <summary>
@@ -55,7 +56,7 @@ public sealed record FieldViolation(
     public override int GetHashCode() =>
         HashCode.Combine(Field, ReasonCode, Detail, ArgsHash(Args));
 
-    internal static bool DictionaryEquals(ImmutableDictionary<string, string>? a, ImmutableDictionary<string, string>? b)
+    internal static bool DictionaryEquals(ImmutableDictionary<string, ValidationArgValue>? a, ImmutableDictionary<string, ValidationArgValue>? b)
     {
         if (ReferenceEquals(a, b)) return true;
         var ca = a?.Count ?? 0;
@@ -63,12 +64,12 @@ public sealed record FieldViolation(
         if (ca != cb) return false;
         if (ca == 0) return true;
         foreach (var kv in a!)
-            if (!b!.TryGetValue(kv.Key, out var v) || !string.Equals(v, kv.Value, StringComparison.Ordinal))
+            if (!b!.TryGetValue(kv.Key, out var v) || !Equals(v, kv.Value))
                 return false;
         return true;
     }
 
-    internal static int ArgsHash(ImmutableDictionary<string, string>? p)
+    internal static int ArgsHash(ImmutableDictionary<string, ValidationArgValue>? p)
     {
         if (p is null || p.Count == 0) return 0;
         var hc = 0;

--- a/Trellis.Core/src/Errors/RuleViolation.cs
+++ b/Trellis.Core/src/Errors/RuleViolation.cs
@@ -20,7 +20,8 @@ using System.Collections.Immutable;
 /// in a UI when no single field carries the violation).
 /// </param>
 /// <param name="Args">
-/// Optional structured arguments for the renderer. Compared by value contents.
+/// Optional structured arguments for the renderer. Build them with <see cref="ValidationArgs"/>.
+/// Compared by value contents.
 /// </param>
 /// <param name="Detail">
 /// Optional caller-supplied detail string. When non-null the boundary renderer prefers
@@ -29,7 +30,7 @@ using System.Collections.Immutable;
 public sealed record RuleViolation(
     string ReasonCode,
     EquatableArray<InputPointer> Fields = default,
-    ImmutableDictionary<string, string>? Args = null,
+    ImmutableDictionary<string, ValidationArgValue>? Args = null,
     string? Detail = null)
 {
     /// <summary>

--- a/Trellis.Core/src/Errors/ValidationArgValue.cs
+++ b/Trellis.Core/src/Errors/ValidationArgValue.cs
@@ -1,0 +1,238 @@
+﻿namespace Trellis;
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// The value of a single entry in the <c>Args</c> carried by a <see cref="FieldViolation"/> or
+/// <see cref="RuleViolation"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a closed union — <see cref="Text"/>, <see cref="Number"/>, or <see cref="List"/> — and
+/// the constructor is private so it stays closed. A client can therefore switch over it
+/// exhaustively, and the JSON shape of an arg is knowable from the type alone rather than from
+/// whatever a producer happened to pass.
+/// </para>
+/// <para>
+/// The predecessor of this type was <see cref="string"/>, which forced every operand onto the wire
+/// quoted: a length bound arrived as <c>"maxLength": "50"</c>, and a client that wanted to compare
+/// it against a length had to parse it back out, guessing at the format. Modelling the number as a
+/// number removes the guess — <c>"maxLength": 50</c> — while keeping the property that made
+/// <see cref="string"/> attractive in the first place, which is that no producer-side culture can
+/// leak into the payload. <see cref="Number"/> holds a <see cref="decimal"/> and is written by
+/// <see cref="System.Text.Json"/> invariantly, so a German server and an American one emit the same
+/// bytes.
+/// </para>
+/// <para>
+/// Args are still operands, not an echo of the caller's input. Never put the rejected value itself
+/// in here — a rejected password or token would then be reflected back in an error response and
+/// into whatever logs that response.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// ValidationArgs.Of("maxLength", 50)                     // {"maxLength": 50}
+/// ValidationArgs.Of("min", 0, "max", 255)                // {"min": 0, "max": 255}
+/// ValidationArgs.Of("allowed", ValidationArgValue.ListOf("red", "green"))
+/// </code>
+/// </example>
+[JsonConverter(typeof(ValidationArgValueJsonConverter))]
+public abstract record ValidationArgValue
+{
+    private ValidationArgValue()
+    {
+    }
+
+    /// <summary>A textual operand, written to JSON as a string.</summary>
+    /// <param name="Value">The text.</param>
+    public sealed record Text(string Value) : ValidationArgValue;
+
+    /// <summary>
+    /// A numeric operand, written to JSON as a number.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="decimal"/> backs every numeric operand rather than a case per CLR numeric type,
+    /// because JSON has a single number type and a client could not observe the distinction anyway.
+    /// It is the widest choice that keeps integers exact, which a <see cref="double"/> would not.
+    /// </remarks>
+    /// <param name="Value">The number.</param>
+    public sealed record Number(decimal Value) : ValidationArgValue;
+
+    /// <summary>
+    /// An ordered list of operands, written to JSON as an array.
+    /// </summary>
+    /// <remarks>
+    /// This is what lets a violation name a set — the permitted members behind an
+    /// <c>enum.name-undefined</c>, say — without a producer inventing a delimiter that a client
+    /// would then have to know to split on.
+    /// </remarks>
+    /// <param name="Items">The list members, in order.</param>
+    public sealed record List(EquatableArray<ValidationArgValue> Items) : ValidationArgValue;
+
+    /// <summary>Builds a <see cref="List"/> from the supplied items.</summary>
+    /// <param name="items">The list members, in order. May be empty.</param>
+    public static ValidationArgValue ListOf(params ValidationArgValue[] items) =>
+        new List(EquatableArray.Create(items ?? []));
+
+    /// <summary>Builds a <see cref="List"/> from a sequence.</summary>
+    /// <param name="items">The list members, in order.</param>
+    public static ValidationArgValue ListFrom(IEnumerable<ValidationArgValue> items) =>
+        new List(EquatableArray.From(items));
+
+    /// <summary>Wraps a string as <see cref="Text"/>.</summary>
+    /// <param name="value">The text.</param>
+    public static implicit operator ValidationArgValue(string value) => new Text(value);
+
+    /// <summary>Wraps an integer as <see cref="Number"/>.</summary>
+    /// <param name="value">The number.</param>
+    public static implicit operator ValidationArgValue(int value) => new Number(value);
+
+    /// <summary>Wraps a long as <see cref="Number"/>.</summary>
+    /// <param name="value">The number.</param>
+    public static implicit operator ValidationArgValue(long value) => new Number(value);
+
+    /// <summary>Wraps a decimal as <see cref="Number"/>.</summary>
+    /// <param name="value">The number.</param>
+    public static implicit operator ValidationArgValue(decimal value) => new Number(value);
+}
+
+/// <summary>
+/// Writes a <see cref="ValidationArgValue"/> as its underlying JSON primitive, and reads one back.
+/// </summary>
+/// <remarks>
+/// This is public because the <see cref="System.Text.Json"/> source generator requires an
+/// accessible converter type: a trimmed or AOT-published application whose
+/// <see cref="JsonSerializerContext"/> includes a violation payload cannot resolve an internal one,
+/// and fails to generate metadata for it at compile time.
+/// </remarks>
+public sealed class ValidationArgValueJsonConverter : JsonConverter<ValidationArgValue>
+{
+    /// <inheritdoc />
+    public override ValidationArgValue? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) =>
+        ReadValue(ref reader);
+
+    private static ValidationArgValue ReadValue(ref Utf8JsonReader reader) => reader.TokenType switch
+    {
+        JsonTokenType.String => new ValidationArgValue.Text(reader.GetString()!),
+        JsonTokenType.Number => ReadNumber(ref reader),
+        JsonTokenType.StartArray => ReadList(ref reader),
+        _ => throw new JsonException(
+            $"A validation arg must be a string, a number, or an array of those; found {reader.TokenType}."),
+    };
+
+    /// <summary>
+    /// Reads a numeric arg, rejecting any value a <see cref="decimal"/> cannot carry faithfully.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Utf8JsonReader.GetDecimal"/> alone is not safe here. It throws on a magnitude
+    /// beyond <see cref="decimal"/>'s range — a <see cref="FormatException"/>, which is not the
+    /// exception a <see cref="JsonConverter{T}"/> is expected to surface — and it silently
+    /// <em>rounds</em> anything it cannot hold exactly: <c>1E-100</c> becomes <c>0</c>, and
+    /// <c>0.00000000000000000000000000009</c> becomes <c>0.0000000000000000000000000001</c>.
+    /// </para>
+    /// <para>
+    /// An arg is an operand a client renders a message from, so a rounded value states a bound the
+    /// producer never wrote. Every such token is refused rather than rounded. Refusal is decided by
+    /// comparing significant digits, not by comparing text, so the ordinary spellings a non-.NET
+    /// producer may use — <c>1e2</c>, <c>1.50</c>, <c>-0</c> — are all accepted.
+    /// </para>
+    /// </remarks>
+    private static ValidationArgValue.Number ReadNumber(ref Utf8JsonReader reader)
+    {
+        if (!reader.TryGetDecimal(out var number))
+            throw new JsonException("A numeric validation arg is out of range for a decimal.");
+
+        if (!RepresentsExactly(number, RawToken(ref reader)))
+            throw new JsonException(
+                "A numeric validation arg carries more precision than a decimal can represent.");
+
+        return new ValidationArgValue.Number(number);
+    }
+
+    private static string RawToken(ref Utf8JsonReader reader) =>
+        Encoding.UTF8.GetString(reader.HasValueSequence
+            ? System.Buffers.BuffersExtensions.ToArray(reader.ValueSequence)
+            : reader.ValueSpan);
+
+    /// <summary>
+    /// True when <paramref name="number"/> carries exactly the value <paramref name="token"/> spells.
+    /// </summary>
+    private static bool RepresentsExactly(decimal number, string token) =>
+        Significand(token) == Significand(number.ToString(CultureInfo.InvariantCulture));
+
+    /// <summary>
+    /// Reduces a JSON number to the canonical form <c>sign, digits, exponent</c>, where
+    /// <c>digits</c> carries no leading or trailing zero. Two spellings of the same value — and only
+    /// those — share a form, so <c>1e2</c> and <c>100</c> agree while <c>1E-100</c> and <c>0</c>
+    /// do not.
+    /// </summary>
+    private static (bool Negative, string Digits, int Exponent) Significand(string token)
+    {
+        var body = token;
+        var negative = body.StartsWith('-');
+        if (negative || body.StartsWith('+'))
+            body = body[1..];
+
+        var exponent = 0;
+        var marker = body.IndexOfAny(['e', 'E']);
+        if (marker >= 0)
+        {
+            exponent = int.Parse(body[(marker + 1)..], NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+            body = body[..marker];
+        }
+
+        var point = body.IndexOf('.');
+        if (point >= 0)
+        {
+            exponent -= body.Length - point - 1;
+            body = string.Concat(body[..point], body[(point + 1)..]);
+        }
+
+        var digits = body.TrimStart('0');
+        var trimmed = digits.TrimEnd('0');
+        exponent += digits.Length - trimmed.Length;
+
+        // Zero has one canonical form; -0, 0.0 and 0e5 must not read as three different values.
+        return trimmed.Length == 0 ? (false, string.Empty, 0) : (negative, trimmed, exponent);
+    }
+
+    private static ValidationArgValue.List ReadList(ref Utf8JsonReader reader)
+    {
+        var items = ImmutableArray.CreateBuilder<ValidationArgValue>();
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            items.Add(ReadValue(ref reader));
+
+        return new ValidationArgValue.List(new EquatableArray<ValidationArgValue>(items.ToImmutable()));
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ValidationArgValue value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case ValidationArgValue.Text text:
+                writer.WriteStringValue(text.Value);
+                break;
+            case ValidationArgValue.Number number:
+                writer.WriteNumberValue(number.Value);
+                break;
+            case ValidationArgValue.List list:
+                writer.WriteStartArray();
+                foreach (var item in list.Items)
+                    Write(writer, item, options);
+                writer.WriteEndArray();
+                break;
+            default:
+                throw new JsonException($"Unsupported validation arg value: {value.GetType().Name}.");
+        }
+    }
+}

--- a/Trellis.Core/src/Errors/ValidationArgValue.cs
+++ b/Trellis.Core/src/Errors/ValidationArgValue.cs
@@ -13,10 +13,18 @@ using System.Text.Json.Serialization;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is a closed union — <see cref="Text"/>, <see cref="Number"/>, or <see cref="List"/> — and
-/// the constructor is private so it stays closed. A client can therefore switch over it
-/// exhaustively, and the JSON shape of an arg is knowable from the type alone rather than from
-/// whatever a producer happened to pass.
+/// This is a closed union — <see cref="Text"/>, <see cref="Number"/>, <see cref="Bool"/>, or
+/// <see cref="List"/> — and the constructor is private so it stays closed. A client can therefore
+/// switch over it exhaustively, and the JSON shape of an arg is knowable from the type alone rather
+/// than from whatever a producer happened to pass.
+/// </para>
+/// <para>
+/// The cases are JSON's self-describing values: its three scalars, plus a list of them. JSON's
+/// other two constructs are deliberately absent. <c>null</c> would give a dictionary two spellings
+/// of the same thing, since an arg with no value is an arg that is simply not there. An object
+/// would mean a client needs a schema per reason code to know what it is looking at, which gives up
+/// the property that makes this union worth having — that the shape follows from the type — and
+/// turns args into an open-ended payload, which is a poor thing to echo back to a caller.
 /// </para>
 /// <para>
 /// The predecessor of this type was <see cref="string"/>, which forced every operand onto the wire
@@ -64,6 +72,20 @@ public abstract record ValidationArgValue
     public sealed record Number(decimal Value) : ValidationArgValue;
 
     /// <summary>
+    /// A boolean operand, written to JSON as <c>true</c> or <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// A boolean is rarely interpolated into a rendered message — you cannot put <c>true</c> into a
+    /// localized sentence — and a flag that selects <em>which</em> message to render usually belongs
+    /// in the reason code, which is the branch point a client is meant to switch on. The case exists
+    /// nonetheless because this union models JSON: without it a producer with a boolean operand has
+    /// to write <c>Text("true")</c>, which is the quoted-primitive problem this type was introduced
+    /// to remove, and a boolean arriving from a non-.NET producer would fail the whole payload.
+    /// </remarks>
+    /// <param name="Value">The flag.</param>
+    public sealed record Bool(bool Value) : ValidationArgValue;
+
+    /// <summary>
     /// An ordered list of operands, written to JSON as an array.
     /// </summary>
     /// <remarks>
@@ -99,6 +121,10 @@ public abstract record ValidationArgValue
     /// <summary>Wraps a decimal as <see cref="Number"/>.</summary>
     /// <param name="value">The number.</param>
     public static implicit operator ValidationArgValue(decimal value) => new Number(value);
+
+    /// <summary>Wraps a boolean as <see cref="Bool"/>.</summary>
+    /// <param name="value">The flag.</param>
+    public static implicit operator ValidationArgValue(bool value) => new Bool(value);
 }
 
 /// <summary>
@@ -123,9 +149,10 @@ public sealed class ValidationArgValueJsonConverter : JsonConverter<ValidationAr
     {
         JsonTokenType.String => new ValidationArgValue.Text(reader.GetString()!),
         JsonTokenType.Number => ReadNumber(ref reader),
+        JsonTokenType.True or JsonTokenType.False => new ValidationArgValue.Bool(reader.GetBoolean()),
         JsonTokenType.StartArray => ReadList(ref reader),
         _ => throw new JsonException(
-            $"A validation arg must be a string, a number, or an array of those; found {reader.TokenType}."),
+            $"A validation arg must be a string, a number, a boolean, or an array of those; found {reader.TokenType}."),
     };
 
     /// <summary>
@@ -224,6 +251,9 @@ public sealed class ValidationArgValueJsonConverter : JsonConverter<ValidationAr
                 break;
             case ValidationArgValue.Number number:
                 writer.WriteNumberValue(number.Value);
+                break;
+            case ValidationArgValue.Bool flag:
+                writer.WriteBooleanValue(flag.Value);
                 break;
             case ValidationArgValue.List list:
                 writer.WriteStartArray();

--- a/Trellis.Core/src/Errors/ValidationArgs.cs
+++ b/Trellis.Core/src/Errors/ValidationArgs.cs
@@ -13,7 +13,8 @@ using System.Collections.Immutable;
 /// own localized message; a client that has only the English detail string cannot.
 /// </para>
 /// <para>
-/// The values are <see cref="ValidationArgValue"/> — a closed union of text, number, and list —
+/// The values are <see cref="ValidationArgValue"/> — a closed union of text, number, boolean, and
+/// list —
 /// rather than <see cref="object"/>. A number therefore reaches the wire as a number, so a client
 /// can compare it without parsing, while the union still denies a producer the chance to hand over
 /// an arbitrary object and let culture-sensitive formatting leak into the payload. The numeric

--- a/Trellis.Core/src/Errors/ValidationArgs.cs
+++ b/Trellis.Core/src/Errors/ValidationArgs.cs
@@ -13,11 +13,20 @@ using System.Collections.Immutable;
 /// own localized message; a client that has only the English detail string cannot.
 /// </para>
 /// <para>
-/// The values are <see cref="string"/> rather than <see cref="object"/> deliberately: they cross a
-/// JSON boundary, and letting a producer hand over an arbitrary object invites culture-sensitive
-/// formatting to leak into the wire. Callers format with
-/// <see cref="System.Globalization.CultureInfo.InvariantCulture"/> — see <see cref="Of(string, IFormattable)"/>,
-/// which does it for them.
+/// The values are <see cref="ValidationArgValue"/> — a closed union of text, number, and list —
+/// rather than <see cref="object"/>. A number therefore reaches the wire as a number, so a client
+/// can compare it without parsing, while the union still denies a producer the chance to hand over
+/// an arbitrary object and let culture-sensitive formatting leak into the payload. The numeric
+/// conversions are implicit, so <c>ValidationArgs.Of("max", 255)</c> needs no ceremony.
+/// </para>
+/// <para>
+/// There is deliberately no <see cref="IFormattable"/> overload. Adding one would make
+/// <c>ValidationArgs.Of("max", 255)</c> <em>ambiguous</em> — an <see cref="int"/> converts to
+/// <see cref="IFormattable"/> by boxing and to <see cref="ValidationArgValue"/> by a user-defined
+/// conversion, and neither target is better than the other — so every numeric call site would stop
+/// compiling. Its absence is what lets the implicit conversions bind. A value with no numeric or
+/// textual meaning of its own, such as a timestamp, must therefore be formatted explicitly and
+/// invariantly by the caller.
 /// </para>
 /// <para>
 /// Args are for operands, not for echoing what the caller sent. Never put the rejected value itself
@@ -30,29 +39,40 @@ public static class ValidationArgs
     /// <summary>Builds a single-entry args dictionary.</summary>
     /// <param name="name">The operand name, in <c>camelCase</c>.</param>
     /// <param name="value">The operand value.</param>
-    public static ImmutableDictionary<string, string> Of(string name, string value) =>
-        ImmutableDictionary<string, string>.Empty.Add(name, value);
-
-    /// <summary>
-    /// Builds a single-entry args dictionary, formatting <paramref name="value"/> with the invariant
-    /// culture so the wire representation does not vary by server locale.
-    /// </summary>
-    /// <param name="name">The operand name, in <c>camelCase</c>.</param>
-    /// <param name="value">The operand value.</param>
-    public static ImmutableDictionary<string, string> Of(string name, IFormattable value) =>
-        Of(name, value.ToString(null, System.Globalization.CultureInfo.InvariantCulture));
+    public static ImmutableDictionary<string, ValidationArgValue> Of(string name, ValidationArgValue value) =>
+        ImmutableDictionary<string, ValidationArgValue>.Empty.Add(name, value);
 
     /// <summary>Builds a two-entry args dictionary.</summary>
-    public static ImmutableDictionary<string, string> Of(string name1, string value1, string name2, string value2) =>
-        ImmutableDictionary<string, string>.Empty.Add(name1, value1).Add(name2, value2);
+    /// <param name="name1">The first operand name, in <c>camelCase</c>.</param>
+    /// <param name="value1">The first operand value.</param>
+    /// <param name="name2">The second operand name, in <c>camelCase</c>.</param>
+    /// <param name="value2">The second operand value.</param>
+    public static ImmutableDictionary<string, ValidationArgValue> Of(
+        string name1,
+        ValidationArgValue value1,
+        string name2,
+        ValidationArgValue value2) =>
+        ImmutableDictionary<string, ValidationArgValue>.Empty.Add(name1, value1).Add(name2, value2);
 
     /// <summary>
-    /// Builds a two-entry args dictionary, formatting both values with the invariant culture.
+    /// Builds an args dictionary of any size.
     /// </summary>
-    public static ImmutableDictionary<string, string> Of(string name1, IFormattable value1, string name2, IFormattable value2) =>
-        Of(
-            name1,
-            value1.ToString(null, System.Globalization.CultureInfo.InvariantCulture),
-            name2,
-            value2.ToString(null, System.Globalization.CultureInfo.InvariantCulture));
+    /// <remarks>
+    /// A rule with three or more operands is ordinary — a scale-and-precision failure carries four —
+    /// and without this overload a producer that needed one had to abandon <see cref="ValidationArgs"/>
+    /// and assemble the dictionary by hand.
+    /// </remarks>
+    /// <param name="pairs">The operand names, in <c>camelCase</c>, paired with their values.</param>
+    public static ImmutableDictionary<string, ValidationArgValue> Of(
+        params (string Name, ValidationArgValue Value)[] pairs)
+    {
+        if (pairs is null || pairs.Length == 0)
+            return ImmutableDictionary<string, ValidationArgValue>.Empty;
+
+        var builder = ImmutableDictionary.CreateBuilder<string, ValidationArgValue>();
+        foreach (var (name, value) in pairs)
+            builder[name] = value;
+
+        return builder.ToImmutable();
+    }
 }

--- a/Trellis.Core/tests/Errors/ValidationArgValueTests.cs
+++ b/Trellis.Core/tests/Errors/ValidationArgValueTests.cs
@@ -21,6 +21,27 @@ public class ValidationArgValueTests
     public void Number_preserves_the_scale_it_was_given() =>
         Serialize(new ValidationArgValue.Number(1.50m)).Should().Be("1.50");
 
+    [Theory]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    public void Bool_serializes_as_a_json_boolean_not_a_string(bool value, string expected) =>
+        Serialize(new ValidationArgValue.Bool(value)).Should().Be(expected);
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void Bool_reads_back_from_a_json_boolean(string json, bool expected) =>
+        JsonSerializer.Deserialize<ValidationArgValue>(json)
+            .Should().BeOfType<ValidationArgValue.Bool>()
+            .Which.Value.Should().Be(expected);
+
+    [Fact]
+    public void Bool_converts_implicitly_so_a_flag_need_not_be_quoted()
+    {
+        ValidationArgValue value = true;
+        value.Should().Be(new ValidationArgValue.Bool(true));
+    }
+
     [Fact]
     public void Number_is_written_invariantly_under_a_comma_decimal_culture()
     {
@@ -58,7 +79,9 @@ public class ValidationArgValueTests
     [InlineData("\"abc\"")]
     [InlineData("255")]
     [InlineData("1.50")]
-    [InlineData("[\"a\",1]")]
+    [InlineData("true")]
+    [InlineData("false")]
+    [InlineData("[\"a\",1,true]")]
     [InlineData("[]")]
     public void Round_trips_through_json(string json)
     {
@@ -67,10 +90,14 @@ public class ValidationArgValueTests
         Serialize(value!).Should().Be(json);
     }
 
-    [Fact]
-    public void Reading_an_unsupported_token_fails_rather_than_inventing_a_case()
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"nested\":1}")]
+    public void Reading_an_unsupported_token_fails_rather_than_inventing_a_case(string json)
     {
-        var read = () => JsonSerializer.Deserialize<ValidationArgValue>("true");
+        // An object would need a schema per reason code to interpret, which is exactly the
+        // knowable-from-the-type property the union exists to keep.
+        var read = () => JsonSerializer.Deserialize<ValidationArgValue>(json);
         read.Should().Throw<JsonException>();
     }
 

--- a/Trellis.Core/tests/Errors/ValidationArgValueTests.cs
+++ b/Trellis.Core/tests/Errors/ValidationArgValueTests.cs
@@ -1,0 +1,159 @@
+﻿namespace Trellis.Core.Tests.Errors;
+
+using System.Globalization;
+using System.Text.Json;
+using FluentAssertions;
+using Trellis;
+
+public class ValidationArgValueTests
+{
+    private static string Serialize(ValidationArgValue value) => JsonSerializer.Serialize(value);
+
+    [Fact]
+    public void Text_serializes_as_a_json_string() =>
+        Serialize(new ValidationArgValue.Text("abc")).Should().Be("\"abc\"");
+
+    [Fact]
+    public void Number_serializes_as_a_json_number_not_a_string() =>
+        Serialize(new ValidationArgValue.Number(255m)).Should().Be("255");
+
+    [Fact]
+    public void Number_preserves_the_scale_it_was_given() =>
+        Serialize(new ValidationArgValue.Number(1.50m)).Should().Be("1.50");
+
+    [Fact]
+    public void Number_is_written_invariantly_under_a_comma_decimal_culture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            Serialize(new ValidationArgValue.Number(1.5m)).Should().Be("1.5");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void List_serializes_as_a_json_array()
+    {
+        var value = ValidationArgValue.ListOf("red", "green");
+        Serialize(value).Should().Be("[\"red\",\"green\"]");
+    }
+
+    [Fact]
+    public void List_may_carry_numbers()
+    {
+        var value = ValidationArgValue.ListOf(1, 2, 3);
+        Serialize(value).Should().Be("[1,2,3]");
+    }
+
+    [Fact]
+    public void Empty_list_serializes_as_an_empty_array() =>
+        Serialize(ValidationArgValue.ListOf()).Should().Be("[]");
+
+    [Theory]
+    [InlineData("\"abc\"")]
+    [InlineData("255")]
+    [InlineData("1.50")]
+    [InlineData("[\"a\",1]")]
+    [InlineData("[]")]
+    public void Round_trips_through_json(string json)
+    {
+        var value = JsonSerializer.Deserialize<ValidationArgValue>(json);
+        value.Should().NotBeNull();
+        Serialize(value!).Should().Be(json);
+    }
+
+    [Fact]
+    public void Reading_an_unsupported_token_fails_rather_than_inventing_a_case()
+    {
+        var read = () => JsonSerializer.Deserialize<ValidationArgValue>("true");
+        read.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Reading_null_yields_null_rather_than_a_case() =>
+        JsonSerializer.Deserialize<ValidationArgValue>("null").Should().BeNull();
+
+    [Theory]
+    [InlineData("1E-100")]
+    [InlineData("1E+100")]
+    [InlineData("0.00000000000000000000000000001")]
+    [InlineData("1.00000000000000000000000000001")]
+    [InlineData("0.00000000000000000000000000009")]
+    public void Reading_a_number_no_decimal_can_represent_fails_rather_than_corrupting_it(string json)
+    {
+        // Rounding these publishes an operand the producer never wrote: 1E-100 lands on 0, and
+        // 0.00000000000000000000000000009 lands on a different non-zero value entirely.
+        var read = () => JsonSerializer.Deserialize<ValidationArgValue>(json);
+        read.Should().Throw<JsonException>();
+    }
+
+    [Theory]
+    [InlineData("1e2", "100")]
+    [InlineData("1E+2", "100")]
+    [InlineData("100", "100")]
+    [InlineData("1.50", "1.50")]
+    [InlineData("-0", "0")]
+    [InlineData("0.0", "0.0")]
+    [InlineData("-12.5", "-12.5")]
+    [InlineData("0", "0")]
+    public void Reading_a_number_accepts_every_spelling_a_decimal_can_hold_exactly(string json, string expected)
+    {
+        // Exactness is decided on significant digits, so a producer that writes 1e2 rather than 100
+        // is not punished for the spelling.
+        var value = JsonSerializer.Deserialize<ValidationArgValue>(json);
+
+        value.Should().BeOfType<ValidationArgValue.Number>()
+            .Which.Value.ToString(CultureInfo.InvariantCulture).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Lists_with_equal_contents_are_equal()
+    {
+        ValidationArgValue.ListOf("a", "b").Should().Be(ValidationArgValue.ListOf("a", "b"));
+        ValidationArgValue.ListOf("a", "b").GetHashCode()
+            .Should().Be(ValidationArgValue.ListOf("a", "b").GetHashCode());
+    }
+
+    [Fact]
+    public void Lists_with_different_contents_are_not_equal() =>
+        ValidationArgValue.ListOf("a", "b").Should().NotBe(ValidationArgValue.ListOf("b", "a"));
+
+    [Fact]
+    public void Text_and_number_are_distinct_even_when_they_render_alike() =>
+        new ValidationArgValue.Text("255").Should().NotBe(new ValidationArgValue.Number(255m));
+
+    [Theory]
+    [InlineData(255)]
+    [InlineData(-1)]
+    public void Int_converts_implicitly_to_number(int value)
+    {
+        ValidationArgValue converted = value;
+        converted.Should().Be(new ValidationArgValue.Number(value));
+    }
+
+    [Fact]
+    public void Long_converts_implicitly_to_number()
+    {
+        ValidationArgValue converted = 9_000_000_000L;
+        converted.Should().Be(new ValidationArgValue.Number(9_000_000_000m));
+    }
+
+    [Fact]
+    public void Decimal_converts_implicitly_to_number()
+    {
+        ValidationArgValue converted = 1.5m;
+        converted.Should().Be(new ValidationArgValue.Number(1.5m));
+    }
+
+    [Fact]
+    public void String_converts_implicitly_to_text()
+    {
+        ValidationArgValue converted = "abc";
+        converted.Should().Be(new ValidationArgValue.Text("abc"));
+    }
+}

--- a/Trellis.Core/tests/Errors/ValidationArgsTests.cs
+++ b/Trellis.Core/tests/Errors/ValidationArgsTests.cs
@@ -1,0 +1,98 @@
+﻿namespace Trellis.Core.Tests.Errors;
+
+using System.Text.Json;
+using FluentAssertions;
+using Trellis;
+
+public class ValidationArgsTests
+{
+    [Fact]
+    public void Of_pairs_a_name_with_a_number_without_quoting_it() =>
+        ValidationArgs.Of("maxLength", 50)["maxLength"]
+            .Should().Be(new ValidationArgValue.Number(50));
+
+    [Fact]
+    public void Of_pairs_a_name_with_text() =>
+        ValidationArgs.Of("expected", "USD")["expected"]
+            .Should().Be(new ValidationArgValue.Text("USD"));
+
+    [Fact]
+    public void Of_builds_two_entries()
+    {
+        var args = ValidationArgs.Of("min", 0, "max", 255);
+
+        args.Should().HaveCount(2);
+        args["min"].Should().Be(new ValidationArgValue.Number(0));
+        args["max"].Should().Be(new ValidationArgValue.Number(255));
+    }
+
+    [Fact]
+    public void Of_builds_more_than_two_entries()
+    {
+        var args = ValidationArgs.Of(
+            ("expectedPrecision", 3),
+            ("expectedScale", 1),
+            ("actualScale", 4),
+            ("digits", 5));
+
+        args.Should().HaveCount(4);
+        args["actualScale"].Should().Be(new ValidationArgValue.Number(4));
+    }
+
+    [Fact]
+    public void Of_mixes_text_numbers_and_lists_in_one_call()
+    {
+        var args = ValidationArgs.Of(
+            ("expected", "red"),
+            ("allowed", ValidationArgValue.ListOf("red", "green")),
+            ("maxChoices", 2));
+
+        args["expected"].Should().Be(new ValidationArgValue.Text("red"));
+        args["allowed"].Should().Be(ValidationArgValue.ListOf("red", "green"));
+        args["maxChoices"].Should().Be(new ValidationArgValue.Number(2));
+    }
+
+    [Fact]
+    public void Of_with_no_pairs_is_empty() =>
+        ValidationArgs.Of().Should().BeEmpty();
+
+    [Fact]
+    public void Of_lets_a_later_pair_win_over_an_earlier_one_of_the_same_name() =>
+        ValidationArgs.Of(("max", 1), ("max", 2))["max"]
+            .Should().Be(new ValidationArgValue.Number(2));
+
+    [Fact]
+    public void A_violations_args_reach_the_wire_as_json_numbers_and_arrays()
+    {
+        var violation = new FieldViolation(
+            InputPointer.ForProperty("colour"),
+            "colour.not-allowed",
+            ValidationArgs.Of(("maxChoices", 2), ("allowed", ValidationArgValue.ListOf("red", "green"))));
+
+        var json = JsonSerializer.SerializeToElement(violation.Args);
+
+        json.GetProperty("maxChoices").ValueKind.Should().Be(JsonValueKind.Number);
+        json.GetProperty("maxChoices").GetInt32().Should().Be(2);
+        json.GetProperty("allowed").ValueKind.Should().Be(JsonValueKind.Array);
+        json.GetProperty("allowed").EnumerateArray().Select(e => e.GetString()).Should().Equal(["red", "green"]);
+    }
+
+    [Fact]
+    public void Violations_with_equal_args_are_equal()
+    {
+        var left = new FieldViolation(InputPointer.ForProperty("a"), "code", ValidationArgs.Of("max", 1));
+        var right = new FieldViolation(InputPointer.ForProperty("a"), "code", ValidationArgs.Of("max", 1));
+
+        left.Should().Be(right);
+        left.GetHashCode().Should().Be(right.GetHashCode());
+    }
+
+    [Fact]
+    public void A_numeric_arg_and_its_textual_twin_do_not_make_violations_equal()
+    {
+        var number = new FieldViolation(InputPointer.ForProperty("a"), "code", ValidationArgs.Of("max", 1));
+        var text = new FieldViolation(InputPointer.ForProperty("a"), "code", ValidationArgs.Of("max", "1"));
+
+        number.Should().NotBe(text);
+    }
+}

--- a/Trellis.FluentValidation/src/ValidationArgsProjection.cs
+++ b/Trellis.FluentValidation/src/ValidationArgsProjection.cs
@@ -121,7 +121,7 @@ public static class ValidationArgsProjection
     /// The application's widening of the default allowlist, or <see langword="null"/> to apply the
     /// framework default alone.
     /// </param>
-    public static ImmutableDictionary<string, string>? Project(
+    public static ImmutableDictionary<string, ValidationArgValue>? Project(
         ValidationFailure failure,
         ValidationArgsOptions? options = null)
     {
@@ -137,7 +137,7 @@ public static class ValidationArgsProjection
             return null;
 
         var template = ResolveTemplate(failure.ErrorCode);
-        ImmutableDictionary<string, string>.Builder? builder = null;
+        ImmutableDictionary<string, ValidationArgValue>.Builder? builder = null;
 
         foreach (var name in allowed)
         {
@@ -158,12 +158,52 @@ public static class ValidationArgsProjection
             if (!IsReconciled(encoded, rendered, failure.ErrorMessage))
                 continue;
 
-            (builder ??= ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal))
-                [ToCamelCase(name)] = encoded;
+            (builder ??= ImmutableDictionary.CreateBuilder<string, ValidationArgValue>(StringComparer.Ordinal))
+                [ToCamelCase(name)] = Lift(raw, encoded);
         }
 
         return builder?.ToImmutable();
     }
+
+    /// <summary>
+    /// Lifts the gated encoding onto the wire union without revisiting the gate's decision.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The gate above runs on strings and must keep doing so: it decides by comparing against the
+    /// message FluentValidation rendered, and that message is text. Nothing here can admit an arg
+    /// the gate rejected, because this runs only on values that already passed it.
+    /// </para>
+    /// <para>
+    /// What changes is representation, and only for a value whose CLR type is numeric to begin
+    /// with — so a threshold reaches the client as <c>50</c> rather than <c>"50"</c>, and a client
+    /// comparing it against a length no longer has to parse it back out.
+    /// </para>
+    /// <para>
+    /// The lift is applied only when the decimal round-trips to the very text the gate approved.
+    /// That is stricter than "parses", deliberately: <c>decimal.TryParse</c> <em>succeeds</em> on
+    /// <c>1E-100</c> and yields zero, so a bound the client was shown as <c>1E-100</c> would be
+    /// published as <c>0</c> — an operand no producer wrote, and one the gate never saw. Requiring
+    /// the round-trip also disposes of the overflow case, where the parse simply fails. Such a
+    /// value stays text, which is exactly what it was before this union existed.
+    /// </para>
+    /// </remarks>
+    private static ValidationArgValue Lift(object raw, string encoded) =>
+        IsNumeric(raw)
+        && decimal.TryParse(encoded, NumberStyles.Float, CultureInfo.InvariantCulture, out var number)
+        && string.Equals(number.ToString(CultureInfo.InvariantCulture), encoded, StringComparison.Ordinal)
+            ? new ValidationArgValue.Number(number)
+            : new ValidationArgValue.Text(encoded);
+
+    /// <summary>
+    /// True for the CLR numeric types, which are the only ones whose args become JSON numbers.
+    /// </summary>
+    /// <remarks>
+    /// An <see cref="Enum"/> is deliberately excluded despite its numeric backing: it is encoded by
+    /// name, and a client matching on the name would be handed an ordinal it cannot interpret.
+    /// </remarks>
+    private static bool IsNumeric(object value) =>
+        value is byte or sbyte or short or ushort or int or uint or long or ulong or decimal or float or double;
 
     /// <summary>
     /// The containment gate: an arg is emitted only when the active message template named that

--- a/Trellis.FluentValidation/tests/ValidationArgsOptionsTests.cs
+++ b/Trellis.FluentValidation/tests/ValidationArgsOptionsTests.cs
@@ -39,7 +39,7 @@ public class ValidationArgsOptionsTests
 
         var violation = Violate(MinimumAgeRule, new Subject(N: 12), options);
 
-        violation.Args!["minAge"].Should().Be("18");
+        violation.Args!["minAge"].Should().Be(new ValidationArgValue.Number(18));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class ValidationArgsOptionsTests
             new Subject(N: 1),
             options);
 
-        violation.Args!["comparisonValue"].Should().Be("5");
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Number(5));
         violation.Args.Should().NotContainKey("propertyName",
             "PropertyName is on the universal denylist, so widening cannot reintroduce it");
     }
@@ -145,7 +145,7 @@ public class ValidationArgsOptionsTests
 
         var violation = Violate(v => v.RuleFor(x => x.N).GreaterThan(5), new Subject(N: 1), options);
 
-        violation.Args!["comparisonValue"].Should().Be("5");
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Number(5));
     }
 
     [Fact]

--- a/Trellis.FluentValidation/tests/ValidationArgsProjectionTests.cs
+++ b/Trellis.FluentValidation/tests/ValidationArgsProjectionTests.cs
@@ -11,7 +11,7 @@ using Trellis.FluentValidation;
 /// </summary>
 public class ValidationArgsProjectionTests
 {
-    private sealed record Subject(string A = "", string B = "", decimal D = 0m, int N = 0, DateTime When = default);
+    private sealed record Subject(string A = "", string B = "", decimal D = 0m, int N = 0, DateTime When = default, double F = 0d);
 
     private static FieldViolation Violate(Action<InlineValidator<Subject>> configure, Subject subject)
     {
@@ -25,14 +25,32 @@ public class ValidationArgsProjectionTests
     }
 
     [Fact]
+    public void A_double_bound_a_decimal_cannot_represent_stays_text_rather_than_becoming_zero()
+    {
+        // Lifting this to a decimal underflows it to 0, publishing a bound of zero that the gate
+        // never approved — the client was shown 1E-100.
+        var violation = Violate(v => v.RuleFor(x => x.F).GreaterThan(1E-100), new Subject(F: 0d));
+
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Text("1E-100"));
+    }
+
+    [Fact]
+    public void A_double_bound_a_decimal_represents_exactly_is_still_lifted_to_a_number()
+    {
+        var violation = Violate(v => v.RuleFor(x => x.F).GreaterThan(1.5), new Subject(F: 0d));
+
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Number(1.5m));
+    }
+
+    [Fact]
     public void Length_emits_both_bounds_and_the_submitted_length()
     {
         var violation = Violate(v => v.RuleFor(x => x.A).Length(2, 4), new Subject(A: "abcdefgh"));
 
         violation.Args.Should().NotBeNull();
-        violation.Args!["minLength"].Should().Be("2");
-        violation.Args["maxLength"].Should().Be("4");
-        violation.Args["totalLength"].Should().Be("8");
+        violation.Args!["minLength"].Should().Be(new ValidationArgValue.Number(2));
+        violation.Args["maxLength"].Should().Be(new ValidationArgValue.Number(4));
+        violation.Args["totalLength"].Should().Be(new ValidationArgValue.Number(8));
     }
 
     [Fact]
@@ -42,7 +60,7 @@ public class ValidationArgsProjectionTests
 
         violation.Args!.Should().NotContainKey("minLength",
             "FluentValidation populates MinLength = 0 on a MaximumLength failure, and a client rendering 'between 0 and 3' from it would be wrong");
-        violation.Args["maxLength"].Should().Be("3");
+        violation.Args["maxLength"].Should().Be(new ValidationArgValue.Number(3));
     }
 
     [Fact]
@@ -52,7 +70,7 @@ public class ValidationArgsProjectionTests
 
         violation.Args!.Should().NotContainKey("maxLength",
             "MaxLength is -1 here, which is meaningless rather than merely unhelpful");
-        violation.Args["minLength"].Should().Be("50");
+        violation.Args["minLength"].Should().Be(new ValidationArgValue.Number(50));
     }
 
     [Fact]
@@ -62,8 +80,8 @@ public class ValidationArgsProjectionTests
 
         violation.Args.Should().NotBeNull(
             "ExactLengthValidator derives from LengthValidator with base(n, n) so both bounds carry the right value, but only MaxLength is named by its template - allowlisting MinLength instead would gate every arg out and leave the client a length with no bound to compare it against");
-        violation.Args!["maxLength"].Should().Be("4");
-        violation.Args["totalLength"].Should().Be("8");
+        violation.Args!["maxLength"].Should().Be(new ValidationArgValue.Number(4));
+        violation.Args["totalLength"].Should().Be(new ValidationArgValue.Number(8));
     }
 
     [Fact]
@@ -104,7 +122,7 @@ public class ValidationArgsProjectionTests
             v => v.RuleFor(x => x.A).Equal("expected-literal"),
             new Subject(A: "other"));
 
-        violation.Args!["comparisonValue"].Should().Be("expected-literal");
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Text("expected-literal"));
     }
 
     [Fact]
@@ -115,9 +133,12 @@ public class ValidationArgsProjectionTests
             v => v.RuleFor(x => x.A).Equal(x => x.B),
             new Subject(A: "other", B: long_));
 
-        violation.Args!["comparisonValue"].Length.Should().BeLessThan(80,
+        var comparison = violation.Args!["comparisonValue"]
+            .Should().BeOfType<ValidationArgValue.Text>().Subject.Value;
+
+        comparison.Length.Should().BeLessThan(80,
             "no structural rule identifies which string args carry submitted input, so the bound is universal");
-        violation.Args["comparisonValue"].Should().EndWith("...");
+        comparison.Should().EndWith("...");
     }
 
     [Fact]
@@ -127,7 +148,7 @@ public class ValidationArgsProjectionTests
             v => v.RuleFor(x => x.A).Equal(x => x.B),
             new Subject(A: "other", B: "foo\0bar"));
 
-        violation.Args!["comparisonValue"].Should().Be("foo\\u0000bar",
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Text("foo\\u0000bar"),
             "escaping re-encodes a character the message already carried rather than revealing a new one, "
             + "so reconciliation must not demand that the escaped form appear in the message verbatim");
     }
@@ -176,8 +197,8 @@ public class ValidationArgsProjectionTests
             v => v.RuleFor(x => x.N).InclusiveBetween(1, 10),
             new Subject(N: 42));
 
-        violation.Args!["from"].Should().Be("1");
-        violation.Args["to"].Should().Be("10");
+        violation.Args!["from"].Should().Be(new ValidationArgValue.Number(1));
+        violation.Args["to"].Should().Be(new ValidationArgValue.Number(10));
     }
 
     [Fact]
@@ -187,8 +208,8 @@ public class ValidationArgsProjectionTests
             v => v.RuleFor(x => x.D).PrecisionScale(3, 1, ignoreTrailingZeros: true),
             new Subject(D: 123.45m));
 
-        violation.Args!["expectedPrecision"].Should().Be("3");
-        violation.Args["expectedScale"].Should().Be("1");
+        violation.Args!["expectedPrecision"].Should().Be(new ValidationArgValue.Number(3));
+        violation.Args["expectedScale"].Should().Be(new ValidationArgValue.Number(1));
     }
 
     [Fact]
@@ -222,7 +243,7 @@ public class ValidationArgsProjectionTests
             v => v.RuleFor(x => x.N).GreaterThan(10),
             new Subject(N: 3));
 
-        violation.Args!["comparisonValue"].Should().Be("10",
+        violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Number(10),
             "a numeric value encodes to exactly what FluentValidation rendered, so nothing is suppressed");
     }
 }

--- a/Trellis.Mediator.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
+++ b/Trellis.Mediator.FluentValidation/tests/FluentValidationMessageValidatorAdapterTests.cs
@@ -58,7 +58,7 @@ public class FluentValidationMessageValidatorAdapterTests
         var result = await adapter.ValidateAsync(new CreateUserCommand("Al", "alice@example.com"), CancellationToken.None);
 
         var violation = ((Error.InvalidInput)result.Error!).Fields[0];
-        violation.Args!["minNameLength"].Should().Be("3",
+        violation.Args!["minNameLength"].Should().Be(new ValidationArgValue.Number(3),
             "the adapter must read the same options the standalone helpers take as a parameter");
     }
 

--- a/Trellis.Primitives/src/Primitives/Age.cs
+++ b/Trellis.Primitives/src/Primitives/Age.cs
@@ -28,7 +28,7 @@ public class Age : ScalarValueObject<Age, int>, IScalarValue<Age, int>, IFormatt
     private Age(int value) : base(value) { }
 
     // Field-normalization + InvalidInput failure in one place (default field name: "age").
-    private static Result<Age> Invalid(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, string>? args = null) =>
+    private static Result<Age> Invalid(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, ValidationArgValue>? args = null) =>
         Result.Fail<Age>(
             Error.InvalidInput.ForField(fieldName.NormalizeFieldName("age"), reasonCode, args, message));
 
@@ -36,9 +36,9 @@ public class Age : ScalarValueObject<Age, int>, IScalarValue<Age, int>, IFormatt
     // Directional codes rather than one `between` code: a client that cannot tell which end failed
     // cannot say "too old" versus "not yet born", and the generator's range checks are directional,
     // so collapsing them here would make Age disagree with a generated primitive on the same input.
-    private static ImmutableDictionary<string, string> MinArgs { get; } = ValidationArgs.Of("comparisonValue", "0");
+    private static ImmutableDictionary<string, ValidationArgValue> MinArgs { get; } = ValidationArgs.Of("comparisonValue", 0);
 
-    private static ImmutableDictionary<string, string> MaxArgs { get; } = ValidationArgs.Of("comparisonValue", "150");
+    private static ImmutableDictionary<string, ValidationArgValue> MaxArgs { get; } = ValidationArgs.Of("comparisonValue", 150);
 
     // No-span validation core. Every public factory opens exactly one span, then delegates here.
     private static Result<Age> Validate(int value, string? fieldName)

--- a/Trellis.Primitives/src/Primitives/CompositeValueObjectJsonConverter.cs
+++ b/Trellis.Primitives/src/Primitives/CompositeValueObjectJsonConverter.cs
@@ -268,7 +268,7 @@ T> : JsonConverter<T>
     private static TrellisJsonValidationException Invalid(string message, InputPointer pointer, string reasonCode) =>
         Invalid(message, pointer, reasonCode, null);
 
-    private static TrellisJsonValidationException Invalid(string message, InputPointer pointer, string reasonCode, ImmutableDictionary<string, string>? args) =>
+    private static TrellisJsonValidationException Invalid(string message, InputPointer pointer, string reasonCode, ImmutableDictionary<string, ValidationArgValue>? args) =>
         new(message)
         {
             InvalidInput = Error.InvalidInput.ForField(pointer, reasonCode, args, message) with
@@ -281,9 +281,9 @@ T> : JsonConverter<T>
     // model binder already reports them for the same failure. Without this the same out-of-range
     // value would carry the bounds when it arrived as a query parameter and lose them when it
     // arrived nested in a JSON object.
-    private static ImmutableDictionary<string, string> ByteRangeArgs { get; } = ValidationArgs.Of("min", "0", "max", "255");
+    private static ImmutableDictionary<string, ValidationArgValue> ByteRangeArgs { get; } = ValidationArgs.Of("min", 0, "max", 255);
 
-    private static ImmutableDictionary<string, string>? FormatArgsFor(Type primitiveType) =>
+    private static ImmutableDictionary<string, ValidationArgValue>? FormatArgsFor(Type primitiveType) =>
         primitiveType == typeof(byte) ? ByteRangeArgs : null;
 
     /// <summary>

--- a/Trellis.Primitives/src/Primitives/MonetaryAmount.cs
+++ b/Trellis.Primitives/src/Primitives/MonetaryAmount.cs
@@ -30,10 +30,10 @@ public class MonetaryAmount : ScalarValueObject<MonetaryAmount, decimal>, IScala
     public static MonetaryAmount Zero => s_zero;
 
     // The comparison operand shared by every "must not be negative" check here.
-    private static ImmutableDictionary<string, string> ZeroArgs { get; } = ValidationArgs.Of("comparisonValue", "0");
+    private static ImmutableDictionary<string, ValidationArgValue> ZeroArgs { get; } = ValidationArgs.Of("comparisonValue", 0);
 
     // Field-normalization + InvalidInput failure in one place (default field name: "amount").
-    private static Result<MonetaryAmount> Invalid(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, string>? args = null) =>
+    private static Result<MonetaryAmount> Invalid(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, ValidationArgValue>? args = null) =>
         Result.Fail<MonetaryAmount>(
             Error.InvalidInput.ForField(fieldName.NormalizeFieldName("amount"), reasonCode, args, message));
 

--- a/Trellis.Primitives/src/Primitives/Money.cs
+++ b/Trellis.Primitives/src/Primitives/Money.cs
@@ -34,11 +34,11 @@ public class Money : ValueObject
 
     // The comparison operand shared by every "must not be negative" / "must be positive" check here.
     // Hoisted so the bound reaches the client structurally rather than only inside English prose.
-    private static ImmutableDictionary<string, string> ZeroArgs { get; } = ValidationArgs.Of("comparisonValue", "0");
+    private static ImmutableDictionary<string, ValidationArgValue> ZeroArgs { get; } = ValidationArgs.Of("comparisonValue", 0);
 
     // The two currencies that failed to match. A client rendering its own message needs both, and
     // ISO 4217 codes are validated symbols rather than free text, so they are safe to echo.
-    private static ImmutableDictionary<string, string> MismatchArgs(CurrencyCode expected, CurrencyCode actual) =>
+    private static ImmutableDictionary<string, ValidationArgValue> MismatchArgs(CurrencyCode expected, CurrencyCode actual) =>
         ValidationArgs.Of("expected", expected.Value, "actual", actual.Value);
 
     private Money(decimal amount, CurrencyCode currency)

--- a/Trellis.Primitives/src/Primitives/Percentage.cs
+++ b/Trellis.Primitives/src/Primitives/Percentage.cs
@@ -85,12 +85,12 @@ public class Percentage : ScalarValueObject<Percentage, decimal>, IScalarValue<P
     public static Percentage Full => _full;
 
     // Field-normalization + InvalidInput failure in one place (default field name: "percentage").
-    private static Result<Percentage> Invalid(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, string>? args = null) =>
+    private static Result<Percentage> Invalid(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, ValidationArgValue>? args = null) =>
         Result.Fail<Percentage>(
             Error.InvalidInput.ForField(fieldName.NormalizeFieldName("percentage"), reasonCode, args, message));
 
     // Field-normalization + InvalidInput failure in one place (default field name: "fraction").
-    private static Result<Percentage> InvalidFraction(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, string>? args = null) =>
+    private static Result<Percentage> InvalidFraction(string? fieldName, string reasonCode, string message, ImmutableDictionary<string, ValidationArgValue>? args = null) =>
         Result.Fail<Percentage>(
             Error.InvalidInput.ForField(fieldName.NormalizeFieldName("fraction"), reasonCode, args, message));
 
@@ -98,13 +98,13 @@ public class Percentage : ScalarValueObject<Percentage, decimal>, IScalarValue<P
     // code: a client that cannot tell which end failed cannot say "over 100%" versus "negative", and
     // the generator's range checks are directional, so collapsing them here would make Percentage
     // disagree with a generated primitive on the same input.
-    private static ImmutableDictionary<string, string> PercentMinArgs { get; } = ValidationArgs.Of("comparisonValue", "0");
+    private static ImmutableDictionary<string, ValidationArgValue> PercentMinArgs { get; } = ValidationArgs.Of("comparisonValue", 0);
 
-    private static ImmutableDictionary<string, string> PercentMaxArgs { get; } = ValidationArgs.Of("comparisonValue", "100");
+    private static ImmutableDictionary<string, ValidationArgValue> PercentMaxArgs { get; } = ValidationArgs.Of("comparisonValue", 100);
 
-    private static ImmutableDictionary<string, string> FractionMinArgs { get; } = ValidationArgs.Of("comparisonValue", "0");
+    private static ImmutableDictionary<string, ValidationArgValue> FractionMinArgs { get; } = ValidationArgs.Of("comparisonValue", 0);
 
-    private static ImmutableDictionary<string, string> FractionMaxArgs { get; } = ValidationArgs.Of("comparisonValue", "1");
+    private static ImmutableDictionary<string, ValidationArgValue> FractionMaxArgs { get; } = ValidationArgs.Of("comparisonValue", 1);
 
     // No-span validation core. Every public factory opens exactly one span, then delegates here.
     private static Result<Percentage> Validate(decimal value, string? fieldName) => value switch

--- a/Trellis.Primitives/tests/PrimitiveReasonCodeTests.cs
+++ b/Trellis.Primitives/tests/PrimitiveReasonCodeTests.cs
@@ -23,7 +23,7 @@ public class PrimitiveReasonCodeTests
         var violation = FirstViolation(Age.TryCreate(-1));
 
         violation.ReasonCode.Should().Be(ValidationCodes.ValueGreaterThanOrEqual);
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("comparisonValue", "0"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("comparisonValue", 0));
     }
 
     [Fact]
@@ -32,7 +32,7 @@ public class PrimitiveReasonCodeTests
         var violation = FirstViolation(Age.TryCreate(151));
 
         violation.ReasonCode.Should().Be(ValidationCodes.ValueLessThanOrEqual);
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("comparisonValue", "150"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("comparisonValue", 150));
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class PrimitiveReasonCodeTests
         // The caller passed a fraction, so `comparisonValue: 100` would name a bound they never
         // supplied a value against.
         FirstViolation(Percentage.FromFraction(1.5m)).Args
-            .Should().Contain(new KeyValuePair<string, string>("comparisonValue", "1"));
+            .Should().Contain(new KeyValuePair<string, ValidationArgValue>("comparisonValue", 1));
 
     [Theory]
     [InlineData(null, "value.not-null")]
@@ -76,7 +76,7 @@ public class PrimitiveReasonCodeTests
         var violation = FirstViolation(usd.Add(eur));
 
         violation.ReasonCode.Should().Be(ValidationCodes.MoneyCurrencyMismatch);
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("expected", "USD"));
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("actual", "EUR"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("expected", "USD"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("actual", "EUR"));
     }
 }

--- a/Trellis.Primitives/tests/ReasonCodeOverrideTests.cs
+++ b/Trellis.Primitives/tests/ReasonCodeOverrideTests.cs
@@ -114,8 +114,8 @@ public class ReasonCodeOverrideTests
     {
         var violation = FirstViolation(AccountReference.TryCreate("ab").UnwrapError());
 
-        violation.Args.Should().Contain("minLength", "3");
-        violation.Args.Should().Contain("totalLength", "2");
+        violation.Args.Should().Contain("minLength", new ValidationArgValue.Number(3));
+        violation.Args.Should().Contain("totalLength", new ValidationArgValue.Number(2));
     }
 
     [Fact]
@@ -123,8 +123,8 @@ public class ReasonCodeOverrideTests
     {
         var violation = FirstViolation(AccountReference.TryCreate("abcdefghi").UnwrapError());
 
-        violation.Args.Should().Contain("maxLength", "8");
-        violation.Args.Should().Contain("totalLength", "9");
+        violation.Args.Should().Contain("maxLength", new ValidationArgValue.Number(8));
+        violation.Args.Should().Contain("totalLength", new ValidationArgValue.Number(9));
     }
 
     [Fact]

--- a/Trellis.Primitives/tests/RequiredStringLengthTests.cs
+++ b/Trellis.Primitives/tests/RequiredStringLengthTests.cs
@@ -269,7 +269,7 @@ public class RequiredStringLengthTests
         // A client rendering "must be at most 10 characters" in its own locale needs the bound as
         // data; recovering it by parsing the English message is the failure mode args exist to end.
         violation.ReasonCode.Should().Be(ValidationCodes.StringMaxLength);
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("maxLength", "10"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("maxLength", 10));
     }
 
     [Fact]
@@ -278,6 +278,6 @@ public class RequiredStringLengthTests
         var violation = ((Error.InvalidInput)UserName.TryCreate("ab").UnwrapError()).Fields[0];
 
         violation.ReasonCode.Should().Be(ValidationCodes.StringMinLength);
-        violation.Args.Should().Contain(new KeyValuePair<string, string>("minLength", "3"));
+        violation.Args.Should().Contain(new KeyValuePair<string, ValidationArgValue>("minLength", 3));
     }
 }

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -455,7 +455,7 @@ public sealed record FieldViolationProblemDetail(
     string Code,
     string? Detail,
     ViolationLocation Location,
-    IReadOnlyDictionary<string, string>? Args);
+    IReadOnlyDictionary<string, ValidationArgValue>? Args);
 ```
 
 | Member | Type | Description |
@@ -463,7 +463,7 @@ public sealed record FieldViolationProblemDetail(
 | `Code` | `string` | The machine-readable reason code. |
 | `Detail` | `string?` | Human-readable explanation. Omitted when absent. |
 | `Location` | `ViolationLocation` | Where the offending value came from. |
-| `Args` | `IReadOnlyDictionary<string, string>?` | Arguments that parameterize the message, letting a client render its own localized prose. Omitted when absent. |
+| `Args` | `IReadOnlyDictionary<string, ValidationArgValue>?` | Arguments that parameterize the message, letting a client render its own localized prose. Omitted when absent. |
 
 AOT-friendly JSON payload used inside Problem Details `extensions["fieldViolations"]` for `Error.InvalidInput` field violations. Application code should treat this as response shape metadata, not as a domain model.
 
@@ -476,7 +476,7 @@ public sealed record RuleViolationProblemDetail(
     string Code,
     string? Detail,
     IReadOnlyList<ViolationLocation> Locations,
-    IReadOnlyDictionary<string, string>? Args);
+    IReadOnlyDictionary<string, ValidationArgValue>? Args);
 ```
 
 | Member | Type | Description |
@@ -484,7 +484,7 @@ public sealed record RuleViolationProblemDetail(
 | `Code` | `string` | The machine-readable reason code. |
 | `Detail` | `string?` | Human-readable explanation. Omitted when absent. |
 | `Locations` | `IReadOnlyList<ViolationLocation>` | Every location the rule spans. **Always present**: an empty array is a positive statement that the rule is form-level rather than bound to any field, which an omitted member could not express. |
-| `Args` | `IReadOnlyDictionary<string, string>?` | Arguments that parameterize the message. Omitted when absent. |
+| `Args` | `IReadOnlyDictionary<string, ValidationArgValue>?` | Arguments that parameterize the message. Omitted when absent. |
 
 AOT-friendly JSON payload used inside Problem Details `extensions["ruleViolations"]` for `Error.InvalidInput` rule violations. Application code should treat this as response shape metadata, not as a domain model.
 
@@ -1438,7 +1438,7 @@ public static class ValidationErrorsContext
 | `public static void AddError(string fieldName, string errorMessage)` | `void` | Appends a single field violation to the current scope, with `FieldViolation.ReasonCode` set to `error.unspecified` — a bare message carries no code to report. Use the `Error.InvalidInput` overload when the producer knows its code. No-op when no scope is active. Called by both reflection-mode (`ScalarValueJsonConverterBase<,,>`) and AOT-generated converters when `TryCreate` returns a non-`Error.InvalidInput` failure. |
 | `public static void AddError(Error.InvalidInput unprocessableContent)` | `void` | Merges every `FieldViolation` and `RuleViolation` in the supplied error into the current scope, preserving each violation's reason code, args, and detail. No-op when no scope is active. Called by both reflection-mode and AOT-generated converters when `TryCreate` returns an `Error.InvalidInput` failure. |
 | `public static void AddBodyError(string fieldName, string errorMessage)` | `void` | As `AddError(string, string)` — including the `error.unspecified` reason code — but locates the violation at `InputLocation.Body`. |
-| `public static void AddBodyError(string fieldName, string code, string message, IReadOnlyDictionary<string, string>? args = null)` | `void` | A coded body violation with optional renderer arguments. No-op when no scope is active. |
+| `public static void AddBodyError(string fieldName, string code, string message, IReadOnlyDictionary<string, ValidationArgValue>? args = null)` | `void` | A coded body violation with optional renderer arguments. No-op when no scope is active. |
 | `public static void AddBodyError(Error.InvalidInput unprocessableContent)` | `void` | As `AddError(Error.InvalidInput)`, but promotes every merged violation to `InputLocation.Body` when the producer left the location unspecified. The JSON pipeline is the one caller that knows by construction that everything it collects came out of the request document — a converter cannot state that itself, since the same converter runs for a body property and for a query-bound scalar. Violations carrying an explicit `Query`, `Path` or `Header` location pass through untouched. A violation already located in the body is prefixed with the current ancestor path but keeps its location; one with an unspecified location is prefixed **and** promoted to `InputLocation.Body`. |
 | `public static Error.InvalidInput? GetUnprocessableContent()` | `Error.InvalidInput?` | Returns the aggregated `Error.InvalidInput` for the current scope (with `Fields` / `Rules` populated from collected `FieldViolation`s) or `null` when no errors were collected. |
 
@@ -1467,7 +1467,7 @@ public static class ValidationErrorsContext
   - The context needs at least one `[JsonSerializable]`. Without it STJ skips the context entirely and never emits the abstract members the base class requires, failing the build with two CS0534 errors that say nothing about the cause. Trellis reports **TRLS059** to explain it.
   - Every value object reachable from a serialized type needs `[JsonConverter]` on the value object itself, for example `[JsonConverter(typeof(ParsableJsonConverter<OrderId>))]`. Otherwise STJ reaches the type transitively, treats it as a POCO, and emits `ObjectCreator = () => new OrderId()` — a constructor that does not exist on a Trellis value object, failing with CS1729 inside STJ's own generated file. When you declare it, the Trellis primitive generator detects the attribute and steps aside rather than emitting a duplicate (which would be CS0579).
   - **This applies only when the value object is declared in the same compilation as the context.** Generator blindness is a within-compilation problem: once a value object lives in a *referenced* assembly, the `[JsonConverter]` Trellis emitted has already been compiled into that assembly's metadata, so STJ reads it like any other attribute and routes the type through the converter without help. A solution that keeps value objects in a domain project and the `JsonSerializerContext` in the web project — the layout the Showcase uses — is unaffected and needs no hand-written `[JsonConverter]`.
-- **Binder conversion failures carry a reason code.** Route/query values that cannot be converted to the parameter's CLR type report a [`ValidationCodes`](trellis-api-core.md#validationcodes--the-reason-code-vocabulary) `format.*` code naming the target type — `format.integer`, `format.guid`, `format.date-time`, and so on, falling back to `format.conversion` when no more specific code applies. Out-of-range-for-type is *also* a `format.*` code (`int.TryParse("99999999999")` and `int.TryParse("abc")` both return `false` and are indistinguishable), except for `byte`, where the binder emits `format.integer` with `args: { min: "0", max: "255" }` so the bound survives structurally. Enums split two ways: a supplied name that is not a member of the enum reports `enum.name-undefined`, while a numeric value that parses into an undefined member reports `enum.undefined`.
+- **Binder conversion failures carry a reason code.** Route/query values that cannot be converted to the parameter's CLR type report a [`ValidationCodes`](trellis-api-core.md#validationcodes--the-reason-code-vocabulary) `format.*` code naming the target type — `format.integer`, `format.guid`, `format.date-time`, and so on, falling back to `format.conversion` when no more specific code applies. Out-of-range-for-type is *also* a `format.*` code (`int.TryParse("99999999999")` and `int.TryParse("abc")` both return `false` and are indistinguishable), except for `byte`, where the binder emits `format.integer` with `args: { min: 0, max: 255 }` so the bound survives structurally. Enums split two ways: a supplied name that is not a member of the enum reports `enum.name-undefined`, while a numeric value that parses into an undefined member reports `enum.undefined`.
 - **Absent, blank, and malformed are three different codes.** A missing value reports `value.not-null`; a value that arrived but is empty or whitespace reports `value.not-empty`; only a non-blank value the parser rejected reports `format.*`. Blank input is checked **before** the type parser for every non-`string` target, because whitespace cannot parse into any scalar — letting it reach `int.TryParse` would report `format.integer` for a failure that has nothing to do with integers. String-typed primitives are exempt: the empty-vs-required decision belongs to the value object's own `TryCreate`, since some scalar value objects legitimately accept an empty string.
 - **Minimal API scalar binding failures are metadata-driven.** When ASP.NET Core throws a 400 while binding route/query parameters, `ScalarValueValidationMiddleware` no longer parses `BadHttpRequestException.Message` to discover a field name or invalid value. It inspects `IParameterBindingMetadata`, reads the matching route/query raw value, and re-runs Trellis scalar validation for `IScalarValue<,>` / `Maybe<TScalar>` parameters. Non-scalar endpoint binding failures are rethrown to ASP.NET Core.
 - **Binder/JSON validation status is configurable.** All three validation seams — `ScalarValueValidationMiddleware`, `ScalarValueValidationFilter` (MVC), and `ScalarValueValidationEndpointFilter` (Minimal API) — resolve the semantic-validation status from the ambient `TrellisAspOptions` `Error.InvalidInput` mapping (default `422`), the same map domain handlers use via `ResponseFailureWriter`. A single `MapError<Error.InvalidInput>(status)` therefore governs scalar/value-object validation failures uniformly across the binder, the JSON body, and handlers. Syntactically malformed JSON is not remapped — it stays `400` (RFC 9110 §15.5.1).

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -774,20 +774,26 @@ Error.InvalidInput.ForField("age", ValidationCodes.ValueBetweenInclusive,
     ValidationArgs.Of("from", 0, "to", 150), "Age is unrealistically high.");
 ```
 
-Values are `ValidationArgValue`, a **closed union** with three cases. Because it is closed, a client can switch over it exhaustively, and the JSON shape of an arg follows from its case rather than from whatever a producer happened to pass:
+Values are `ValidationArgValue`, a **closed union** with four cases. Because it is closed, a client can switch over it exhaustively, and the JSON shape of an arg follows from its case rather than from whatever a producer happened to pass:
 
 | Case | Declaration | JSON |
 |---|---|---|
 | `ValidationArgValue.Text` | `sealed record Text(string Value)` | `"red"` |
 | `ValidationArgValue.Number` | `sealed record Number(decimal Value)` | `50` |
+| `ValidationArgValue.Bool` | `sealed record Bool(bool Value)` | `true` |
 | `ValidationArgValue.List` | `sealed record List(EquatableArray<ValidationArgValue> Items)` | `["red","green"]` |
+
+The cases are JSON's self-describing values: its three scalars, plus a list of them. JSON's other two constructs are deliberately absent. `null` would give the dictionary two spellings of the same thing, because an arg with no value is an arg that is simply not there — omit the key. An object would mean a client needs a schema per reason code to know what it is looking at, which gives up the property that makes the union worth having (the shape follows from the case) and turns args into an open-ended payload, which is a poor thing to echo back to a caller. Both are rejected with `JsonException` on read.
 
 > [!IMPORTANT]
 > A numeric operand reaches the wire as a **JSON number**, not a quoted string: `{"maxLength": 50}`, not `{"maxLength": "50"}`. A client comparing a bound against a length no longer has to parse it back out and guess at the format.
 
 `Number` holds a `decimal` — one case rather than one per CLR numeric type, because JSON has a single number type and a client could not observe the distinction. It is written invariantly, so a German server and an American one emit the same bytes.
 
-Build values implicitly. `string`, `int`, `long`, and `decimal` all convert on their own, so ordinary calls need no ceremony; use `ValidationArgValue.ListOf(...)` (or `ListFrom(...)` for a sequence) for the list case:
+> [!NOTE]
+> **`Bool` exists to model the format, not to encourage boolean args.** A boolean is rarely interpolated into a rendered message — you cannot put `true` into a localized sentence — and a flag that selects *which* message to render usually belongs in the reason code, which is the branch point a client is meant to switch on. But without the case, a producer with a boolean operand would write `Text("true")`, reintroducing the quoted-primitive problem the union removes, and a boolean sent by a non-.NET producer would fail the entire error payload rather than one arg.
+
+Build values implicitly. `string`, `int`, `long`, `decimal`, and `bool` all convert on their own, so ordinary calls need no ceremony; use `ValidationArgValue.ListOf(...)` (or `ListFrom(...)` for a sequence) for the list case:
 
 ```csharp
 ValidationArgs.Of("maxLength", 50);                         // {"maxLength": 50}

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -606,8 +606,8 @@ HTTP-specific supporting types (`AuthChallenge`, `EntityTagValue`, `RetryAfterVa
 | `ResourceRef` | `readonly record struct (string Type, string? Id = null)` plus `ResourceRef.For(string type, object? id = null)` and `ResourceRef.For<TResource>(object? id = null)` | Aggregate identity. The `For(...)` helpers convert IDs with invariant formatting when possible. `For<TResource>` peels `Maybe<T>` wrappers and strips generic arity. `ResourceRef.FormatTypeName(Type)` exposes just the arity-stripping step — `typeof(List<int>)` → `"List"` — **without** the `Maybe<T>` peeling, which stays scoped to `For<TResource>` because that method owns the resource-naming contract. Use it when a component needs a type-derived identifier on the wire (AOT-generated converter fallback messages, for example). Throws `ArgumentNullException` for a null type. |
 | `InputPointer` | `readonly record struct` with `InputPointer(string Path)` and `InputPointer(string Path, InputLocation In)` | RFC 6901 JSON Pointer (for example `/email`) plus the part of the input it addresses. Construct simple property names via `InputPointer.ForProperty("email")`, or use `InputPointer.Root` for the document root. See [`InputPointer` locations](#inputpointer-locations) for the location-stamping factories. |
 | `InputLocation` | `enum { Unspecified = 0, Body, Query, Path, Header }` | Which part of the input an offending value came from — the `in` discriminator of a violation's wire location. `Unspecified` projects as `"unknown"`. |
-| `FieldViolation` | `sealed record (InputPointer Field, string ReasonCode, ImmutableDictionary<string,string>? Args = null, string? Detail = null)` | Single per-field violation inside `InvalidInput.Fields`. `Equals` / `GetHashCode` compare `Args` by content. |
-| `RuleViolation` | `sealed record (string ReasonCode, EquatableArray<InputPointer> Fields = default, ImmutableDictionary<string,string>? Args = null, string? Detail = null)` | Multi-field invariant or object-level rule inside `InvalidInput.Rules`. `Equals` / `GetHashCode` compare `Args` by content. |
+| `FieldViolation` | `sealed record (InputPointer Field, string ReasonCode, ImmutableDictionary<string,ValidationArgValue>? Args = null, string? Detail = null)` | Single per-field violation inside `InvalidInput.Fields`. `Equals` / `GetHashCode` compare `Args` by content. |
+| `RuleViolation` | `sealed record (string ReasonCode, EquatableArray<InputPointer> Fields = default, ImmutableDictionary<string,ValidationArgValue>? Args = null, string? Detail = null)` | Multi-field invariant or object-level rule inside `InvalidInput.Rules`. `Equals` / `GetHashCode` compare `Args` by content. |
 | `ITransportFault` | marker interface | Transport-specific payload contract used by `Error.TransportFault`. HTTP-aware code uses `HttpError` from `Trellis.Http.Abstractions`; other transports can define their own implementations. |
 | `ICodedTransportFault` | `ITransportFault` plus `string Kind { get; }` and `string Code { get; }` | Opt-in sub-interface for a fault that names its own failure. See [Coded transport faults](#icodedtransportfault--a-fault-that-names-itself) below. |
 | `RetryAdvice` | `readonly record struct (TimeSpan? After = null, DateTimeOffset? At = null)` | Transport-neutral retry hint carried by `Error.RateLimited` and `Error.Unavailable`. Boundary layers translate it to headers such as `Retry-After`. |
@@ -765,16 +765,55 @@ Three distinctions are easy to get wrong and are worth stating outright:
 
 **Producer independence.** The same failure reports the same code regardless of which part of the framework noticed it. A malformed integer is `format.integer` whether it arrived through query-string binding, a JSON body, or a generated `TryCreate`. This is what makes a single client branch sufficient, and it is enforced by `ProducerIndependenceTests`.
 
-#### `ValidationArgs`
+#### `ValidationArgs` and `ValidationArgValue`
 
 `ValidationArgs.Of(...)` builds the `Args` dictionary carried by a violation — the machine-readable operands of the rule, such as the `50` in "must be at most 50" or the `0`/`255` bounds on a byte.
 
 ```csharp
 Error.InvalidInput.ForField("age", ValidationCodes.ValueBetweenInclusive,
-    ValidationArgs.Of("from", "0", "to", "150"), "Age is unrealistically high.");
+    ValidationArgs.Of("from", 0, "to", 150), "Age is unrealistically high.");
 ```
 
-Values are `string`, and the `IFormattable` overloads format with the invariant culture, so a server's locale never leaks onto the wire. **Never put the rejected value itself in `Args`** — it would be reflected back in the error response and into anything that logs it.
+Values are `ValidationArgValue`, a **closed union** with three cases. Because it is closed, a client can switch over it exhaustively, and the JSON shape of an arg follows from its case rather than from whatever a producer happened to pass:
+
+| Case | Declaration | JSON |
+|---|---|---|
+| `ValidationArgValue.Text` | `sealed record Text(string Value)` | `"red"` |
+| `ValidationArgValue.Number` | `sealed record Number(decimal Value)` | `50` |
+| `ValidationArgValue.List` | `sealed record List(EquatableArray<ValidationArgValue> Items)` | `["red","green"]` |
+
+> [!IMPORTANT]
+> A numeric operand reaches the wire as a **JSON number**, not a quoted string: `{"maxLength": 50}`, not `{"maxLength": "50"}`. A client comparing a bound against a length no longer has to parse it back out and guess at the format.
+
+`Number` holds a `decimal` — one case rather than one per CLR numeric type, because JSON has a single number type and a client could not observe the distinction. It is written invariantly, so a German server and an American one emit the same bytes.
+
+Build values implicitly. `string`, `int`, `long`, and `decimal` all convert on their own, so ordinary calls need no ceremony; use `ValidationArgValue.ListOf(...)` (or `ListFrom(...)` for a sequence) for the list case:
+
+```csharp
+ValidationArgs.Of("maxLength", 50);                         // {"maxLength": 50}
+ValidationArgs.Of("expected", "USD", "actual", "EUR");      // both text
+ValidationArgs.Of("allowed", ValidationArgValue.ListOf("red", "green"));
+```
+
+For three or more operands — a scale-and-precision failure carries four — use the `params` overload, which takes name/value pairs:
+
+```csharp
+ValidationArgs.Of(
+    ("expectedPrecision", 3),
+    ("expectedScale", 1),
+    ("actualScale", 4),
+    ("digits", 5));
+```
+
+> [!NOTE]
+> There is deliberately **no `IFormattable` overload**. Adding one would make `ValidationArgs.Of("max", 255)` *ambiguous* — an `int` converts to `IFormattable` by boxing and to `ValidationArgValue` by a user-defined conversion, and neither target is better than the other, so the call fails with `CS0121`. Its absence is what lets the implicit conversions bind. Format a value with no numeric or textual meaning of its own, such as a timestamp, explicitly and invariantly at the call site.
+
+`ValidationArgValueJsonConverter` is applied to the union by attribute, so serialization needs no registration. It is public because the `System.Text.Json` source generator cannot resolve an internal converter: a trimmed or AOT-published application whose `JsonSerializerContext` roots a violation payload fails at compile time with `SYSLIB1220` otherwise.
+
+> [!IMPORTANT]
+> **Reading a number a `decimal` cannot hold exactly throws `JsonException`.** `Utf8JsonReader.GetDecimal()` rounds silently — `1E-100` arrives as `0`, and `0.00000000000000000000000000009` arrives as `0.0000000000000000000000000001` — and an arg is an operand a client renders a bound from, so a rounded value states a limit the producer never wrote. The converter refuses such tokens instead. Exactness is judged on significant digits rather than on text, so the ordinary spellings a non-.NET producer may emit (`1e2`, `1.50`, `-0`) are all accepted and compare equal to their plain forms.
+
+**Never put the rejected value itself in `Args`** — it would be reflected back in the error response and into anything that logs it.
 
 `Error.InvalidInput.ForField` and `ForRule` each have an overload taking `args` directly.
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -169,7 +169,7 @@ public static class ValidationArgsProjection
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static ImmutableDictionary<string, string>? Project(ValidationFailure failure, ValidationArgsOptions? options = null)` | `ImmutableDictionary<string,string>?` | Projects a failure's `FormattedMessagePlaceholderValues` onto the `Args` carried by `FieldViolation`, applying the allowlist, the containment gate and the encoding rules below. Returns `null` when nothing survives. Both adapters call this — `FluentValidationResultExtensions.ToResult` and, in `Trellis.Mediator.FluentValidation`, `FluentValidationMessageValidatorAdapter`. |
+| `public static ImmutableDictionary<string, ValidationArgValue>? Project(ValidationFailure failure, ValidationArgsOptions? options = null)` | `ImmutableDictionary<string,ValidationArgValue>?` | Projects a failure's `FormattedMessagePlaceholderValues` onto the `Args` carried by `FieldViolation`, applying the allowlist, the containment gate and the encoding rules below. Returns `null` when nothing survives. Both adapters call this — `FluentValidationResultExtensions.ToResult` and, in `Trellis.Mediator.FluentValidation`, `FluentValidationMessageValidatorAdapter`. |
 
 `Args` is what lets a client render its own localized message instead of displaying the server's English prose. Blanket camelCase pass-through of FluentValidation's placeholders is unsafe on two independent counts, so two controls apply.
 
@@ -223,6 +223,13 @@ Naive conversion is not acceptable: `Convert.ToString(dateTime, InvariantCulture
 The gate compares FluentValidation's **rendered** form, because that is what the message contains — but what Trellis publishes is the **encoded** form, and the two differ for dates. So an arg is emitted only when the encoded value is *also* reconcilable with the message: identical to the rendered form, identical to it after bounding, or present in the message verbatim. Otherwise it is **suppressed**.
 
 In practice that makes temporal args a standing false negative, since a culture-rendered date and a round-trip one essentially never coincide. That direction is deliberate — a false negative hides a safe arg and stays recoverable through an explicit opt-in, while a false positive discloses and cannot be taken back. Bounding and escaping are reconciled rather than treated as a mismatch: `Sanitize` derives every character it emits from a character of the value the gate already accepted — truncation omits, escaping re-encodes — so it cannot introduce content the message lacked, even though its output is not byte-for-byte present there. Demanding verbatim presence would suppress exactly the long and control-bearing values the bound exists to serve.
+
+**Wire representation.** The gate above runs entirely on strings and still does, because it decides by comparing against the message FluentValidation rendered, and that message is text. Only after an arg has passed is it lifted onto [`ValidationArgValue`](trellis-api-core.md#validationargs-and-validationargvalue): a placeholder whose CLR type is numeric becomes `ValidationArgValue.Number` and reaches the client as a JSON number, everything else becomes `ValidationArgValue.Text`.
+
+> [!NOTE]
+> The lift cannot admit an arg the gate rejected — it runs only on values that already passed. What changes is representation, not eligibility. `maxLength` now arrives as `4`, not `"4"`.
+
+An enum is deliberately **not** numeric for this purpose: it is encoded by name, and a client matching on the name would otherwise be handed an ordinal it cannot interpret. A numeric value whose invariant encoding will not round-trip through `decimal` — a `double` beyond decimal's range, or one rendered in exponent form — stays text rather than losing precision or throwing.
 
 ### `ValidationArgsOptions`
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -229,7 +229,7 @@ In practice that makes temporal args a standing false negative, since a culture-
 > [!NOTE]
 > The lift cannot admit an arg the gate rejected — it runs only on values that already passed. What changes is representation, not eligibility. `maxLength` now arrives as `4`, not `"4"`.
 
-An enum is deliberately **not** numeric for this purpose: it is encoded by name, and a client matching on the name would otherwise be handed an ordinal it cannot interpret. A numeric value whose invariant encoding will not round-trip through `decimal` — a `double` beyond decimal's range, or one rendered in exponent form — stays text rather than losing precision or throwing.
+An enum is deliberately **not** numeric for this purpose: it is encoded by name, and a client matching on the name would otherwise be handed an ordinal it cannot interpret. A boolean placeholder is likewise left as text: FluentValidation renders one as `True`/`False`, so lifting it would put a value on the wire spelled differently from the message it was reconciled against, and no validator in the allowlist carries one. A numeric value whose invariant encoding will not round-trip through `decimal` — a `double` beyond decimal's range, or one rendered in exponent form — stays text rather than losing precision or throwing.
 
 ### `ValidationArgsOptions`
 

--- a/docs/docfx_project/articles/error-handling.md
+++ b/docs/docfx_project/articles/error-handling.md
@@ -144,9 +144,9 @@ var single = Error.InvalidInput.ForField("email", "required", "Email is required
 var multiField = new Error.InvalidInput(EquatableArray.Create(
     new FieldViolation(InputPointer.ForProperty("email"),    "required") { Detail = "Email is required" },
     new FieldViolation(InputPointer.ForProperty("password"), "min_length",
-        ImmutableDictionary<string, string>.Empty.Add("min", "8")) { Detail = "Password must be at least 8 characters" },
+        ValidationArgs.Of("min", 8)) { Detail = "Password must be at least 8 characters" },
     new FieldViolation(InputPointer.ForProperty("age"),      "min",
-        ImmutableDictionary<string, string>.Empty.Add("min", "18")) { Detail = "Must be 18 or older" }));
+        ValidationArgs.Of("min", 18)) { Detail = "Must be 18 or older" }));
 
 var crossField = new Error.InvalidInput(
     Fields: EquatableArray<FieldViolation>.Empty,


### PR DESCRIPTION
## Why

`FieldViolation.Args` and `RuleViolation.Args` were `ImmutableDictionary<string, string>`, so every numeric operand reached the wire quoted:

```jsonc
// before
"args": { "minLength": "3", "maxLength": "50" }
// after
"args": { "minLength": 3, "maxLength": 50 }
```

Args exist so a client can render its own localized message instead of parsing the server's English prose. Quoting every operand undercut that: a client comparing a bound against a length had to parse it back out of a string and guess at the format — the same recovery-by-parsing the args were introduced to end.

## What

`Args` becomes `ImmutableDictionary<string, ValidationArgValue>`, where `ValidationArgValue` is a **closed union** of `Text(string)`, `Number(decimal)` and `List(EquatableArray<ValidationArgValue>)`. Because it is closed, a client can switch over it exhaustively and the JSON shape of an arg follows from its case rather than from whatever a producer happened to pass.

The union keeps the property that motivated `string` in the first place — a producer still cannot hand over an arbitrary `object` and let culture-sensitive formatting leak onto the wire — because `Number` holds a `decimal` and is written invariantly.

`Number` is backed by `decimal` alone rather than one case per CLR numeric type: JSON has a single number type, so a client could not observe the distinction, and `decimal` is the widest choice that keeps integers exact. `List` is what lets a violation name a set without a producer inventing a delimiter a client would then have to know to split on.

**The type change alone would have been cosmetic.** Most framework producers passed numeric operands as *quoted string literals* — `Of("comparisonValue", "0")`, `Of("min", "0", "max", "255")` — and the `Required*` source generator **emitted** them that way too. Roughly twenty call sites plus the generator's emitted literals are de-quoted here (with correct suffixes: `m` for decimal, `L` for long, bare for int). Without that, a consumer would upgrade and see the same quoted wire as before.

`ValidationArgs.Of` also gains a `params` overload taking name/value pairs, retiring the previous ceiling of two. A rule with more operands is ordinary — a scale-and-precision failure carries four — and previously had to abandon `ValidationArgs` and assemble the dictionary by hand.

## Deserialization refuses what a `decimal` cannot hold exactly

`Utf8JsonReader.GetDecimal()` is not safe here on its own. It **rounds silently** — `1E-100` reads back as `0`, and `0.00000000000000000000000000009` as `0.0000000000000000000000000001` — and it raises `FormatException` on overflow, which is not the exception a `JsonConverter<T>` is expected to surface.

An arg is the operand a client renders a *bound* from, so a rounded value states a limit the producer never wrote. Such tokens now throw `JsonException` instead. Exactness is judged on **significant digits rather than on text**, so the ordinary spellings a non-.NET producer may emit — `1e2`, `1.50`, `-0` — are all accepted and compare equal to their plain forms.

The same rule governs `Trellis.FluentValidation`'s promotion of an approved string arg to `Number`, which now requires an exact invariant round-trip before promoting.

## The FluentValidation disclosure gate is deliberately untouched

`ValidationArgsProjection` decides which validator arguments may be echoed to a client by comparing candidates against the message FluentValidation actually rendered — which is text — so the gate (`ShouldEmit` + `IsReconciled` + the per-validator allowlist + `Sanitize`'s 64-char bound) keeps operating on strings. Promotion to `Number` runs **strictly after** it, so it can change *representation* only, never *eligibility*: no value becomes emittable that was not emittable before.

## Notes for reviewers

- **`ValidationArgValueJsonConverter` is public on purpose.** The `System.Text.Json` source generator cannot resolve an internal converter, so a trimmed or AOT-published application whose `JsonSerializerContext` roots a violation payload fails at compile time with `SYSLIB1220`.
- **`List` holds an `EquatableArray`, not a raw `ImmutableArray`**, which compares its underlying array by *reference* and would silently break record equality for nested lists.
- **There is deliberately no `IFormattable` overload.** Adding one would make `Of("max", 255)` *ambiguous* — an `int` converts to `IFormattable` by boxing and to `ValidationArgValue` by a user-defined conversion, neither target is better than the other, and the call fails with `CS0121`. Its absence is what lets the implicit conversions bind.
- One issue surfaced in review was **declined as out of scope**: `DictionaryEquals` looks keys up through the *other* dictionary's comparer, so equality can be asymmetric if a caller supplies a non-ordinal comparer. `git diff` shows that shape is byte-identical before and after this change — it is pre-existing and unrelated to the value-type change, and belongs in its own fix.

## Migrating

Most call sites need no change: `string`, `int`, `long` and `decimal` all convert implicitly, so `ValidationArgs.Of("max", 255)` compiles as it did. Two things do change:

- **A numeric operand written as a quoted string keeps compiling and stays quoted.** `Of("comparisonValue", "0")` is now `Text("0")`, not a number — drop the quotes to get the new shape. Every framework producer has been de-quoted, including generated code, so generated value objects and the built-in primitives emit numbers with no consumer action.
- **The `IFormattable` overloads are removed.** Format a value with no numeric or textual meaning of its own — a timestamp, say — explicitly and invariantly at the call site.

## Validation

- `dotnet build Trellis.slnx` — clean in **Debug and Release**
- `dotnet test Trellis.slnx` — **passing in Debug and Release**
- `docs\lint-api-reference.ps1` — pass (28 files)
- completeness audit (TRLDOC005 / TRLDOC008) — exit 0
- Docs updated: `trellis-api-core.md`, `trellis-api-asp.md`, `trellis-api-fluentvalidation.md`, `articles/error-handling.md`, `CHANGELOG.md`

New tests pin the wire shape end to end (numbers serialize unquoted, lists as JSON arrays), the rejected-precision cases, and the accepted spellings.
