### PR TITLE
chore: bump package validation baseline to 3.0.0-alpha.458

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -99,8 +99,13 @@
 
       Bump this in the same commit that publishes a release. Leaving it behind means comparing
       against an ever-older surface and re-reporting breaks that were already accepted.
+
+      This must name a version published to nuget.org, not merely one present in the local
+      package cache. Packing locally leaves builds like 3.0.0-alpha.484 in ~/.nuget/packages,
+      so a baseline pointing at one restores here and fails restore on CI, where the only feed
+      is nuget.org.
     -->
-    <PackageValidationBaselineVersion>3.0.0-alpha.455</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>3.0.0-alpha.458</PackageValidationBaselineVersion>
 
     <!-- Release hygiene (ga-07) -->
     <!-- DotNet.ReproducibleBuilds bundles Microsoft.SourceLink.GitHub and sets


### PR DESCRIPTION
## What

Bumps `PackageValidationBaselineVersion` from `3.0.0-alpha.455` to `3.0.0-alpha.458`, and records why the baseline must name a *published* version.

## Why

`alpha.458` is the newest version of every Trellis package on nuget.org. With the baseline pinned at `.455`, every pack compared the current surface against a release older than the one consumers actually have, re-reporting breaks that had already shipped and been accepted — which is exactly what the comment above the property warns against.

## Verification

**All 23 packable packages publish `.458`.** Queried via the NuGet flat-container API rather than assumed from `Trellis.Core`; a baseline missing for even one package fails that package's restore.

**The gate is live, not vacuous.** With the new baseline in place, flipping `public static class EquatableArray` to `internal` and re-packing `Trellis.Core` produces:

```
error CP0001: Type 'Trellis.EquatableArray' exists on [Baseline] lib/net10.0/Trellis.Core.dll
  but not on lib/net10.0/Trellis.Core.dll
```

compared against the `alpha.458` nupkg. The change was reverted. This check mattered: validation *was* being skipped via an up-to-date `Microsoft.NET.ApiCompat.ValidatePackage.semaphore`, and a skipped run is indistinguishable from a passing one in pack output. All 23 semaphores were therefore deleted before the verifying solution-wide pack, which exits 0 with no CP diagnostics and recreates all 23.

**No suppression churn.** Each of the five `CompatibilitySuppressions.xml` files was tested by moving it aside and re-packing — all five still fail with `CP0002`/`CP0012`, so none is wholly unnecessary at the new baseline. Each was also regenerated with `/p:ApiCompatGenerateSuppressionFile=true` and its entry set diffed against the committed file: **zero stale entries, zero missing entries** across all five. The regenerated files were discarded. Leaving them untouched preserves the hand-written rationale comments that `Trellis.Core/src/CompatibilitySuppressions.xml` explicitly warns regeneration would drop.

`alpha.455` is referenced nowhere else in the repository.

## The added comment

While choosing the version I found that the local package cache holds `alpha.470`, `.483` and `.484` — none of which are on nuget.org; they are local `dotnet pack` artifacts. A baseline naming one of those restores fine on a developer machine and fails restore on CI, whose only feed is nuget.org. The new paragraph records that constraint.

## Note for future bumps

Moving the baseline forward bakes in any break made between `.455` and `.458`, so it is no longer reported. That is intended — `.458` is what consumers have — but it is the reason this bump belongs with each release rather than in batches.