### PR TITLE
fix(ci): stamp the SBOM with the real package version

### DIFF
--- a/.github/workflows/publish-nuget-org.yml
+++ b/.github/workflows/publish-nuget-org.yml
@@ -75,7 +75,17 @@ jobs:
           Copy-Item -Path $packageFile.FullName -Destination $dropDirectory -Force
         }
 
-        $packageVersion = (dotnet msbuild .\Trellis.Core\src\Trellis.Core.csproj --getProperty:PackageVersion).Trim()
+        # Must come from nbgv, not `dotnet msbuild --getProperty:PackageVersion`.
+        # Nerdbank.GitVersioning computes the version inside the GetBuildVersion
+        # target, which --getProperty does not run, so it reports the static
+        # evaluation-time default (1.0.0) and stamps the SBOM with a version no
+        # package in the drop carries.
+        $packageVersion = (nbgv get-version -v NuGetPackageVersion).Trim()
+
+        $packagePattern = "Trellis.Core.$packageVersion.nupkg"
+        if (-not (Test-Path -LiteralPath (Join-Path $dropDirectory $packagePattern))) {
+          throw "SBOM version '$packageVersion' does not match the packed artifacts; expected $packagePattern in the drop."
+        }
 
         sbom-tool generate `
           -b $dropDirectory `


### PR DESCRIPTION
## Summary

The release SBOM was being stamped `1.0.0` while the packages it described were `3.0.0-alpha.492`. The step exited `0` and produced a structurally valid SPDX 3.0 manifest, so nothing failed — the SBOM was simply wrong about what it described.

Found while verifying the SBOM step end to end. It was the only step in `publish-nuget-org.yml` that the `alpha.491` local-feed release rehearsal did not exercise, because it installs a global tool and runs against a drop directory.

## Root cause

Versioning is done by Nerdbank.GitVersioning, which computes the version inside the MSBuild `GetBuildVersion` **target**. `--getProperty` evaluates properties but does not run targets, so it returned the static evaluation-time default.

| Invocation | Result |
|---|---|
| `dotnet msbuild <proj> --getProperty:PackageVersion` — **what the step used** | `1.0.0` ❌ |
| `dotnet msbuild <proj> -restore --getProperty:PackageVersion` | `1.0.0` ❌ |
| `dotnet msbuild <proj> -t:GetBuildVersion --getProperty:PackageVersion` | `3.0.0-alpha.492` ✅ |
| `nbgv get-version -v NuGetPackageVersion` | `3.0.0-alpha.492` ✅ |
| Actual packed artifact in the drop | `Trellis.Core.3.0.0-alpha.492.nupkg` |

Running the step verbatim against a real 23-package pack produced a manifest carrying the wrong version in three places:

- root package `software_packageVersion`: `1.0.0`
- `SpdxDocument` name: `Trellis 1.0.0`
- namespace URI: `https://github.com/xavierjohn/Trellis/sbom/Trellis/1.0.0/…`

## Changes

**1. Source the version from `nbgv`.** `nbgv get-version -v NuGetPackageVersion` replaces the `dotnet msbuild` call. `nbgv` is already installed globally by the earlier `Setup versioning` step in the same job, so this adds no dependency, and it puts the SBOM on the same source of truth that names the packed files. A comment records why `--getProperty` cannot be used, so it doesn't get "simplified" back later.

**2. Add a version/artifact mismatch guard.** The defect's real cost was that nothing failed, so the fix includes a check: throw unless `Trellis.Core.$packageVersion.nupkg` is actually present in the drop directory.

## Verification

Run on Windows against a real Release build and 23-package pack:

- Guard **passes** for `3.0.0-alpha.492`.
- Guard **rejects** the old `1.0.0` value, with the diagnostic naming the expected file.
- Guard **fails closed** on empty, whitespace-only, and error-string versions — none of them can pass, so a future version-resolution failure (shallow clone, `nbgv` missing) cannot silently ship a wrong SBOM.
- `sbom-tool` succeeds post-fix (exit `0`), and the regenerated manifest carries `3.0.0-alpha.492` in all three places above.

Also confirmed while I was in there, all previously unverified:

- The empty-`nupkgs` guard genuinely throws rather than producing an empty SBOM.
- `sbom/_manifest/**` matches what is actually emitted — `manifest.spdx.json` plus its `.sha256`.
- `specVersion` is `3.0`, as `-mi SPDX:3.0` intends.
- `$LASTEXITCODE` from `sbom-tool` survives the trailing `Write-Host` / `Get-ChildItem | Format-Table`, so a `sbom-tool` failure would still fail the step.

Workflow YAML re-parsed and step ordering re-checked, confirming `Setup versioning` precedes `Generate SBOM`.

## Notes

Not addressed here: `nupkgs/` and `sbom/` are not gitignored, so a local release rehearsal can leave 23 `.nupkg` files stageable. Worth a separate change.
