### PR TITLE
Name the enum members a rejection would have accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — enum rejections name the members they would have accepted
+
+A violation carrying `enum.name-undefined` or `enum.undefined` now includes an `allowed` arg listing the permitted member names as a JSON array of strings:
+
+```json
+{ "code": "enum.name-undefined", "args": { "allowed": ["Green", "Red"] } }
+```
+
+The members were not always dropped before, but they were never available as data. `RequiredEnum.TryCreate` joined them into the English detail (`"'X' is not a valid Y. Valid values: A, B, C"`), so a client that wanted to render "choose one of…" in the caller's language had to parse an English sentence. Query-string binding was worse: its detail is the generic `"The value is not a recognized option."`, so the permitted set was unavailable by any means at all. The detail keeps its list — this is additive, and a human reading the response still gets a complete sentence.
+
+All five producers that can reject an enum now agree: query binding (`PrimitiveConverter`), the body converter (`ScalarValueJsonConverterBase`), `RequiredEnum.TryCreate`, `RequiredEnumJsonConverter`, and a FluentValidation `IsInEnum()` rule. They route through a new `ValidationArgs.Allowed(names)` helper, which fixes both the entry name and its **ordinal** ordering in one place — the producers read their members from unrelated sources (`Enum.GetNames` versus a registry of declared statics), and nothing else would force those to line up for a client that compares or caches the list.
+
+`enum.undefined` (a numeric value that parsed but names no member) carries the same list as `enum.name-undefined`. The remedy is identical, and covering only the name case would tell a client its options when it sent `"mauve"` but not when it sent `99`.
+
+The arg rides on the reason code, not on the producer: a blank value reports `value.not-empty` and carries no `allowed`, since there the entry would degrade from "these are your options" into "an enum was involved somewhere".
+
+The list is bounded. `ValidationArgs.MaxAllowedMembers` is 64; beyond it the members are dropped whole and an `allowedCount` arg is sent in their place. The 248 ISO country names cost roughly 3 KB of args on *every* rejection, and a request carrying several invalid enum fields multiplies that — a small request provoking a large response is an amplification vector, not merely waste. Truncating instead was rejected because a client cannot distinguish a shortened list from a complete one: a truncated `allowed` states that a member it omitted is not permitted, so a chooser renders the wrong set and a client validating against it rejects valid input.
+
+The same bound now governs the prose. `RequiredEnum.TryCreate` and `RequiredEnumJsonConverter` spell every member into `Detail`, which for those 248 countries is a further 2.8 KB — more than the arg it accompanies — so above the bound the `"Valid values: …"` clause is dropped and the message reads `"'x' is not a valid Country."`, which is what the body converter already emitted. **This changes the message text for enums with more than 64 members**; narrower enums are unaffected.
+
+The FluentValidation path reaches the same list by a different route, because FluentValidation has no placeholder for it — its message reports only the value it rejected. `ValidationArgsProjection` therefore derives the members from the attempted value's own type, and this one arg does not pass through the containment gate that governs every other. That gate asks whether a value already reached the client in the rendered message, which is the right question for an operand the application chose — a bound, a regex, a compared property — and the wrong one for member names, which are the API's own contract and the very spellings a client must send to succeed. An error code borrowed for a rule over a non-enum names nothing.
+
 ### Fixed — HTTP and ASP faults now carry a stable `Code` instead of a random GUID
 
 Ten call sites in `Trellis.Http` and `Trellis.Asp` built their failure as `new Error.Unexpected(Guid.NewGuid().ToString("N"))`. Because the signature is `Error.Unexpected(string Code, string? FaultId = null)`, the GUID landed in **`Code`** and `FaultId` was left null — so every individual incident published a different `code` on the wire, which no dashboard can group, while the field that exists for a per-incident value went unused.

--- a/Examples/Showcase/api.http
+++ b/Examples/Showcase/api.http
@@ -153,10 +153,21 @@ Accept: application/json
 ###
 ###   "fieldViolations": [{
 ###     "code": "enum.name-undefined",
-###     "detail": "'Platinum' is not a valid AccountType. Valid values: Checking, MoneyMarket, Savings",
+###     "detail": "...",
 ###     "location": { "in": "body", "pointer": "/accountType" },
 ###     "args": { "allowed": ["Checking", "MoneyMarket", "Savings"] }
 ###   }]
+###
+### `detail` is deliberately elided above, because it is not one sentence. This
+### rejection has two producers and they word it differently -- `RequiredEnum.TryCreate`
+### says "'Platinum' is not a valid AccountType. Valid values: ...", while
+### `RequiredEnumJsonConverter` says "Invalid AccountType value: 'Platinum'. Valid
+### values are: ...". Which one answers depends on how the value reached the model.
+###
+### That is the argument for `args.allowed` in one line: `code`, `location` and
+### `allowed` are identical across both producers and both hosts, so a client can
+### depend on them. The English cannot be depended on, and a client that scraped
+### "Valid values: " out of `detail` would break on the other producer.
 ###
 ### The names are sorted ordinally, not by declaration order, so a client may compare
 ### or cache the list across producers. Enums wider than 64 members send an

--- a/Examples/Showcase/api.http
+++ b/Examples/Showcase/api.http
@@ -144,6 +144,38 @@ Accept: application/json
   "overdraftLimit":       { "amount":    0.00, "currency": "USD" }
 }
 
+### Open account — unknown product type (422 `enum.name-undefined`)
+### `AccountType` is a RequiredEnum, so an unrecognized name is rejected at the JSON
+### binding layer. The violation names the products it *would* have accepted as a
+### machine-readable `args.allowed` array — not only as English prose in `detail` —
+### which is what lets a client render "choose one of…" in the caller's language
+### instead of parsing an English sentence:
+###
+###   "fieldViolations": [{
+###     "code": "enum.name-undefined",
+###     "detail": "'Platinum' is not a valid AccountType. Valid values: Checking, MoneyMarket, Savings",
+###     "location": { "in": "body", "pointer": "/accountType" },
+###     "args": { "allowed": ["Checking", "MoneyMarket", "Savings"] }
+###   }]
+###
+### The names are sorted ordinally, not by declaration order, so a client may compare
+### or cache the list across producers. Enums wider than 64 members send an
+### `allowedCount` instead — a truncated list would read as exhaustive and tell a
+### client that a member it omitted is not permitted.
+### @parity: status-only
+# @expect status: 422
+# @expect content-type: application/problem+json
+POST {{host}}/api/accounts
+Content-Type: application/json
+Accept: application/json
+
+{
+  "customerId": "{{aliceCustomer}}",
+  "accountType": "Platinum",
+  "initialDeposit":       { "amount": 250.00, "currency": "USD" },
+  "dailyWithdrawalLimit": { "amount": 500.00, "currency": "USD" },
+  "overdraftLimit":       { "amount":   0.00, "currency": "USD" }
+}
 ### Freeze account
 POST {{host}}/api/accounts/{{aliceChecking}}/freeze
 Content-Type: application/json

--- a/Examples/Showcase/tests/Showcase.Tests/Api/ApiHttpFileParityTests.cs
+++ b/Examples/Showcase/tests/Showcase.Tests/Api/ApiHttpFileParityTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Trellis.Showcase.Application;
 using Trellis.Testing.AspNetCore.Http;
 
 /// <summary>
@@ -153,6 +154,79 @@ public class ApiHttpFileParityTests : IClassFixture<ApiHttpFileParityTests.Parit
     }
 
     private static string Truncate(string s) => s.Length <= 300 ? s : s[..300] + "…";
+
+    /// <summary>
+    /// An unknown <c>AccountType</c> must carry the same machine-readable contract —
+    /// <c>code</c>, <c>location</c>, <c>args.allowed</c> — from either host, so a client
+    /// that switches hosts does not have to relearn how to read a rejection.
+    /// <para>
+    /// Prose is deliberately excluded from that contract, because this rejection has two
+    /// producers that word it differently: <c>RequiredEnum.TryCreate</c> says "'Platinum' is
+    /// not a valid AccountType. Valid values: …", and <c>RequiredEnumJsonConverter</c> says
+    /// "Invalid AccountType value: 'Platinum'. Valid values are: …". Which one answers
+    /// depends on how the value reached the model, which is the case for <c>args.allowed</c>
+    /// in miniature: the members a rejection would have accepted are the API's contract, and
+    /// belong somewhere a client can read without a parser.
+    /// </para>
+    /// <para>
+    /// Note that both <see cref="WebApplicationFactory{TEntryPoint}"/> hosts here happen to
+    /// take the <c>TryCreate</c> path, so their prose agrees today; the standalone Minimal API
+    /// host takes the converter path and its prose does not. That divergence is precisely why
+    /// this test asserts the machine-readable fields and only checks that <c>detail</c> is
+    /// non-empty — asserting the sentence would pin one producer's wording and make the test
+    /// fail on a host it is supposed to cover.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Unknown_enum_member_carries_the_same_machine_readable_contract_on_both_hosts()
+    {
+        using var mvcClient = _fixture.Mvc.CreateClient();
+        using var minClient = _fixture.Minimal.CreateClient();
+
+        var mvc = await RejectUnknownAccountTypeAsync(mvcClient);
+        var min = await RejectUnknownAccountTypeAsync(minClient);
+
+        foreach (var (host, violation) in new[] { ("MVC", mvc), ("Minimal API", min) })
+        {
+            violation.GetProperty("code").GetString().Should().Be("enum.name-undefined", $"{host} rejects by name");
+
+            var location = violation.GetProperty("location");
+            location.GetProperty("in").GetString().Should().Be("body", $"{host} rejected a body field, not a query or route value");
+            location.GetProperty("pointer").GetString().Should().Be("/accountType", $"{host} points at the field");
+
+            violation.GetProperty("args").GetProperty("allowed").EnumerateArray()
+                .Select(member => member.GetString())
+                .Should().Equal(["Checking", "MoneyMarket", "Savings"],
+                    $"{host} must name the products it accepts, ordinally sorted");
+        }
+
+        mvc.GetProperty("detail").GetString().Should().NotBeNullOrWhiteSpace();
+        min.GetProperty("detail").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    private static async Task<JsonElement> RejectUnknownAccountTypeAsync(HttpClient client)
+    {
+        var payload = $$"""
+            {
+              "customerId": "{{ShowcaseSeed.AliceId}}",
+              "accountType": "Platinum",
+              "initialDeposit":       { "amount": 250.00, "currency": "USD" },
+              "dailyWithdrawalLimit": { "amount": 500.00, "currency": "USD" },
+              "overdraftLimit":       { "amount":   0.00, "currency": "USD" }
+            }
+            """;
+
+        var response = await client.PostAsync(
+            new Uri("/api/accounts", UriKind.Relative),
+            new StringContent(payload, Encoding.UTF8, "application/json"),
+            Ct);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.UnprocessableContent);
+
+        // Clone before disposing: the returned element must outlive the document's pooled buffers.
+        using var document = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Ct));
+        return document.RootElement.GetProperty("fieldViolations")[0].Clone();
+    }
 
     /// <summary>
     /// Owns both MVC and Minimal API factories so the parity test can reuse the

--- a/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
@@ -66,6 +66,50 @@ public class ShowcaseApiTests : IClassFixture<WebApplicationFactory<Program>>
         location.GetProperty("pointer").GetString().Should().Be("/amount");
     }
 
+    /// <summary>
+    /// <c>AccountType</c> is a <c>RequiredEnum</c>, so an unrecognized product name is rejected at
+    /// the JSON binding layer. The violation names the products it *would* have accepted as a
+    /// machine-readable <c>args.allowed</c> array, not only as English prose inside <c>detail</c> —
+    /// which is what lets a client render "choose one of…" in the caller's own language.
+    /// </summary>
+    [Fact]
+    public async Task Open_account_with_unknown_account_type_names_the_products_it_accepts()
+    {
+        var client = _factory.CreateClient();
+        var payload = $$"""
+            {
+              "customerId": "{{ShowcaseSeed.AliceId}}",
+              "accountType": "Platinum",
+              "initialDeposit":       { "amount": 250.00, "currency": "USD" },
+              "dailyWithdrawalLimit": { "amount": 500.00, "currency": "USD" },
+              "overdraftLimit":       { "amount":   0.00, "currency": "USD" }
+            }
+            """;
+
+        var response = await client.PostAsync(
+            new Uri("/api/accounts", UriKind.Relative),
+            new StringContent(payload, System.Text.Encoding.UTF8, "application/json"),
+            Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableContent);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/problem+json");
+
+        using var problem = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Ct));
+        var violation = problem.RootElement.GetProperty("fieldViolations")[0];
+
+        violation.GetProperty("code").GetString().Should().Be("enum.name-undefined");
+        violation.GetProperty("location").GetProperty("in").GetString().Should().Be("body");
+        violation.GetProperty("location").GetProperty("pointer").GetString().Should().Be("/accountType");
+
+        violation.GetProperty("args").GetProperty("allowed").EnumerateArray()
+            .Select(member => member.GetString())
+            .Should().Equal(["Checking", "MoneyMarket", "Savings"],
+                "the products are ordinally sorted so a client can compare or cache the list across producers");
+
+        // The English sentence is kept alongside the machine-readable list, not replaced by it.
+        violation.GetProperty("detail").GetString()
+            .Should().Be("'Platinum' is not a valid AccountType. Valid values: Checking, MoneyMarket, Savings");
+    }
     [Fact]
     public async Task Secure_withdraw_with_invalid_code_returns_422()
     {

--- a/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
+++ b/Examples/Showcase/tests/Showcase.Tests/Api/ShowcaseApiTests.cs
@@ -107,6 +107,10 @@ public class ShowcaseApiTests : IClassFixture<WebApplicationFactory<Program>>
                 "the products are ordinally sorted so a client can compare or cache the list across producers");
 
         // The English sentence is kept alongside the machine-readable list, not replaced by it.
+        // This exact wording belongs to the RequiredEnum.TryCreate producer, which is the path
+        // this in-process host takes; RequiredEnumJsonConverter words the same rejection
+        // differently, so only `code`, `location` and `args` are asserted cross-host in
+        // ApiHttpFileParityTests.
         violation.GetProperty("detail").GetString()
             .Should().Be("'Platinum' is not a valid AccountType. Valid values: Checking, MoneyMarket, Savings");
     }

--- a/Trellis.Asp/src/ModelBinding/PrimitiveConverter.cs
+++ b/Trellis.Asp/src/ModelBinding/PrimitiveConverter.cs
@@ -88,10 +88,12 @@ internal static class PrimitiveConverter
                 // Two distinct failures share one message but not one code: the name was not a
                 // member at all, versus a numeric value that parsed into an undefined member.
                 // A client offering "did you mean?" needs the first; one reporting a corrupt
-                // stored value needs the second.
+                // stored value needs the second. Both get the permitted set: the remedy is the
+                // same either way, and the detail here never named the members at all.
                 return Result.Fail<TPrimitive>(Invalid(
                     parsed ? ValidationCodes.EnumUndefined : ValidationCodes.EnumNameUndefined,
-                    "The value is not a recognized option."));
+                    "The value is not a recognized option.",
+                    ValidationArgs.Allowed(Enum.GetNames(underlyingType))));
             }
 
             if (underlyingType == typeof(Guid))

--- a/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
+++ b/Trellis.Asp/src/Validation/ScalarValueJsonConverterBase.cs
@@ -108,7 +108,11 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
                 return false;
             }
 
-            ValidationErrorsContext.AddBodyError(fieldName, ValidationCodes.EnumNameUndefined, $"'{rawValue}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
+            ValidationErrorsContext.AddBodyError(
+                fieldName,
+                ValidationCodes.EnumNameUndefined,
+                $"'{rawValue}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.",
+                ValidationArgs.Allowed(Enum.GetNames(typeof(TPrimitive))));
             return false;
         }
 
@@ -119,7 +123,11 @@ public abstract class ScalarValueJsonConverterBase<TResult, TValue, TPrimitive> 
                 var enumValue = ReadNumericEnumValue(ref reader);
                 if (!IsValidEnumValue(enumValue))
                 {
-                    ValidationErrorsContext.AddBodyError(fieldName, ValidationCodes.EnumUndefined, $"'{enumValue}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.");
+                    ValidationErrorsContext.AddBodyError(
+                        fieldName,
+                        ValidationCodes.EnumUndefined,
+                        $"'{enumValue}' is not a valid {ResourceRef.FormatTypeName(typeof(TPrimitive))}.",
+                        ValidationArgs.Allowed(Enum.GetNames(typeof(TPrimitive))));
                     return false;
                 }
 

--- a/Trellis.Asp/tests/ProducerIndependenceTests.cs
+++ b/Trellis.Asp/tests/ProducerIndependenceTests.cs
@@ -137,6 +137,46 @@ public class ProducerIndependenceTests
         CodeOf(undefinedNumeric.Error!).Should().Be(ValidationCodes.EnumUndefined);
     }
 
+    private static ValidationArgValue? AllowedOf(Error error) =>
+        ((Error.InvalidInput)error).Fields.Items[0].Args?["allowed"];
+
+    /// <remarks>
+    /// Query binding's detail is the generic "The value is not a recognized option." — it never
+    /// named the members at all, so before this the permitted set was unavailable to a client by
+    /// any means, localized or not.
+    /// </remarks>
+    [Fact]
+    public void Unknown_enum_name_carries_the_permitted_members_as_args()
+    {
+        var result = PrimitiveConverter.ConvertToPrimitive<ProducerIndependenceColor>("mauve");
+
+        AllowedOf(result.Error!).Should().Be(ValidationArgValue.ListOf("Green", "Red"));
+    }
+
+    /// <remarks>
+    /// The two enum codes are chosen by a ternary inside one branch, so covering only the
+    /// name case would leave a client told which members exist when it sent <c>"mauve"</c> but
+    /// not when it sent <c>99</c> — an asymmetry with no defensible explanation. The remedy set
+    /// is the same either way: here are the members you may send.
+    /// </remarks>
+    [Fact]
+    public void An_undefined_numeric_enum_value_carries_the_permitted_members_too()
+    {
+        var result = PrimitiveConverter.ConvertToPrimitive<ProducerIndependenceColor>("99");
+
+        CodeOf(result.Error!).Should().Be(ValidationCodes.EnumUndefined);
+        AllowedOf(result.Error!).Should().Be(ValidationArgValue.ListOf("Green", "Red"));
+    }
+
+    [Fact]
+    public void Both_enum_failures_report_the_same_permitted_members()
+    {
+        var byName = PrimitiveConverter.ConvertToPrimitive<ProducerIndependenceColor>("mauve");
+        var byNumber = PrimitiveConverter.ConvertToPrimitive<ProducerIndependenceColor>("99");
+
+        AllowedOf(byName.Error!).Should().Be(AllowedOf(byNumber.Error!));
+    }
+
     [Fact]
     public void Byte_out_of_range_carries_its_bounds_as_args()
     {

--- a/Trellis.Asp/tests/ValidatingJsonConverterEdgeCasesTests.cs
+++ b/Trellis.Asp/tests/ValidatingJsonConverterEdgeCasesTests.cs
@@ -383,6 +383,49 @@ public class ValidatingJsonConverterEdgeCasesTests
         }
     }
 
+    /// <remarks>
+    /// The body converter is a distinct producer from query binding, and a client that reads
+    /// <c>allowed</c> must not have to know which one answered. Ordinal order, not the
+    /// declaration order <c>Unknown, Fast, Safe</c>.
+    /// </remarks>
+    [Fact]
+    public void Read_EnumNameUndefined_CarriesThePermittedMembersAsArgs()
+    {
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var reader = new Utf8JsonReader("\"Slow\""u8);
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            var violation = ValidationErrorsContext.GetUnprocessableContent()!.Fields.Items[0];
+            violation.ReasonCode.Should().Be(ValidationCodes.EnumNameUndefined);
+            violation.Args!["allowed"].Should().Be(ValidationArgValue.ListOf("Fast", "Safe", "Unknown"));
+        }
+    }
+
+    [Fact]
+    public void Read_EnumUndefinedNumericValue_CarriesThePermittedMembersAsArgs()
+    {
+        var converter = new ValidatingJsonConverter<ProcessingModeVO, ProcessingMode>();
+        var reader = new Utf8JsonReader("10"u8);
+        reader.Read();
+
+        using (ValidationErrorsContext.BeginScope())
+        {
+            ValidationErrorsContext.CurrentPropertyName = "mode";
+
+            converter.Read(ref reader, typeof(ProcessingModeVO), new JsonSerializerOptions());
+
+            var violation = ValidationErrorsContext.GetUnprocessableContent()!.Fields.Items[0];
+            violation.ReasonCode.Should().Be(ValidationCodes.EnumUndefined);
+            violation.Args!["allowed"].Should().Be(ValidationArgValue.ListOf("Fast", "Safe", "Unknown"));
+        }
+    }
+
     [Fact]
     public void Read_EnumNumericOverflow_CollectsValidationError()
     {

--- a/Trellis.Core/src/Errors/ValidationArgs.cs
+++ b/Trellis.Core/src/Errors/ValidationArgs.cs
@@ -1,6 +1,8 @@
 ﻿namespace Trellis;
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 /// <summary>
 /// Builds the <c>Args</c> dictionary carried by a <see cref="FieldViolation"/> or
@@ -75,5 +77,65 @@ public static class ValidationArgs
             builder[name] = value;
 
         return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// The largest member list <see cref="Allowed"/> will publish.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A list a client cannot act on is not worth what it costs to send. The 248 ISO country names
+    /// serialize to roughly 3 KB, attached to <em>every</em> rejection; a request carrying several
+    /// invalid enum fields multiplies that, so a small request provokes a large response, which is
+    /// an amplification vector rather than mere waste. Past a few dozen options a client is not
+    /// rendering "choose one of…" from an error payload anyway — it wants a schema or an
+    /// enumeration endpoint, and the error is the wrong channel.
+    /// </para>
+    /// <para>
+    /// The bound is a member count rather than a serialized length because member names are
+    /// identifiers in every producer — CLR enum names, or the static field names behind a
+    /// <c>RequiredEnum</c> — so their length is already bounded in practice, and a count is
+    /// something a client can be told and can predict.
+    /// </para>
+    /// </remarks>
+    public const int MaxAllowedMembers = 64;
+
+    /// <summary>
+    /// Builds the <c>allowed</c> entry naming the members a symbolic value may take.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every producer that rejects a value for not being one of a fixed set routes through here,
+    /// so none of them can disagree about the entry's name, the order of its members, or the point
+    /// at which the list becomes too long to send. The producers derive their members from
+    /// unrelated places — <see cref="System.Enum.GetNames(System.Type)"/> for query binding, a
+    /// registry of declared statics for <c>RequiredEnum</c> — and nothing else would force those
+    /// to line up. A client that compares the list across producers, or caches it, must not see a
+    /// difference that is only ordering.
+    /// </para>
+    /// <para>
+    /// Ordinal sorting is what makes the order total and culture-independent; sorting by the
+    /// current culture would let the same enum serialize differently on two machines.
+    /// </para>
+    /// <para>
+    /// Beyond <see cref="MaxAllowedMembers"/> the list is dropped <em>whole</em> and replaced by an
+    /// <c>allowedCount</c> entry. Truncating instead would publish a false statement: a client
+    /// cannot tell a shortened list from a complete one, so it would render "choose one of…" over a
+    /// wrong set and reject valid input when validating against it. Omission is already a case
+    /// every client handles, since a blank value carries no list either; the count is what
+    /// distinguishes "too many to send" from "not applicable here".
+    /// </para>
+    /// </remarks>
+    /// <param name="names">The permitted member names. May be empty.</param>
+    public static ImmutableDictionary<string, ValidationArgValue> Allowed(IEnumerable<string> names)
+    {
+        var members = (names ?? []).ToArray();
+        if (members.Length > MaxAllowedMembers)
+            return Of("allowedCount", members.Length);
+
+        Array.Sort(members, StringComparer.Ordinal);
+        return Of(
+            "allowed",
+            ValidationArgValue.ListFrom(members.Select(name => (ValidationArgValue)new ValidationArgValue.Text(name))));
     }
 }

--- a/Trellis.Core/src/Primitives/EnumMemberProse.cs
+++ b/Trellis.Core/src/Primitives/EnumMemberProse.cs
@@ -1,0 +1,36 @@
+﻿namespace Trellis;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Renders a permitted-member list for a human-readable message, under the same bound that governs
+/// the machine-readable <c>allowed</c> arg.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The prose and the arg are gated by one constant deliberately. Capping only the arg would leave
+/// the larger half of the problem in place: <c>RequiredEnum.TryCreate</c> spells every member into
+/// its detail, which for the 248 ISO country names is roughly 2.8 KB of prose on every rejection —
+/// more than the arg it was meant to replace.
+/// </para>
+/// <para>
+/// Above the bound the clause is dropped rather than shortened, matching the arg. A message reading
+/// "Valid values: Afghanistan, Albania, …" invites a reader to believe the list is exhaustive, and
+/// a reader who cannot see the whole set is better served by being told nothing than by being told
+/// a fraction that looks complete. The resulting sentence is the one the body converter already
+/// emits, so the producers agree there too.
+/// </para>
+/// </remarks>
+internal static class EnumMemberProse
+{
+    /// <summary>
+    /// The members joined in ordinal order, or <see langword="null"/> when there are more than
+    /// <see cref="ValidationArgs.MaxAllowedMembers"/> of them.
+    /// </summary>
+    internal static string? ListOrNull(IReadOnlyCollection<string> names) =>
+        names.Count > ValidationArgs.MaxAllowedMembers
+            ? null
+            : string.Join(", ", names.OrderBy(name => name, StringComparer.Ordinal));
+}

--- a/Trellis.Core/src/Primitives/RequiredEnum.cs
+++ b/Trellis.Core/src/Primitives/RequiredEnum.cs
@@ -233,8 +233,14 @@ public abstract class RequiredEnum<[DynamicallyAccessedMembers(DynamicallyAccess
         if (cache.ByName.TryGetValue(value, out var member))
             return Result.Ok(member);
 
-        var validNames = string.Join(", ", cache.ByName.Keys.OrderBy(n => n, StringComparer.Ordinal));
-        return Result.Fail<TSelf>(Error.InvalidInput.ForField(field, ValidationCodes.EnumNameUndefined, $"'{value}' is not a valid {typeof(TSelf).Name}. Valid values: {validNames}"));
+        var validNames = EnumMemberProse.ListOrNull(cache.ByName.Keys);
+        return Result.Fail<TSelf>(Error.InvalidInput.ForField(
+            field,
+            ValidationCodes.EnumNameUndefined,
+            ValidationArgs.Allowed(cache.ByName.Keys),
+            validNames is null
+                ? $"'{value}' is not a valid {typeof(TSelf).Name}."
+                : $"'{value}' is not a valid {typeof(TSelf).Name}. Valid values: {validNames}"));
     }
 
     /// <summary>

--- a/Trellis.Core/src/Primitives/RequiredEnumJsonConverter.cs
+++ b/Trellis.Core/src/Primitives/RequiredEnumJsonConverter.cs
@@ -1,5 +1,6 @@
 ﻿namespace Trellis;
 
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
@@ -67,18 +68,27 @@ public sealed class RequiredEnumJsonConverter<[DynamicallyAccessedMembers(Dynami
             onSuccess: value => value,
             onFailure: error =>
             {
-                var validValues = string.Join(", ", RequiredEnum<TRequiredEnum>.GetAll()
+                var memberNames = RequiredEnum<TRequiredEnum>.GetAll()
                     .Select(value => value.Value)
-                    .OrderBy(value => value, StringComparer.Ordinal));
+                    .ToArray();
+                var validValues = EnumMemberProse.ListOrNull(memberNames);
 
                 // The message is this converter's, but the code is the producer's: TryCreate already
                 // separates absent from blank from not-a-member, and overwriting all three with
                 // `enum.name-undefined` would make the same blank value report a different code
                 // through JSON than through query binding or a direct TryCreate.
+                var reasonCode = ReasonCodeOf(error, ValidationCodes.EnumNameUndefined);
+
+                // For the same reason the permitted set rides only on the not-a-member code. A
+                // blank value reports `value.not-empty`, where `allowed` would degrade from
+                // "these are your options" into "an enum was involved somewhere".
                 throw Invalid(
-                    ReasonCodeOf(error, ValidationCodes.EnumNameUndefined),
-                    $"Invalid {typeof(TRequiredEnum).Name} value: '{SanitizeForExceptionMessage(name)}'. " +
-                    $"Valid values are: {validValues}.");
+                    reasonCode,
+                    $"Invalid {typeof(TRequiredEnum).Name} value: '{SanitizeForExceptionMessage(name)}'." +
+                    (validValues is null ? string.Empty : $" Valid values are: {validValues}."),
+                    reasonCode == ValidationCodes.EnumNameUndefined
+                        ? ValidationArgs.Allowed(memberNames)
+                        : null);
             });
     }
 
@@ -106,10 +116,13 @@ public sealed class RequiredEnumJsonConverter<[DynamicallyAccessedMembers(Dynami
     /// 422 through the composite converter, so the two producers now agree.
     /// </para>
     /// </remarks>
-    private static TrellisJsonValidationException Invalid(string reasonCode, string message) =>
+    private static TrellisJsonValidationException Invalid(
+        string reasonCode,
+        string message,
+        ImmutableDictionary<string, ValidationArgValue>? args = null) =>
         new(message)
         {
-            InvalidInput = Error.InvalidInput.ForField(InputPointer.Root, reasonCode, message) with
+            InvalidInput = Error.InvalidInput.ForField(InputPointer.Root, reasonCode, args, message) with
             {
                 Detail = message,
             },

--- a/Trellis.Core/tests/Errors/ValidationArgsTests.cs
+++ b/Trellis.Core/tests/Errors/ValidationArgsTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace Trellis.Core.Tests.Errors;
 
+using System.Globalization;
+using System.Linq;
 using System.Text.Json;
 using FluentAssertions;
 using Trellis;
@@ -57,6 +59,47 @@ public class ValidationArgsTests
         ValidationArgs.Of().Should().BeEmpty();
 
     [Fact]
+    public void Allowed_names_the_entry_allowed() =>
+        ValidationArgs.Allowed(["red", "green"]).Should().ContainKey("allowed");
+
+    /// <remarks>
+    /// The whole point of routing every producer through one helper: query binding reads its
+    /// members from <c>Enum.GetNames</c> (declaration order), a <c>RequiredEnum</c> reads its own
+    /// registry, and nothing would otherwise force the two to agree. A client that diffs the list
+    /// across producers must not see a difference that is only ordering.
+    /// </remarks>
+    [Fact]
+    public void Allowed_sorts_ordinally_so_producers_cannot_disagree_on_order() =>
+        ValidationArgs.Allowed(["zulu", "alpha", "Mike"])["allowed"]
+            .Should().Be(ValidationArgValue.ListOf("Mike", "alpha", "zulu"));
+
+    [Fact]
+    public void Allowed_carries_each_name_as_text() =>
+        ValidationArgs.Allowed(["red"])["allowed"]
+            .Should().Be(new ValidationArgValue.List(EquatableArray.Create<ValidationArgValue>(
+                [new ValidationArgValue.Text("red")])));
+
+    /// <remarks>
+    /// An enum with no members is degenerate but reachable, and an empty array is the honest
+    /// answer — "nothing is permitted" — where omitting the entry would read as "this violation
+    /// forgot to say".
+    /// </remarks>
+    [Fact]
+    public void Allowed_with_no_names_is_an_empty_list() =>
+        ValidationArgs.Allowed([])["allowed"]
+            .Should().Be(ValidationArgValue.ListOf());
+
+    [Fact]
+    public void Allowed_reaches_the_wire_as_a_json_array_of_strings()
+    {
+        var json = JsonSerializer.SerializeToElement(ValidationArgs.Allowed(["green", "red"]));
+
+        json.GetProperty("allowed").ValueKind.Should().Be(JsonValueKind.Array);
+        json.GetProperty("allowed").EnumerateArray().Select(e => e.GetString())
+            .Should().Equal(["green", "red"]);
+    }
+
+    [Fact]
     public void Of_lets_a_later_pair_win_over_an_earlier_one_of_the_same_name() =>
         ValidationArgs.Of(("max", 1), ("max", 2))["max"]
             .Should().Be(new ValidationArgValue.Number(2));
@@ -94,5 +137,54 @@ public class ValidationArgsTests
         var text = new FieldViolation(InputPointer.ForProperty("a"), "code", ValidationArgs.Of("max", "1"));
 
         number.Should().NotBe(text);
+    }
+
+    /// <remarks>
+    /// A list a client cannot act on is not worth the bytes it costs. 248 country names serialize
+    /// to roughly 3 KB on <em>every</em> rejection, and a request with several invalid enum fields
+    /// multiplies that — a small request provoking a large response is an amplification vector, not
+    /// merely waste.
+    /// </remarks>
+    [Fact]
+    public void A_member_list_at_the_cap_is_still_published()
+    {
+        var names = Enumerable.Range(1, ValidationArgs.MaxAllowedMembers)
+            .Select(i => i.ToString("D3", CultureInfo.InvariantCulture));
+
+        var args = ValidationArgs.Allowed(names);
+
+        args.Should().ContainKey("allowed");
+        args.Should().NotContainKey("allowedCount");
+    }
+
+    /// <remarks>
+    /// The list is dropped whole rather than truncated. A truncated list is a false statement: it
+    /// tells a client that a member it omitted is not permitted, so a client rendering "choose one
+    /// of…" shows a wrong list and one validating against it rejects valid input. Absent already
+    /// means "not provided" — a blank value and a FluentValidation rule over a RequiredEnum both
+    /// omit it — so dropping it costs a client nothing it was not already handling.
+    /// </remarks>
+    [Fact]
+    public void One_member_past_the_cap_drops_the_list_rather_than_truncating_it()
+    {
+        var names = Enumerable.Range(1, ValidationArgs.MaxAllowedMembers + 1)
+            .Select(i => i.ToString("D3", CultureInfo.InvariantCulture));
+
+        var args = ValidationArgs.Allowed(names);
+
+        args.Should().NotContainKey("allowed");
+        args["allowedCount"].Should().Be(new ValidationArgValue.Number(ValidationArgs.MaxAllowedMembers + 1));
+    }
+
+    [Fact]
+    public void The_omitted_count_reaches_the_wire_as_a_json_number()
+    {
+        var names = Enumerable.Range(1, 248).Select(i => i.ToString("D3", CultureInfo.InvariantCulture));
+
+        var json = JsonSerializer.SerializeToElement(ValidationArgs.Allowed(names));
+
+        json.TryGetProperty("allowed", out _).Should().BeFalse();
+        json.GetProperty("allowedCount").ValueKind.Should().Be(JsonValueKind.Number);
+        json.GetProperty("allowedCount").GetInt32().Should().Be(248);
     }
 }

--- a/Trellis.Core/tests/Primitives/RequiredEnumAllowedArgsTests.cs
+++ b/Trellis.Core/tests/Primitives/RequiredEnumAllowedArgsTests.cs
@@ -1,0 +1,259 @@
+﻿namespace Trellis.Core.Tests.Primitives;
+
+using System.Text.Json;
+using FluentAssertions;
+using Trellis;
+
+/// <summary>
+/// An <c>enum.name-undefined</c> violation names the members it would have accepted, as
+/// machine-readable args rather than as English prose.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The members were never dropped — <c>RequiredEnum.TryCreate</c> has always joined them into the
+/// detail (<c>"'X' is not a valid Y. Valid values: A, B, C"</c>). The defect is that prose is the
+/// only place they lived: a client that wants to render "choose one of…" in the caller's language
+/// had to parse an English sentence, which is precisely the situation `Args` exists to end.
+/// </para>
+/// <para>
+/// The detail keeps its list. Args is additive here, not a replacement, so a human reading the
+/// response still gets a complete sentence.
+/// </para>
+/// </remarks>
+public sealed class RequiredEnumAllowedArgsTests
+{
+    private static ValidationArgValue? AllowedOf(Error error) =>
+        ((Error.InvalidInput)error).Fields.Items[0].Args?["allowed"];
+
+    [Fact]
+    public void An_undefined_name_carries_the_permitted_members()
+    {
+        var result = AllowedArgsShade.TryCreate("mauve");
+
+        result.IsFailure.Should().BeTrue();
+        AllowedOf(result.Error!).Should().Be(ValidationArgValue.ListOf("Amber", "Zinc"));
+    }
+
+    /// <remarks>
+    /// The fixture declares <c>Zinc</c> before <c>Amber</c> deliberately. Registry order is an
+    /// implementation detail of where the members happen to sit in the file; a wire contract a
+    /// client diffs across producers cannot inherit it.
+    /// </remarks>
+    [Fact]
+    public void The_permitted_members_are_ordinally_sorted_not_declaration_ordered()
+    {
+        var result = AllowedArgsShade.TryCreate("mauve");
+
+        AllowedOf(result.Error!).Should().Be(ValidationArgValue.ListOf("Amber", "Zinc"));
+    }
+
+    /// <remarks>
+    /// A blank value reports <c>value.not-empty</c>, not <c>enum.name-undefined</c> — the caller
+    /// named no member at all rather than an unrecognized one. Attaching the permitted set there
+    /// would make `allowed` mean "some enum was involved" instead of "these are your options",
+    /// and a client keying on its presence would be misled.
+    /// </remarks>
+    [Fact]
+    public void A_blank_value_is_not_an_undefined_name_and_carries_no_permitted_members()
+    {
+        var result = AllowedArgsShade.TryCreate("   ");
+
+        var violation = ((Error.InvalidInput)result.Error!).Fields.Items[0];
+        violation.ReasonCode.Should().Be(ValidationCodes.ValueNotEmpty);
+        violation.Args.Should().BeNull();
+    }
+
+    [Fact]
+    public void The_detail_still_spells_the_members_out_for_a_human()
+    {
+        var result = AllowedArgsShade.TryCreate("mauve");
+
+        ((Error.InvalidInput)result.Error!).Fields.Items[0].Detail
+            .Should().Contain("Valid values: Amber, Zinc");
+    }
+
+    [Fact]
+    public void The_permitted_members_reach_the_wire_as_a_json_array()
+    {
+        var result = AllowedArgsShade.TryCreate("mauve");
+
+        var json = JsonSerializer.SerializeToElement(
+            ((Error.InvalidInput)result.Error!).Fields.Items[0].Args);
+
+        json.GetProperty("allowed").ValueKind.Should().Be(JsonValueKind.Array);
+        json.GetProperty("allowed").EnumerateArray().Select(e => e.GetString())
+            .Should().Equal(["Amber", "Zinc"]);
+    }
+
+    /// <remarks>
+    /// The JSON converter is a fourth producer, and it curates its own message rather than
+    /// propagating the producer's detail (the raw name is attacker-supplied and is sanitized
+    /// here). That curation is exactly where a permitted set could have been dropped, so it is
+    /// asserted rather than assumed.
+    /// </remarks>
+    [Fact]
+    public void The_json_converter_carries_the_permitted_members_too()
+    {
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new RequiredEnumJsonConverter<AllowedArgsShade>() },
+        };
+
+        var act = () => JsonSerializer.Deserialize<AllowedArgsShade>("\"mauve\"", options);
+
+        var thrown = act.Should().Throw<TrellisJsonValidationException>().Which;
+        var violation = thrown.InvalidInput!.Fields.Items[0];
+        violation.ReasonCode.Should().Be(ValidationCodes.EnumNameUndefined);
+        violation.Args!["allowed"].Should().Be(ValidationArgValue.ListOf("Amber", "Zinc"));
+    }
+
+    /// <remarks>
+    /// The converter deliberately reports the <em>producer's</em> code, so a blank value arrives
+    /// as <c>value.not-empty</c> rather than <c>enum.name-undefined</c>. The permitted set must
+    /// follow the code, not the converter: attaching it here would make <c>allowed</c> mean "an
+    /// enum was involved" instead of "these are your options".
+    /// </remarks>
+    [Fact]
+    public void The_json_converter_omits_the_permitted_members_when_the_value_was_merely_blank()
+    {
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new RequiredEnumJsonConverter<AllowedArgsShade>() },
+        };
+
+        var act = () => JsonSerializer.Deserialize<AllowedArgsShade>("\"   \"", options);
+
+        var violation = act.Should().Throw<TrellisJsonValidationException>()
+            .Which.InvalidInput!.Fields.Items[0];
+        violation.ReasonCode.Should().Be(ValidationCodes.ValueNotEmpty);
+        violation.Args.Should().BeNull();
+    }
+}
+
+public sealed class AllowedArgsShade :
+    RequiredEnum<AllowedArgsShade>,
+    IScalarValue<AllowedArgsShade, string>
+{
+    public static readonly AllowedArgsShade Zinc = new();
+    public static readonly AllowedArgsShade Amber = new();
+
+    /// <remarks>
+    /// <para>
+    /// 248 country names cost roughly 3 KB of args and another 2.8 KB of prose on every rejection,
+    /// and a request with several invalid enum fields multiplies both — a small request provoking a
+    /// large response is an amplification vector, not merely waste.
+    /// </para>
+    /// <para>
+    /// Both halves are dropped whole rather than shortened. A truncated list reads as exhaustive,
+    /// so it would tell a client that a member it omitted is not permitted.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void An_enum_wider_than_the_cap_reports_a_count_instead_of_a_list()
+    {
+        var result = WideShade.TryCreate("mauve");
+
+        var violation = ((Error.InvalidInput)result.Error!).Fields.Items[0];
+        violation.ReasonCode.Should().Be(ValidationCodes.EnumNameUndefined);
+        violation.Args!.Should().NotContainKey("allowed");
+        violation.Args["allowedCount"].Should().Be(new ValidationArgValue.Number(65));
+    }
+
+    [Fact]
+    public void An_enum_wider_than_the_cap_keeps_its_detail_short_too()
+    {
+        var result = WideShade.TryCreate("mauve");
+
+        var detail = ((Error.InvalidInput)result.Error!).Fields.Items[0].Detail;
+        detail.Should().Be("'mauve' is not a valid WideShade.");
+        detail.Should().NotContain("Valid values",
+            "capping the args while the prose still spells out every member would leave the larger half of the payload in place");
+    }
+
+    [Fact]
+    public void The_json_converter_applies_the_same_cap_to_both_halves()
+    {
+        var options = new JsonSerializerOptions
+        {
+            Converters = { new RequiredEnumJsonConverter<WideShade>() },
+        };
+
+        var act = () => JsonSerializer.Deserialize<WideShade>("\"mauve\"", options);
+
+        var thrown = act.Should().Throw<TrellisJsonValidationException>().Which;
+        var violation = thrown.InvalidInput!.Fields.Items[0];
+        violation.Args!.Should().NotContainKey("allowed");
+        violation.Args["allowedCount"].Should().Be(new ValidationArgValue.Number(65));
+        thrown.Message.Should().NotContain("Valid values");
+    }
+}
+
+/// <summary>65 members — one past <see cref="ValidationArgs.MaxAllowedMembers"/>.</summary>
+public sealed class WideShade : RequiredEnum<WideShade>, IScalarValue<WideShade, string>
+{
+    public static readonly WideShade M01 = new();
+    public static readonly WideShade M02 = new();
+    public static readonly WideShade M03 = new();
+    public static readonly WideShade M04 = new();
+    public static readonly WideShade M05 = new();
+    public static readonly WideShade M06 = new();
+    public static readonly WideShade M07 = new();
+    public static readonly WideShade M08 = new();
+    public static readonly WideShade M09 = new();
+    public static readonly WideShade M10 = new();
+    public static readonly WideShade M11 = new();
+    public static readonly WideShade M12 = new();
+    public static readonly WideShade M13 = new();
+    public static readonly WideShade M14 = new();
+    public static readonly WideShade M15 = new();
+    public static readonly WideShade M16 = new();
+    public static readonly WideShade M17 = new();
+    public static readonly WideShade M18 = new();
+    public static readonly WideShade M19 = new();
+    public static readonly WideShade M20 = new();
+    public static readonly WideShade M21 = new();
+    public static readonly WideShade M22 = new();
+    public static readonly WideShade M23 = new();
+    public static readonly WideShade M24 = new();
+    public static readonly WideShade M25 = new();
+    public static readonly WideShade M26 = new();
+    public static readonly WideShade M27 = new();
+    public static readonly WideShade M28 = new();
+    public static readonly WideShade M29 = new();
+    public static readonly WideShade M30 = new();
+    public static readonly WideShade M31 = new();
+    public static readonly WideShade M32 = new();
+    public static readonly WideShade M33 = new();
+    public static readonly WideShade M34 = new();
+    public static readonly WideShade M35 = new();
+    public static readonly WideShade M36 = new();
+    public static readonly WideShade M37 = new();
+    public static readonly WideShade M38 = new();
+    public static readonly WideShade M39 = new();
+    public static readonly WideShade M40 = new();
+    public static readonly WideShade M41 = new();
+    public static readonly WideShade M42 = new();
+    public static readonly WideShade M43 = new();
+    public static readonly WideShade M44 = new();
+    public static readonly WideShade M45 = new();
+    public static readonly WideShade M46 = new();
+    public static readonly WideShade M47 = new();
+    public static readonly WideShade M48 = new();
+    public static readonly WideShade M49 = new();
+    public static readonly WideShade M50 = new();
+    public static readonly WideShade M51 = new();
+    public static readonly WideShade M52 = new();
+    public static readonly WideShade M53 = new();
+    public static readonly WideShade M54 = new();
+    public static readonly WideShade M55 = new();
+    public static readonly WideShade M56 = new();
+    public static readonly WideShade M57 = new();
+    public static readonly WideShade M58 = new();
+    public static readonly WideShade M59 = new();
+    public static readonly WideShade M60 = new();
+    public static readonly WideShade M61 = new();
+    public static readonly WideShade M62 = new();
+    public static readonly WideShade M63 = new();
+    public static readonly WideShade M64 = new();
+    public static readonly WideShade M65 = new();
+}

--- a/Trellis.FluentValidation/src/ValidationArgsProjection.cs
+++ b/Trellis.FluentValidation/src/ValidationArgsProjection.cs
@@ -83,6 +83,12 @@ public static class ValidationArgsProjection
     private const int MaxStringLength = 64;
 
     /// <summary>
+    /// FluentValidation's error code for <c>IsInEnum()</c>, which
+    /// <see cref="ValidationCodeProjection"/> maps to <see cref="ValidationCodes.EnumUndefined"/>.
+    /// </summary>
+    private const string EnumValidatorCode = "EnumValidator";
+
+    /// <summary>
     /// Combines the framework allowlist with the application's widening for one error code.
     /// </summary>
     /// <remarks>
@@ -124,6 +130,56 @@ public static class ValidationArgsProjection
     public static ImmutableDictionary<string, ValidationArgValue>? Project(
         ValidationFailure failure,
         ValidationArgsOptions? options = null)
+    {
+        var projected = ProjectPlaceholders(failure, options);
+        var allowedMembers = AllowedEnumMembers(failure);
+
+        if (allowedMembers is null)
+            return projected;
+
+        return projected is null ? allowedMembers : projected.SetItems(allowedMembers);
+    }
+
+    /// <summary>
+    /// Names the members an <c>EnumValidator</c> failure would have accepted.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the one arg that does not come from a placeholder, because FluentValidation has no
+    /// placeholder for it: the default message reports only the value it rejected. Deriving it
+    /// here is what lets a FluentValidation rule and a Trellis query binding answer the same
+    /// rejection identically — a client cannot render one localized message for
+    /// <c>enum.undefined</c> if the arg it needs is present from one producer and absent from
+    /// another.
+    /// </para>
+    /// <para>
+    /// It is therefore also the one arg the containment gate cannot judge, and must not. The gate
+    /// asks whether a value already reached the client in the message, which is the right question
+    /// for an operand the application chose — a bound, a regex, a compared property. Member names
+    /// are not that. They are the API's own contract, the very spellings a client has to send to
+    /// succeed, and every other producer of this code already publishes them in its detail prose.
+    /// Withholding them here would conceal nothing while breaking the agreement.
+    /// </para>
+    /// <para>
+    /// The members are read from the attempted value's own type rather than the rule's, because
+    /// FluentValidation reports no type. An error code an application borrowed for a rule over
+    /// some other type therefore names nothing, which is the fail-safe direction.
+    /// </para>
+    /// </remarks>
+    private static ImmutableDictionary<string, ValidationArgValue>? AllowedEnumMembers(ValidationFailure failure)
+    {
+        if (!string.Equals(failure.ErrorCode, EnumValidatorCode, StringComparison.Ordinal))
+            return null;
+
+        var attemptedType = failure.AttemptedValue?.GetType();
+        return attemptedType is { IsEnum: true }
+            ? ValidationArgs.Allowed(Enum.GetNames(attemptedType))
+            : null;
+    }
+
+    private static ImmutableDictionary<string, ValidationArgValue>? ProjectPlaceholders(
+        ValidationFailure failure,
+        ValidationArgsOptions? options)
     {
         var placeholders = failure.FormattedMessagePlaceholderValues;
         if (placeholders is null || placeholders.Count == 0)

--- a/Trellis.FluentValidation/tests/ValidationArgsProjectionTests.cs
+++ b/Trellis.FluentValidation/tests/ValidationArgsProjectionTests.cs
@@ -11,7 +11,14 @@ using Trellis.FluentValidation;
 /// </summary>
 public class ValidationArgsProjectionTests
 {
-    private sealed record Subject(string A = "", string B = "", decimal D = 0m, int N = 0, DateTime When = default, double F = 0d);
+    private sealed record Subject(string A = "", string B = "", decimal D = 0m, int N = 0, DateTime When = default, double F = 0d, Shade Tone = default, Shade? MaybeTone = null, Shade[]? Tones = null);
+
+    /// <summary>Declares Zinc before Amber so ordinal ordering is distinguishable from declaration order.</summary>
+    internal enum Shade
+    {
+        Zinc = 1,
+        Amber = 2,
+    }
 
     private static FieldViolation Violate(Action<InlineValidator<Subject>> configure, Subject subject)
     {
@@ -246,4 +253,111 @@ public class ValidationArgsProjectionTests
         violation.Args!["comparisonValue"].Should().Be(new ValidationArgValue.Number(10),
             "a numeric value encodes to exactly what FluentValidation rendered, so nothing is suppressed");
     }
+
+    [Fact]
+    public void An_enum_failure_names_the_members_it_would_have_accepted()
+    {
+        var violation = Violate(v => v.RuleFor(x => x.Tone).IsInEnum(), new Subject(Tone: (Shade)99));
+
+        violation.ReasonCode.Should().Be(ValidationCodes.EnumUndefined);
+        violation.Args.Should().NotBeNull();
+        violation.Args!["allowed"].Should().Be(
+            ValidationArgValue.ListOf(new ValidationArgValue.Text("Amber"), new ValidationArgValue.Text("Zinc")),
+            "the members are ordinally sorted, so Amber precedes Zinc even though Zinc is declared first");
+    }
+
+    [Fact]
+    public void An_enum_failure_agrees_with_every_other_producer_of_the_same_code()
+    {
+        var violation = Violate(v => v.RuleFor(x => x.Tone).IsInEnum(), new Subject(Tone: (Shade)99));
+
+        violation.Args!["allowed"].Should().Be(
+            ValidationArgs.Allowed(Enum.GetNames<Shade>())["allowed"],
+            "a client must not be able to tell which producer rejected the value");
+    }
+
+    [Fact]
+    public void A_nullable_enum_failure_names_its_members_too()
+    {
+        var violation = Violate(v => v.RuleFor(x => x.MaybeTone).IsInEnum(), new Subject(MaybeTone: (Shade)99));
+
+        violation.Args!["allowed"].Should().Be(
+            ValidationArgs.Allowed(Enum.GetNames<Shade>())["allowed"]);
+    }
+
+    [Fact]
+    public void The_enum_code_on_a_non_enum_rule_names_nothing()
+    {
+        var violation = Violate(
+            v => v.RuleFor(x => x.A).NotEmpty().WithErrorCode("EnumValidator"),
+            new Subject(A: ""));
+
+        violation.Args.Should().BeNull(
+            "the members are derived from the attempted value's own type, so an error code borrowed by a rule over a string has no member list to name");
+    }
+
+    [Fact]
+    public void An_enum_failure_names_its_members_even_when_the_application_replaced_the_message()
+    {
+        var violation = Violate(
+            v => v.RuleFor(x => x.Tone).IsInEnum().WithMessage("bad"),
+            new Subject(Tone: (Shade)99));
+
+        violation.Args!["allowed"].Should().Be(
+            ValidationArgs.Allowed(Enum.GetNames<Shade>())["allowed"],
+            "the member list is the API's own contract rather than an echo of the message, so it does not pass through the containment gate");
+    }
+
+    [Fact]
+    public void An_opted_in_placeholder_joins_the_member_list_rather_than_replacing_it()
+    {
+        var options = new ValidationArgsOptions().AllowArgs("EnumValidator", "CollectionIndex");
+        var validator = new InlineValidator<Subject>();
+        validator.RuleForEach(x => x.Tones).IsInEnum();
+        // Index 9 so its rendering appears in the message's own "99", which the containment gate
+        // requires of every placeholder arg; the member list below is exempt from that gate.
+        var subject = new Subject(Tones: [.. Enumerable.Repeat(Shade.Zinc, 9), (Shade)99]);
+
+        var result = validator.Validate(subject).ToResult(subject, argsOptions: options);
+
+        var violation = ((Error.InvalidInput)result.Error!).Fields[0];
+        violation.Args!["allowed"].Should().Be(ValidationArgs.Allowed(Enum.GetNames<Shade>())["allowed"]);
+        violation.Args.Should().ContainKey("collectionIndex",
+            "the member list is merged into the projected placeholders rather than substituted for them");
+    }
+
+    /// <remarks>
+    /// <c>RequiredEnum&lt;T&gt;</c> is a registry of declared statics, not a CLR enum, so
+    /// FluentValidation's <c>IsInEnum()</c> rejects <em>every</em> value of one — including a valid
+    /// member. That is FluentValidation's own behaviour and not something Trellis can correct from
+    /// here; what Trellis controls is that a violation it cannot substantiate names nothing, rather
+    /// than lending a spurious rejection the authority of a member list.
+    /// </remarks>
+    [Fact]
+    public void A_RequiredEnum_is_not_a_clr_enum_so_the_violation_names_nothing()
+    {
+        var validator = new InlineValidator<ToneHolder>();
+        validator.RuleFor(x => x.Tone).IsInEnum();
+        var holder = new ToneHolder { Tone = SmartTone.Zinc };
+
+        var result = validator.Validate(holder).ToResult(holder);
+
+        result.IsFailure.Should().BeTrue();
+        var violation = ((Error.InvalidInput)result.Error!).Fields[0];
+        violation.ReasonCode.Should().Be(ValidationCodes.EnumUndefined);
+        violation.Args.Should().BeNull(
+            "the members are read from the attempted value's own type, and a RequiredEnum has none to read");
+    }
+
+    private sealed class ToneHolder
+    {
+        public SmartTone? Tone { get; set; }
+    }
+}
+
+/// <summary>A registry-backed symbolic value, deliberately not a CLR enum.</summary>
+public sealed partial class SmartTone : RequiredEnum<SmartTone>, IScalarValue<SmartTone, string>
+{
+    public static readonly SmartTone Zinc = new();
+    public static readonly SmartTone Amber = new();
 }

--- a/docs/docfx_project/api_reference/trellis-api-asp.md
+++ b/docs/docfx_project/api_reference/trellis-api-asp.md
@@ -463,7 +463,7 @@ public sealed record FieldViolationProblemDetail(
 | `Code` | `string` | The machine-readable reason code. |
 | `Detail` | `string?` | Human-readable explanation. Omitted when absent. |
 | `Location` | `ViolationLocation` | Where the offending value came from. |
-| `Args` | `IReadOnlyDictionary<string, ValidationArgValue>?` | Arguments that parameterize the message, letting a client render its own localized prose. Omitted when absent. |
+| `Args` | `IReadOnlyDictionary<string, ValidationArgValue>?` | Arguments that parameterize the message, letting a client render its own localized prose. Omitted when absent. An enum rejection (`enum.name-undefined`, `enum.undefined`) carries `allowed` — the permitted member names, ordinally sorted — from every producer that can reject one: query binding, the body converter, `RequiredEnum.TryCreate`, its JSON converter, and a FluentValidation `IsInEnum()` rule. Beyond 64 members the list is dropped whole and `allowedCount` is sent instead, so a client must treat a missing `allowed` as "not supplied" rather than "nothing is permitted". |
 
 AOT-friendly JSON payload used inside Problem Details `extensions["fieldViolations"]` for `Error.InvalidInput` field violations. Application code should treat this as response shape metadata, not as a domain model.
 

--- a/docs/docfx_project/api_reference/trellis-api-core.md
+++ b/docs/docfx_project/api_reference/trellis-api-core.md
@@ -725,8 +725,8 @@ Emit these by constant, not by literal — a typo in a literal is a silent wire 
 | `FieldsExactlyOne` | `fields.exactly-one` | Exactly one of a group was required. |
 | `FieldsOnlyOne` | `fields.only-one` | At most one of a group was allowed. |
 | `FieldsAtLeastOne` | `fields.at-least-one` | None of a group was supplied. |
-| `EnumNameUndefined` | `enum.name-undefined` | The supplied name is not a member of the enum. |
-| `EnumUndefined` | `enum.undefined` | A numeric value parsed but is not a defined member. |
+| `EnumNameUndefined` | `enum.name-undefined` | The supplied name is not a member of the enum. Args: `allowed`, the permitted member names as a JSON array of strings, ordinally sorted. |
+| `EnumUndefined` | `enum.undefined` | A numeric value parsed but is not a defined member. Args: `allowed`, the same list the name failure carries — the remedy is identical, so a client is told its options whichever form it sent. |
 | `MoneyCurrencyMismatch` | `money.currency-mismatch` | An operation combined two different currencies. Args: `expected`, `actual`. |
 | `MoneyNegativeResult` | `money.negative-result` | The operation would produce a negative amount. |
 | `PageSizeOutOfRange` | `page-size.out-of-range` | Page size not positive, or above the maximum. |
@@ -828,6 +828,32 @@ ValidationArgs.Of(
 
 > [!NOTE]
 > There is deliberately **no `IFormattable` overload**. Adding one would make `ValidationArgs.Of("max", 255)` *ambiguous* — an `int` converts to `IFormattable` by boxing and to `ValidationArgValue` by a user-defined conversion, and neither target is better than the other, so the call fails with `CS0121`. Its absence is what lets the implicit conversions bind. Format a value with no numeric or textual meaning of its own, such as a timestamp, explicitly and invariantly at the call site.
+
+##### `ValidationArgs.Allowed(...)` — the permitted-members entry
+
+`ValidationArgs.Allowed(names)` builds the `allowed` entry naming the members a symbolic value may take, and is what every producer that rejects a value for not being one of a fixed set calls:
+
+```csharp
+ValidationArgs.Allowed(Enum.GetNames(typeof(Colour)));   // {"allowed": ["Green", "Red"]}
+```
+
+It exists as a helper rather than as a convention because the producers derive their members from unrelated places — `Enum.GetNames` for query binding and the body converter, a registry of declared statics for `RequiredEnum` — and nothing else would force those to agree on either the entry's name or its order. The names are sorted **ordinally**, which makes the order total and culture-independent; sorting by the current culture would let the same enum serialize differently on two machines. A client may therefore compare or cache the list across producers.
+
+Passing no names yields an empty array rather than omitting the entry: "nothing is permitted" is a real answer, where a missing entry reads as "this violation forgot to say".
+
+**A list longer than `ValidationArgs.MaxAllowedMembers` (64) is dropped whole and replaced by `allowedCount`.**
+
+```csharp
+ValidationArgs.Allowed(isoCountryNames);   // {"allowedCount": 248}
+```
+
+The bound exists because a list a client cannot act on is not worth what it costs to send. The 248 ISO country names serialize to roughly 3 KB attached to *every* rejection, and a request carrying several invalid enum fields multiplies that — a small request provoking a large response is an amplification vector, not merely waste. Past a few dozen options a client is not rendering "choose one of…" from an error payload anyway; it wants a schema or an enumeration endpoint.
+
+The list is dropped rather than **truncated** because a client cannot distinguish a shortened list from a complete one. A truncated `allowed` is a false statement: it tells a client that a member it omitted is not permitted, so a client rendering a chooser shows a wrong set and a client validating against it rejects valid input. Omission is a case every client already handles, because a blank value carries no list either — `allowedCount` is what separates "too many to send" from "not applicable here".
+
+The bound counts members rather than serialized bytes because member names are identifiers in every producer — CLR enum names, or the static field names behind a `RequiredEnum` — so their length is already bounded in practice, and a count is something a client can be told and can predict.
+
+The same bound governs the human-readable `Detail`. `RequiredEnum.TryCreate` and `RequiredEnumJsonConverter` spell their members into prose (`"'x' is not a valid Colour. Valid values: Green, Red"`), which for 248 countries is another 2.8 KB — more than the arg it accompanies. Above the bound that clause is dropped too, leaving `"'x' is not a valid Country."`, which is the sentence the body converter already emits.
 
 `ValidationArgValueJsonConverter` is applied to the union by attribute, so serialization needs no registration. It is public because the `System.Text.Json` source generator cannot resolve an internal converter: a trimmed or AOT-published application whose `JsonSerializerContext` roots a violation payload fails at compile time with `SYSLIB1220` otherwise.
 

--- a/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
+++ b/docs/docfx_project/api_reference/trellis-api-fluentvalidation.md
@@ -169,7 +169,7 @@ public static class ValidationArgsProjection
 
 | Signature | Returns | Description |
 | --- | --- | --- |
-| `public static ImmutableDictionary<string, ValidationArgValue>? Project(ValidationFailure failure, ValidationArgsOptions? options = null)` | `ImmutableDictionary<string,ValidationArgValue>?` | Projects a failure's `FormattedMessagePlaceholderValues` onto the `Args` carried by `FieldViolation`, applying the allowlist, the containment gate and the encoding rules below. Returns `null` when nothing survives. Both adapters call this — `FluentValidationResultExtensions.ToResult` and, in `Trellis.Mediator.FluentValidation`, `FluentValidationMessageValidatorAdapter`. |
+| `public static ImmutableDictionary<string, ValidationArgValue>? Project(ValidationFailure failure, ValidationArgsOptions? options = null)` | `ImmutableDictionary<string,ValidationArgValue>?` | Projects a failure's `FormattedMessagePlaceholderValues` onto the `Args` carried by `FieldViolation`, applying the allowlist, the containment gate and the encoding rules below, and merges in the `allowed` member list for an `IsInEnum()` failure. Returns `null` when nothing survives. Both adapters call this — `FluentValidationResultExtensions.ToResult` and, in `Trellis.Mediator.FluentValidation`, `FluentValidationMessageValidatorAdapter`. |
 
 `Args` is what lets a client render its own localized message instead of displaying the server's English prose. Blanket camelCase pass-through of FluentValidation's placeholders is unsafe on two independent counts, so two controls apply.
 
@@ -185,6 +185,7 @@ public static class ValidationArgsProjection
 | `InclusiveBetween`, `ExclusiveBetween` | `from`, `to` |
 | `ScalePrecision` | `expectedPrecision`, `expectedScale`, `actualScale`, `digits` |
 | `RegularExpression` | `regularExpression` |
+| `IsInEnum` | `allowed` — derived rather than projected, and exempt from the gate below |
 | all others | none |
 
 `ExactLength` allows `maxLength` and **not** `minLength`, which looks arbitrary because `ExactLengthValidator(n)` calls `base(n, n)` and so populates both with the same correct value. The allowlist does not act alone — it composes with the gate below, and the pinned template names `{MaxLength}`. Allowlisting `minLength` would gate it out for being absent from the template while `maxLength` was dropped for not being allowlisted, and the expected length would vanish from the wire entirely, leaving a client with the length it sent and no bound to compare it against. **The allowlist tracks the template, not merely the populated fields.**
@@ -199,13 +200,31 @@ The consequences fall out uniformly, with no per-arg judgement:
 | Case | Result |
 | --- | --- |
 | default message | the templated args emit — they are already in today's `errors` string, so nothing new is disclosed |
-| `.WithMessage("bad")` | nothing emits — the app took the values out of its prose |
+| `.WithMessage("bad")` | nothing emits — the app took the values out of its prose. `allowed` is exempt and still emits |
 | `AppendArgument("Secret", …)` | nothing emits — in no template, and Trellis cannot classify it |
 | localized message (e.g. `culture es`) | the templated args emit, because `GetString` returns the *culture-active* template |
 | an app-supplied `ErrorCode` | nothing emits — an unrecognized code resolves to no template, which is fail-safe and consistent with a user-set code always winning |
+| the gate itself | never applies to `allowed`, which is derived rather than projected |
 | `Matches(...)`, any message | `regularExpression` never emits — it is in no default template, so emitting it would disclose an internal format |
 
 `PropertyValue`, `PropertyPath` and `PropertyName` are denied unconditionally, on app-authored placeholders too: `PropertyValue` carries the user's submitted input and *is* rendered into some default messages, so containment alone would let it through. `PropertyName` is redundant with the violation's own location.
+
+**Enum members — the one derived arg.** An `IsInEnum()` failure carries `allowed`, the permitted member names ordinally sorted, exactly as every other Trellis producer of `enum.undefined` does:
+
+```json
+{ "code": "enum.undefined", "args": { "allowed": ["Amber", "Zinc"] } }
+```
+
+It is derived rather than projected because FluentValidation has no placeholder for it — the default message reports only the value it rejected. The members are read from the **attempted value's own type**, since FluentValidation reports no type of its own. So an `ErrorCode` an application borrowed for a rule over something that is not an enum names nothing, which is the fail-safe direction, and a nullable enum works because a boxed `Shade?` is a `Shade`.
+
+This is the one arg the containment gate does not judge, and must not. The gate asks whether a value already reached the client in the rendered message — the right question for an operand the *application* chose, such as a bound, a regex or a compared property. Member names are not that: they are the API's own contract, the very spellings a client must send to succeed, and the other producers of this code publish them in their detail prose already. So `allowed` survives `.WithMessage(...)`, unlike every row in the table above. Withholding it would conceal nothing and would break the agreement the arg exists to create — a client cannot render one localized *"choose one of…"* for `enum.undefined` if the list is present from a query binding and absent from a validator.
+
+An application that widens the allowlist for `EnumValidator` through `ValidationArgsOptions` gets its placeholders **in addition to** `allowed`, not instead of it.
+
+An enum with more than `ValidationArgs.MaxAllowedMembers` (64) members sends `allowedCount` instead of the list, on this path as on every other — see `trellis-api-core.md`.
+
+> [!WARNING]
+> **`IsInEnum()` does not work on a `RequiredEnum<T>`, and fails open the wrong way.** `RequiredEnum<T>` is a registry of declared statics rather than a CLR enum, and FluentValidation's `EnumValidator` rejects any type that is not a CLR enum — so the rule fails **every** value, including a perfectly valid member, with `enum.undefined`. This is FluentValidation's own behaviour and predates the `allowed` arg. Validate a `RequiredEnum<T>` through its own `TryCreate` or the scalar-value binding pipeline, both of which do carry `allowed`; if you need a FluentValidation rule, write it against the underlying `string`. Such a violation carries no `allowed`, because the members are read from the attempted value's type and a `RequiredEnum<T>` has no CLR members to read — a spurious rejection is not given the authority of a member list.
 
 **Bounding.** Every string-valued arg is capped at 64 characters (with a `...` marker) and control characters are escaped as `\uXXXX`. The bound is universal rather than targeted because no structural rule identifies which args can carry submitted input: `Equal(x => x.Other + "!")` carries the full submitted value with an **empty** `ComparisonProperty`, byte-for-byte indistinguishable from a safe literal comparison.
 


### PR DESCRIPTION
An `enum.name-undefined` violation told the client only that its value was wrong, in an English sentence. A client that wanted to show the caller which products it could pick had to parse `"Valid values: Checking, MoneyMarket, Savings"` out of `detail` — and three of the five producers did not print the members at all, so for those there was nothing to parse.

This attaches the members as a machine-readable `args.allowed` array, so a client can render its own chooser in the caller's own language:

```json
"fieldViolations": [{
  "code": "enum.name-undefined",
  "detail": "'Platinum' is not a valid AccountType. Valid values: Checking, MoneyMarket, Savings",
  "location": { "in": "body", "pointer": "/accountType" },
  "args": { "allowed": ["Checking", "MoneyMarket", "Savings"] }
}]
```

The English sentence is kept alongside the list, not replaced by it.

## One choke point, because five producers must agree

All five routes through `ValidationArgs.Allowed`, which fixes the entry name and the ordinal sort in one place:

| Producer | Members from | Previously printed |
|---|---|---|
| `RequiredEnum.TryCreate` | registry of declared statics | all names |
| `RequiredEnumJsonConverter` | registry of declared statics | all names |
| `PrimitiveConverter` (query/route) | `Enum.GetNames` | *nothing* — "The value is not a recognized option." |
| `ScalarValueJsonConverterBase` (body) | `Enum.GetNames` | *nothing* — "'X' is not a valid Y." |
| `ValidationArgsProjection` (FluentValidation) | failure's attempted value | FluentValidation's own message |

They derive members from unrelated sources, and nothing but a shared choke point would force them to line up.

## Bounded at 64 members — omitted, never truncated

A real 248-member enum of ISO country names costs **3,177 bytes** of `allowed` per violation, on top of **2,825 bytes** of prose. Over `ValidationArgs.MaxAllowedMembers = 64` the list is dropped *whole* and replaced by `allowedCount`.

Truncating would publish a false statement: a client cannot distinguish a shortened list from a complete one, so it would render a wrong chooser and reject input that is actually valid. Absent already means "not provided" — blank values and the `RequiredEnum` case below both omit it — so dropping costs clients nothing new, and `allowedCount` still separates "too many" from "not applicable".

The same constant bounds the English prose via `EnumMemberProse`, so the two cannot diverge. Capping only the arg would have left the larger half in place.

## Two deliberate FluentValidation decisions

**`allowed` bypasses the containment gate.** That gate asks whether an arg's value already appeared in the rendered message — right for an application-chosen operand (a bound, a regex, a compared property), wrong for member names, which are the API's own contract and which other producers already print. Consequence: `allowed` survives a custom `.WithMessage(...)`.

**It is guarded on `IsEnum`.** FluentValidation's `IsInEnum()` rejects *every* value of a `RequiredEnum` property, including valid members — a pre-existing trap now called out with a warning in the reference. A list derived from that failure would be meaningless, so none is emitted.

## Behavior change

`detail` text changes for enums wider than 64 members: the "Valid values: …" clause is dropped. Noted in the changelog.

## Validation

Release build 0 warnings · **8,272 tests, 0 failed** · API-reference lint, stale-docs, and stale-v1 gates all exit 0 · gpt-5.5 code review clean.

Both cap gates and both FluentValidation branches were mutation-tested. The new `api.http` entry was mutation-tested too, to confirm it is genuinely replayed rather than silently skipped.

Docs updated in `trellis-api-core.md`, `trellis-api-asp.md`, and `trellis-api-fluentvalidation.md`, plus a Showcase example (test + `api.http`) demonstrating the payload against a real host.