### PR TITLE
Ignore local release-rehearsal output (nupkgs/, sbom/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,9 @@ MigrationBackup/
 # Showcase api.http replay transcripts. Each run carries fresh account ids and
 # trace ids, so a transcript is a local artifact for diffing, not a baseline.
 Examples/Showcase/replay-*.txt
+
+# Local release rehearsal output. `publish-nuget-org.yml` packs into `nupkgs/`
+# and writes SBOM manifests to `sbom/` at the repository root; CI always runs
+# from a fresh checkout, so these only ever appear when rehearsing locally.
+/nupkgs/
+/sbom/


### PR DESCRIPTION
Closes backlog item R2 (found while rehearsing R1, the NuGet.org publish).

## Problem

`publish-nuget-org.yml` packs into `nupkgs/` and writes SBOM manifests to `sbom/`, both at the repository root. Neither was ignored. CI is unaffected because it always runs from a fresh checkout — this only bites a **local** release rehearsal, which leaves 23 `.nupkg` files and a ~2.5 MB SBOM manifest sitting stageable in the working tree, ready to be swept into an unrelated `git add -A`.

## Change

Six lines in `.gitignore`.

## Two judgement calls worth reviewing

**Root-anchored `/nupkgs/` and `/sbom/`, not bare `nupkgs/`.** The workflow writes to `$PWD/nupkgs` at the root. A bare pattern would additionally match any same-named directory nested under a package — nothing needs that today, and it is the kind of over-broad ignore that hides a real file later without saying so.

**`.gitignore` is left without a UTF-8 BOM**, which is a deliberate exception to this repo's UTF-8-with-BOM rule rather than an oversight. Git treats a leading BOM as part of the first pattern, so adding one would silently break whatever rule sits on line 1. The file had no BOM before this change and still has none.

## Verification

Created the exact artifacts the workflow produces and confirmed the tree stays clean:

```
$ git status --short
 M .gitignore

$ git check-ignore -v nupkgs/Trellis.Core.3.0.0-alpha.nupkg sbom/_manifest/manifest.spdx.json
.gitignore:369:/nupkgs/  nupkgs/Trellis.Core.3.0.0-alpha.nupkg
.gitignore:370:/sbom/    sbom/_manifest/manifest.spdx.json
```

No build or test run, and no code-review agent: this touches no compiled or documented surface, and the change is six ignore patterns with a mechanical verification.